### PR TITLE
GitHub ota

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       target:
@@ -17,6 +23,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TARGET: ${{ inputs.target || 'esp32p4' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,13 +49,13 @@ jobs:
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: v5.4.3
-          target: ${{ inputs.target }}
+          target: ${{ env.TARGET }}
           path: '.'
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-v${{ steps.version.outputs.version }}-${{ inputs.target }}
+          name: firmware-v${{ steps.version.outputs.version }}-${{ env.TARGET }}
           path: |
             build/arctic_controller.bin
             build/bootloader/bootloader.bin
@@ -62,7 +70,7 @@ jobs:
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Version | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Target | ${{ inputs.target }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Target | ${{ env.TARGET }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ESP-IDF | v5.4.3 |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "1.3.0")
+set(PROJECT_VER "1.4.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -241,7 +241,7 @@ bool api_server_start(void)
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
     config.uri_match_fn = httpd_uri_match_wildcard;
-    config.max_uri_handlers = 24;  // Increased for all endpoints
+    config.max_uri_handlers = 32;  // Increased for all endpoints
     config.stack_size = 8192;      // Larger stack for file upload
     config.max_resp_headers = 16;  // More response headers
     config.recv_wait_timeout = 10; // 10 second receive timeout
@@ -252,6 +252,16 @@ bool api_server_start(void)
         ESP_LOGE(TAG, "Failed to start server: %s", esp_err_to_name(ret));
         return false;
     }
+    
+    // Helper macro - abort if URI registration fails (catches max_uri_handlers issues)
+    #define REGISTER_URI(uri_struct) do { \
+        esp_err_t err = httpd_register_uri_handler(server, &(uri_struct)); \
+        if (err != ESP_OK) { \
+            ESP_LOGE(TAG, "FATAL: Failed to register URI '%s': %s", (uri_struct).uri, esp_err_to_name(err)); \
+            ESP_LOGE(TAG, "Increase max_uri_handlers in httpd config!"); \
+            abort(); \
+        } \
+    } while(0)
     
     // ========================================================================
     // Web Interface
@@ -264,7 +274,7 @@ bool api_server_start(void)
         .handler = web_root_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &web_root_uri);
+    REGISTER_URI(web_root_uri);
     
     httpd_uri_t web_index_uri = {
         .uri = "/index.html",
@@ -272,7 +282,7 @@ bool api_server_start(void)
         .handler = web_root_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &web_index_uri);
+    REGISTER_URI(web_index_uri);
     
     // GET /favicon.ico - Return 204 No Content (no favicon)
     httpd_uri_t favicon_uri = {
@@ -281,7 +291,7 @@ bool api_server_start(void)
         .handler = favicon_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &favicon_uri);
+    REGISTER_URI(favicon_uri);
     
     // POST /login - Web login
     httpd_uri_t login_uri = {
@@ -290,7 +300,7 @@ bool api_server_start(void)
         .handler = web_login_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &login_uri);
+    REGISTER_URI(login_uri);
     
     // POST /logout - Web logout
     httpd_uri_t logout_uri = {
@@ -299,7 +309,7 @@ bool api_server_start(void)
         .handler = web_logout_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &logout_uri);
+    REGISTER_URI(logout_uri);
     
     // ========================================================================
     // API Endpoints
@@ -312,7 +322,7 @@ bool api_server_start(void)
         .handler = health_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &health_uri);
+    REGISTER_URI(health_uri);
     
     // GET /api/status
     httpd_uri_t status_uri = {
@@ -321,7 +331,7 @@ bool api_server_start(void)
         .handler = status_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &status_uri);
+    REGISTER_URI(status_uri);
     
     // GET /api/time
     httpd_uri_t time_uri = {
@@ -330,7 +340,7 @@ bool api_server_start(void)
         .handler = time_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &time_uri);
+    REGISTER_URI(time_uri);
     
     // GET/POST /api/time/config
     httpd_uri_t time_config_get_uri = {
@@ -339,7 +349,7 @@ bool api_server_start(void)
         .handler = time_config_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &time_config_get_uri);
+    REGISTER_URI(time_config_get_uri);
     
     httpd_uri_t time_config_post_uri = {
         .uri = "/api/time/config",
@@ -347,7 +357,7 @@ bool api_server_start(void)
         .handler = time_config_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &time_config_post_uri);
+    REGISTER_URI(time_config_post_uri);
     
     // POST /api/time/sync
     httpd_uri_t time_sync_uri = {
@@ -356,7 +366,7 @@ bool api_server_start(void)
         .handler = time_sync_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &time_sync_uri);
+    REGISTER_URI(time_sync_uri);
     
     // GET /api/wifi
     httpd_uri_t wifi_uri = {
@@ -365,7 +375,7 @@ bool api_server_start(void)
         .handler = wifi_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &wifi_uri);
+    REGISTER_URI(wifi_uri);
     
     // GET /api/info
     httpd_uri_t info_uri = {
@@ -374,7 +384,7 @@ bool api_server_start(void)
         .handler = info_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &info_uri);
+    REGISTER_URI(info_uri);
     
     // GET /api/ota/status
     httpd_uri_t ota_status_uri = {
@@ -383,7 +393,7 @@ bool api_server_start(void)
         .handler = ota_status_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_status_uri);
+    REGISTER_URI(ota_status_uri);
     
     // POST /api/ota/update
     httpd_uri_t ota_update_uri = {
@@ -392,7 +402,7 @@ bool api_server_start(void)
         .handler = ota_update_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_update_uri);
+    REGISTER_URI(ota_update_uri);
     
     // POST /api/ota/upload
     httpd_uri_t ota_upload_uri = {
@@ -401,7 +411,7 @@ bool api_server_start(void)
         .handler = ota_upload_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_upload_uri);
+    REGISTER_URI(ota_upload_uri);
     
     // POST /api/ota/reboot
     httpd_uri_t ota_reboot_uri = {
@@ -410,7 +420,7 @@ bool api_server_start(void)
         .handler = ota_reboot_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_reboot_uri);
+    REGISTER_URI(ota_reboot_uri);
     
     // GET /api/ota/releases - Check GitHub for updates
     httpd_uri_t ota_releases_uri = {
@@ -419,7 +429,7 @@ bool api_server_start(void)
         .handler = ota_releases_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_releases_uri);
+    REGISTER_URI(ota_releases_uri);
     
     // POST /api/ota/github - Start update from GitHub
     httpd_uri_t ota_github_uri = {
@@ -428,7 +438,7 @@ bool api_server_start(void)
         .handler = ota_github_update_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ota_github_uri);
+    REGISTER_URI(ota_github_uri);
     
     // GET /api/auth/config
     httpd_uri_t auth_config_get_uri = {
@@ -437,7 +447,7 @@ bool api_server_start(void)
         .handler = auth_config_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_config_get_uri);
+    REGISTER_URI(auth_config_get_uri);
     
     // POST /api/auth/config
     httpd_uri_t auth_config_post_uri = {
@@ -446,7 +456,7 @@ bool api_server_start(void)
         .handler = auth_config_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_config_post_uri);
+    REGISTER_URI(auth_config_post_uri);
     
     // GET /api/auth/status - Quick auth status check for web UI
     httpd_uri_t auth_status_uri = {
@@ -455,7 +465,7 @@ bool api_server_start(void)
         .handler = auth_status_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_status_uri);
+    REGISTER_URI(auth_status_uri);
     
     // POST /api/auth/credentials
     httpd_uri_t auth_credentials_uri = {
@@ -464,7 +474,7 @@ bool api_server_start(void)
         .handler = auth_credentials_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_credentials_uri);
+    REGISTER_URI(auth_credentials_uri);
     
     // GET /api/auth/apikey
     httpd_uri_t auth_apikey_uri = {
@@ -473,7 +483,7 @@ bool api_server_start(void)
         .handler = auth_apikey_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_apikey_uri);
+    REGISTER_URI(auth_apikey_uri);
     
     // POST /api/auth/apikey/regenerate
     httpd_uri_t auth_apikey_regen_uri = {
@@ -482,7 +492,7 @@ bool api_server_start(void)
         .handler = auth_apikey_regenerate_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &auth_apikey_regen_uri);
+    REGISTER_URI(auth_apikey_regen_uri);
     
     // GET /api/heatpump/status
     httpd_uri_t heatpump_uri = {
@@ -491,9 +501,11 @@ bool api_server_start(void)
         .handler = heatpump_status_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &heatpump_uri);
+    REGISTER_URI(heatpump_uri);
     
-    ESP_LOGI(TAG, "HTTP server started successfully");
+    #undef REGISTER_URI
+    
+    ESP_LOGI(TAG, "HTTP server started successfully (26 URI handlers registered)");
     ESP_LOGI(TAG, "Web UI: http://%s.local/", hostname);
     
     return true;

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -53,6 +53,8 @@ static esp_err_t ota_status_get_handler(httpd_req_t* req);
 static esp_err_t ota_update_post_handler(httpd_req_t* req);
 static esp_err_t ota_upload_post_handler(httpd_req_t* req);
 static esp_err_t ota_reboot_post_handler(httpd_req_t* req);
+static esp_err_t ota_releases_get_handler(httpd_req_t* req);
+static esp_err_t ota_github_update_post_handler(httpd_req_t* req);
 static esp_err_t auth_config_get_handler(httpd_req_t* req);
 static esp_err_t auth_config_post_handler(httpd_req_t* req);
 static esp_err_t auth_status_get_handler(httpd_req_t* req);
@@ -409,6 +411,24 @@ bool api_server_start(void)
         .user_ctx = NULL
     };
     httpd_register_uri_handler(server, &ota_reboot_uri);
+    
+    // GET /api/ota/releases - Check GitHub for updates
+    httpd_uri_t ota_releases_uri = {
+        .uri = "/api/ota/releases",
+        .method = HTTP_GET,
+        .handler = ota_releases_get_handler,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &ota_releases_uri);
+    
+    // POST /api/ota/github - Start update from GitHub
+    httpd_uri_t ota_github_uri = {
+        .uri = "/api/ota/github",
+        .method = HTTP_POST,
+        .handler = ota_github_update_post_handler,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &ota_github_uri);
     
     // GET /api/auth/config
     httpd_uri_t auth_config_get_uri = {
@@ -1166,6 +1186,81 @@ static esp_err_t ota_reboot_post_handler(httpd_req_t* req)
     
     vTaskDelay(pdMS_TO_TICKS(500));
     esp_restart();
+    
+    return ESP_OK;
+}
+
+static esp_err_t ota_releases_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    
+    set_json_content_type(req);
+    
+    ota_release_info_t info;
+    if (!ota_mgr_check_github_releases(&info)) {
+        send_json_error(req, "502 Bad Gateway", "Failed to check GitHub for updates");
+        return ESP_OK;
+    }
+    
+    ota_status_t status = ota_mgr_get_status();
+    
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "update_available", info.update_available);
+    cJSON_AddStringToObject(root, "current_version", status.current_version);
+    cJSON_AddStringToObject(root, "latest_version", info.latest_version);
+    cJSON_AddStringToObject(root, "published_at", info.published_at);
+    
+    if (info.download_url[0] != '\0') {
+        cJSON_AddBoolToObject(root, "download_ready", true);
+    } else {
+        cJSON_AddBoolToObject(root, "download_ready", false);
+    }
+    
+    // Truncate release notes for JSON response
+    if (info.release_notes[0] != '\0') {
+        cJSON_AddStringToObject(root, "release_notes", info.release_notes);
+    }
+    
+    char* json_str = cJSON_PrintUnformatted(root);
+    httpd_resp_sendstr(req, json_str);
+    free(json_str);
+    cJSON_Delete(root);
+    
+    return ESP_OK;
+}
+
+static esp_err_t ota_github_update_post_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    
+    set_json_content_type(req);
+    
+    const ota_release_info_t* info = ota_mgr_get_release_info();
+    if (!info->update_available) {
+        send_json_error(req, "400 Bad Request", "No update available - check for updates first");
+        return ESP_OK;
+    }
+    
+    if (!ota_mgr_start_github_update()) {
+        send_json_error(req, "409 Conflict", "OTA update already in progress or no download URL");
+        return ESP_OK;
+    }
+    
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "status", "started");
+    cJSON_AddStringToObject(root, "message", "GitHub update started");
+    cJSON_AddStringToObject(root, "version", info->latest_version);
+    
+    char* json_str = cJSON_PrintUnformatted(root);
+    httpd_resp_sendstr(req, json_str);
+    free(json_str);
+    cJSON_Delete(root);
     
     return ESP_OK;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -67,7 +67,7 @@ extern "C" void app_main(void)
         ret = nvs_flash_init();
     }
     if (ret != ESP_OK) {
-        mclog::tagError(TAG, "Failed to initialize NVS: %d", ret);
+        mclog::tagError(TAG, "Failed to initialize NVS: {}", ret);
     }
 
     // Initialize i18n (localization) system
@@ -108,7 +108,7 @@ extern "C" void app_main(void)
     lv_display_set_rotation(display, LV_DISPLAY_ROTATION_90);
     bsp_display_backlight_on();
 
-    mclog::tagInfo(TAG, "Display initialized: %dx%d", BSP_LCD_H_RES, BSP_LCD_V_RES);
+    mclog::tagInfo(TAG, "Display initialized: {}x{}", BSP_LCD_H_RES, BSP_LCD_V_RES);
 
     // Start the startup animation
     bsp_display_lock(0);
@@ -373,7 +373,7 @@ static void on_status_bar_wifi_click(void)
 
 static void on_wifi_connect(const char* ssid, const char* password)
 {
-    mclog::tagInfo(TAG, "WiFi connect requested: SSID='%s'", ssid);
+    mclog::tagInfo(TAG, "WiFi connect requested: SSID='{}'", ssid);
     
     if (!wifi_mgr_is_initialized()) {
         settings_screen_show_error("WiFi not initialized.\nPlease try again.");
@@ -498,7 +498,7 @@ static void on_status_bar_notify_item_click(status_bar_notify_type_t type)
 static void on_update_check_complete(bool update_available, const char* new_version)
 {
     if (update_available) {
-        mclog::tagInfo(TAG, "Firmware update available: %s", new_version);
+        mclog::tagInfo(TAG, "Firmware update available: {}", new_version ? new_version : "?");
         char msg[64];
         snprintf(msg, sizeof(msg), "Firmware v%s available", new_version ? new_version : "?");
         bsp_display_lock(0);
@@ -536,7 +536,7 @@ static void wifi_init_task(void* param)
         char password[65];
         
         if (wifi_mgr_load_credentials(ssid, sizeof(ssid), password, sizeof(password))) {
-            mclog::tagInfo(TAG, "[BG] Auto-connecting to: %s", ssid);
+            mclog::tagInfo(TAG, "[BG] Auto-connecting to: {}", ssid);
             
             // Store as pending for state callback
             strncpy(pending_ssid, ssid, sizeof(pending_ssid) - 1);

--- a/main/ota_manager.cpp
+++ b/main/ota_manager.cpp
@@ -13,21 +13,28 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <string.h>
+#include <cJSON.h>
 
 static const char* TAG = "ota_manager";
 
 // OTA task stack size
 #define OTA_TASK_STACK_SIZE 8192
 
-// Allowed URL prefix for firmware updates (security)
+// GitHub API URL for releases
+#define GITHUB_API_URL "https://api.github.com/repos/sslivins/arctic-controller/releases/latest"
+
+// Allowed URL prefixes for firmware updates (security)
 #define ALLOWED_OTA_URL_PREFIX "https://github.com/sslivins/arctic-controller/"
+#define ALLOWED_OTA_URL_PREFIX2 "https://objects.githubusercontent.com/"
 
 bool ota_mgr_is_url_allowed(const char* url)
 {
     if (url == NULL || strlen(url) == 0) {
         return false;
     }
-    return strncmp(url, ALLOWED_OTA_URL_PREFIX, strlen(ALLOWED_OTA_URL_PREFIX)) == 0;
+    // Allow both GitHub repo URLs and GitHub's CDN (objects.githubusercontent.com)
+    return strncmp(url, ALLOWED_OTA_URL_PREFIX, strlen(ALLOWED_OTA_URL_PREFIX)) == 0 ||
+           strncmp(url, ALLOWED_OTA_URL_PREFIX2, strlen(ALLOWED_OTA_URL_PREFIX2)) == 0;
 }
 
 // Current OTA status
@@ -39,6 +46,15 @@ static ota_status_t ota_status = {
     .error_msg = "",
     .current_version = "",
     .new_version = ""
+};
+
+// Cached release info
+static ota_release_info_t release_info = {
+    .update_available = false,
+    .latest_version = "",
+    .download_url = "",
+    .release_notes = "",
+    .published_at = ""
 };
 
 // URL for current update
@@ -431,4 +447,190 @@ static void ota_task(void* pvParameter)
     
     // Never reached
     vTaskDelete(NULL);
+}
+
+// Compare semantic versions (returns: -1 if v1<v2, 0 if equal, 1 if v1>v2)
+static int compare_versions(const char* v1, const char* v2)
+{
+    int major1 = 0, minor1 = 0, patch1 = 0;
+    int major2 = 0, minor2 = 0, patch2 = 0;
+    
+    // Skip 'v' prefix if present
+    if (v1[0] == 'v' || v1[0] == 'V') v1++;
+    if (v2[0] == 'v' || v2[0] == 'V') v2++;
+    
+    sscanf(v1, "%d.%d.%d", &major1, &minor1, &patch1);
+    sscanf(v2, "%d.%d.%d", &major2, &minor2, &patch2);
+    
+    if (major1 != major2) return (major1 > major2) ? 1 : -1;
+    if (minor1 != minor2) return (minor1 > minor2) ? 1 : -1;
+    if (patch1 != patch2) return (patch1 > patch2) ? 1 : -1;
+    return 0;
+}
+
+// HTTP response buffer for GitHub API
+static char* http_response_buffer = NULL;
+static size_t http_response_len = 0;
+static size_t http_response_capacity = 0;
+
+static esp_err_t github_http_event_handler(esp_http_client_event_t* evt)
+{
+    switch (evt->event_id) {
+        case HTTP_EVENT_ON_DATA:
+            if (http_response_buffer == NULL) {
+                // Initial allocation
+                http_response_capacity = 4096;
+                http_response_buffer = (char*)malloc(http_response_capacity);
+                http_response_len = 0;
+            }
+            // Grow buffer if needed
+            if (http_response_len + evt->data_len >= http_response_capacity) {
+                http_response_capacity = http_response_len + evt->data_len + 1024;
+                http_response_buffer = (char*)realloc(http_response_buffer, http_response_capacity);
+            }
+            if (http_response_buffer) {
+                memcpy(http_response_buffer + http_response_len, evt->data, evt->data_len);
+                http_response_len += evt->data_len;
+                http_response_buffer[http_response_len] = '\0';
+            }
+            break;
+        default:
+            break;
+    }
+    return ESP_OK;
+}
+
+bool ota_mgr_check_github_releases(ota_release_info_t* info)
+{
+    ESP_LOGI(TAG, "Checking GitHub for updates...");
+    
+    // Reset release info
+    memset(&release_info, 0, sizeof(release_info));
+    
+    // Free any previous response buffer
+    if (http_response_buffer) {
+        free(http_response_buffer);
+        http_response_buffer = NULL;
+    }
+    http_response_len = 0;
+    http_response_capacity = 0;
+    
+    // Configure HTTP client for GitHub API
+    esp_http_client_config_t config = {};
+    config.url = GITHUB_API_URL;
+    config.event_handler = github_http_event_handler;
+    config.timeout_ms = 15000;
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+    config.buffer_size = 2048;
+    
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == NULL) {
+        ESP_LOGE(TAG, "Failed to init HTTP client");
+        return false;
+    }
+    
+    // GitHub API requires User-Agent header
+    esp_http_client_set_header(client, "User-Agent", "arctic-controller");
+    esp_http_client_set_header(client, "Accept", "application/vnd.github.v3+json");
+    
+    esp_err_t err = esp_http_client_perform(client);
+    int status_code = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    
+    if (err != ESP_OK || status_code != 200) {
+        ESP_LOGE(TAG, "GitHub API request failed: %s (HTTP %d)", esp_err_to_name(err), status_code);
+        if (http_response_buffer) {
+            free(http_response_buffer);
+            http_response_buffer = NULL;
+        }
+        return false;
+    }
+    
+    ESP_LOGI(TAG, "Got GitHub response (%d bytes)", http_response_len);
+    
+    // Parse JSON response
+    cJSON* root = cJSON_Parse(http_response_buffer);
+    free(http_response_buffer);
+    http_response_buffer = NULL;
+    
+    if (root == NULL) {
+        ESP_LOGE(TAG, "Failed to parse GitHub JSON response");
+        return false;
+    }
+    
+    // Extract version tag
+    cJSON* tag_name = cJSON_GetObjectItem(root, "tag_name");
+    if (tag_name && cJSON_IsString(tag_name)) {
+        strncpy(release_info.latest_version, tag_name->valuestring, sizeof(release_info.latest_version) - 1);
+    }
+    
+    // Extract published date
+    cJSON* published_at = cJSON_GetObjectItem(root, "published_at");
+    if (published_at && cJSON_IsString(published_at)) {
+        strncpy(release_info.published_at, published_at->valuestring, sizeof(release_info.published_at) - 1);
+    }
+    
+    // Extract release notes (body), truncate if needed
+    cJSON* body = cJSON_GetObjectItem(root, "body");
+    if (body && cJSON_IsString(body)) {
+        strncpy(release_info.release_notes, body->valuestring, sizeof(release_info.release_notes) - 1);
+    }
+    
+    // Find the .bin asset in assets array
+    cJSON* assets = cJSON_GetObjectItem(root, "assets");
+    if (assets && cJSON_IsArray(assets)) {
+        cJSON* asset;
+        cJSON_ArrayForEach(asset, assets) {
+            cJSON* name = cJSON_GetObjectItem(asset, "name");
+            if (name && cJSON_IsString(name)) {
+                // Look for .bin file
+                if (strstr(name->valuestring, ".bin") != NULL) {
+                    cJSON* download_url = cJSON_GetObjectItem(asset, "browser_download_url");
+                    if (download_url && cJSON_IsString(download_url)) {
+                        strncpy(release_info.download_url, download_url->valuestring, sizeof(release_info.download_url) - 1);
+                        ESP_LOGI(TAG, "Found firmware: %s", name->valuestring);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    
+    cJSON_Delete(root);
+    
+    // Compare versions
+    if (strlen(release_info.latest_version) > 0 && strlen(ota_status.current_version) > 0) {
+        int cmp = compare_versions(release_info.latest_version, ota_status.current_version);
+        release_info.update_available = (cmp > 0);
+        ESP_LOGI(TAG, "Current: %s, Latest: %s, Update available: %s",
+                 ota_status.current_version, release_info.latest_version,
+                 release_info.update_available ? "YES" : "NO");
+    }
+    
+    if (info) {
+        memcpy(info, &release_info, sizeof(ota_release_info_t));
+    }
+    
+    return true;
+}
+
+const ota_release_info_t* ota_mgr_get_release_info(void)
+{
+    return &release_info;
+}
+
+bool ota_mgr_start_github_update(void)
+{
+    if (strlen(release_info.download_url) == 0) {
+        ESP_LOGE(TAG, "No download URL available - run check first");
+        return false;
+    }
+    
+    if (!release_info.update_available) {
+        ESP_LOGW(TAG, "No update available");
+        return false;
+    }
+    
+    ESP_LOGI(TAG, "Starting GitHub OTA update to %s", release_info.latest_version);
+    return ota_mgr_start_update(release_info.download_url);
 }

--- a/main/ota_manager.h
+++ b/main/ota_manager.h
@@ -15,6 +15,7 @@ extern "C" {
 // OTA update states
 typedef enum {
     OTA_STATE_IDLE,
+    OTA_STATE_CHECKING,     // Checking GitHub for updates
     OTA_STATE_UPLOADING,    // File upload in progress
     OTA_STATE_DOWNLOADING,  // URL download in progress
     OTA_STATE_VERIFYING,
@@ -32,6 +33,15 @@ typedef struct {
     char current_version[32];
     char new_version[32];
 } ota_status_t;
+
+// GitHub release info
+typedef struct {
+    bool update_available;
+    char latest_version[32];
+    char download_url[256];
+    char release_notes[512];
+    char published_at[32];
+} ota_release_info_t;
 
 /**
  * @brief Initialize OTA manager
@@ -97,6 +107,26 @@ void ota_mgr_mark_valid(void);
  * @param size Pointer to store partition size (can be NULL)
  */
 void ota_mgr_get_partition_info(char* label, uint32_t* address, uint32_t* size);
+
+/**
+ * @brief Check GitHub for available updates
+ * @param info Pointer to store release info
+ * @return true if check succeeded (doesn't mean update available)
+ */
+bool ota_mgr_check_github_releases(ota_release_info_t* info);
+
+/**
+ * @brief Get cached release info from last check
+ * @return Pointer to cached release info (valid until next check)
+ */
+const ota_release_info_t* ota_mgr_get_release_info(void);
+
+/**
+ * @brief Start OTA update from GitHub release
+ * Uses the URL from the last successful release check
+ * @return true if update started
+ */
+bool ota_mgr_start_github_update(void);
 
 #ifdef __cplusplus
 }

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -994,8 +994,7 @@
                 
                 <main>
                     <!-- Dashboard Page -->
-                    <template x-if="page === 'dashboard'">
-                        <div>
+                    <div x-show="page === 'dashboard'">
                             <div class="card">
                                 <div class="card-header">
                                     <h2 x-text="t('heatPumpStatus')"></h2>
@@ -1047,11 +1046,9 @@
                                 </div>
                             </div>
                         </div>
-                    </template>
                     
                     <!-- Settings Page -->
-                    <template x-if="page === 'settings'">
-                        <div>
+                    <div x-show="page === 'settings'">
                             <!-- Device Info -->
                             <div class="card">
                                 <div class="card-header">
@@ -1177,12 +1174,7 @@
                                                             <span class="label" x-text="t('latestVersion')"></span>
                                                             <span class="value" style="color: var(--success);" x-text="github.latestVersion"></span>
                                                         </div>
-                                                        <template x-if="github.releaseNotes">
-                                                            <div style="margin: 0.75rem 0; padding: 0.75rem; background: var(--bg-secondary); border-radius: 6px; font-size: 0.9rem; color: var(--text-secondary); max-height: 100px; overflow-y: auto;">
-                                                                <span x-text="github.releaseNotes.substring(0, 300) + (github.releaseNotes.length > 300 ? '...' : '')"></span>
-                                                            </div>
-                                                        </template>
-                                                        <button class="btn btn-primary" style="width: 100%;" 
+                                                        <button class="btn btn-primary" style="width: 100%; margin-top: 0.5rem;" 
                                                                 @click="startGithubUpdate()" 
                                                                 :disabled="loading || ota.state === 'downloading' || !github.downloadReady"
                                                                 x-text="t('installUpdate')"></button>
@@ -1193,15 +1185,23 @@
                                                 </template>
                                                 
                                                 <template x-if="!github.error && !github.updateAvailable">
-                                                    <div style="text-align: center; color: var(--success);">
-                                                        ✅ <span x-text="t('upToDate')"></span>
+                                                    <div>
+                                                        <div style="text-align: center; color: var(--success); margin-bottom: 0.75rem;">
+                                                            ✅ <span x-text="t('upToDate')"></span>
+                                                        </div>
+                                                        <button class="btn btn-secondary" style="width: 100%;" 
+                                                                @click="checkForUpdates()" 
+                                                                :disabled="loading || ota.state === 'downloading'"
+                                                                x-text="t('checkForUpdates')"></button>
                                                     </div>
                                                 </template>
                                                 
-                                                <button class="btn btn-secondary" style="width: 100%; margin-top: 0.75rem;" 
-                                                        @click="checkForUpdates()" 
-                                                        :disabled="loading || ota.state === 'downloading'"
-                                                        x-text="t('checkForUpdates')"></button>
+                                                <template x-if="github.error">
+                                                    <button class="btn btn-secondary" style="width: 100%; margin-top: 0.75rem;" 
+                                                            @click="checkForUpdates()" 
+                                                            :disabled="loading || ota.state === 'downloading'"
+                                                            x-text="t('checkForUpdates')"></button>
+                                                </template>
                                             </div>
                                         </template>
                                     </div>
@@ -1219,7 +1219,9 @@
                                     </template>
                                     
                                     <template x-if="ota.state === 'ready_to_reboot'">
-                                        <div class="alert alert-success" x-text="t('updateSuccess')"></div>
+                                        <div class="alert alert-success">
+                                            🔄 <span x-text="t('rebooting')"></span>
+                                        </div>
                                     </template>
                                     
                                     <template x-if="ota.error">
@@ -1280,9 +1282,7 @@
                                         </template>
                                     </div>
                                     
-                                    <template x-if="ota.state === 'ready_to_reboot'">
-                                        <button class="btn btn-primary" style="width: 100%; margin-top: 1rem;" @click="reboot()" x-text="t('rebootNow')"></button>
-                                    </template>
+                                    
                                 </div>
                             </div>
                             
@@ -1357,7 +1357,6 @@
                                 </div>
                             </div>
                         </div>
-                    </template>
                 </main>
             </div>
         </template>
@@ -1396,6 +1395,7 @@
                 timeConfig: { timezone: 'EST5EDT,M3.2.0,M11.1.0', format24h: true, synced: false },
                 security: { webAuthEnabled: false, apiAuthEnabled: false, username: '', newPassword: '', apiKey: '' },
                 
+                dataLoaded: false, // Prevents saving during initial load
                 selectedFile: null,
                 uploadState: 'idle', // idle, uploading, verifying, rebooting, complete, error
                 uploadProgress: 0,
@@ -1497,16 +1497,41 @@
                         this.loadSecurity(),
                         this.loadHeatpump()
                     ]);
+                    this.dataLoaded = true;
                     this.lastUpdate = Date.now();
                 },
                 
                 startPolling() {
-                    setInterval(async () => {
-                        await this.loadStatus();
+                    // Adaptive polling - fast during OTA, normal otherwise
+                    let prevOtaState = this.ota.state;
+                    const poll = async () => {
                         await this.loadOta();
-                        await this.loadHeatpump();
-                        this.lastUpdate = Date.now();
-                    }, 5000);
+                        
+                        // Reset github update state when OTA completes (ready_to_reboot)
+                        // This ensures after reboot, the UI shows "Check for Updates" instead of stale state
+                        if (this.ota.state === 'ready_to_reboot' && prevOtaState !== 'ready_to_reboot') {
+                            this.github.checked = false;
+                            this.github.updateAvailable = false;
+                            this.github.latestVersion = '';
+                            this.github.downloadReady = false;
+                            this.github.error = '';
+                        }
+                        prevOtaState = this.ota.state;
+                        
+                        // Poll faster (500ms) when OTA is active for smooth progress
+                        const otaActive = this.ota.state === 'downloading' || this.ota.state === 'verifying' || this.ota.state === 'uploading';
+                        const interval = otaActive ? 500 : 5000;
+                        
+                        // Only load other status on slow poll interval
+                        if (!otaActive) {
+                            await this.loadStatus();
+                            await this.loadHeatpump();
+                            this.lastUpdate = Date.now();
+                        }
+                        
+                        setTimeout(poll, interval);
+                    };
+                    poll();
                 },
                 
                 async loadInfo() {
@@ -1541,9 +1566,15 @@
                     try {
                         const res = await fetch('/api/time/config');
                         const data = await res.json();
-                        // Map snake_case API response to camelCase UI model
-                        this.timeConfig.timezone = data.timezone || this.timeConfig.timezone;
-                        this.timeConfig.format24h = data.format_24h !== undefined ? data.format_24h : this.timeConfig.format24h;
+                        // Store what we're loading BEFORE setting reactive properties
+                        // This prevents race conditions with @change handlers
+                        const newTz = data.timezone || this.timeConfig.timezone;
+                        const newFormat = data.format_24h !== undefined ? data.format_24h : this.timeConfig.format24h;
+                        this._loadedTimezone = newTz;
+                        this._loadedFormat24h = newFormat;
+                        // Now set the reactive properties
+                        this.timeConfig.timezone = newTz;
+                        this.timeConfig.format24h = newFormat;
                         this.timeConfig.synced = data.synced || false;
                     } catch (e) { console.error(e); }
                 },
@@ -1623,6 +1654,12 @@
                 },
                 
                 async saveTimeConfig() {
+                    if (!this.dataLoaded) return; // Don't save during initial load
+                    // Only save if values actually changed from what was loaded
+                    if (this.timeConfig.timezone === this._loadedTimezone &&
+                        this.timeConfig.format24h === this._loadedFormat24h) {
+                        return;
+                    }
                     try {
                         await fetch('/api/time/config', {
                             method: 'POST',
@@ -1632,6 +1669,9 @@
                                 format_24h: this.timeConfig.format24h
                             })
                         });
+                        // Update loaded values after successful save
+                        this._loadedTimezone = this.timeConfig.timezone;
+                        this._loadedFormat24h = this.timeConfig.format24h;
                     } catch (e) { console.error(e); }
                 },
                 

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -71,6 +71,12 @@
                 // Settings - Firmware
                 firmwareUpdates: 'Firmware Updates',
                 currentVersion: 'Current Version',
+                latestVersion: 'Latest Version',
+                checkForUpdates: 'Check for Updates',
+                checking: 'Checking...',
+                updateAvailable: 'Update Available!',
+                upToDate: 'You are up to date',
+                installUpdate: 'Install Update',
                 downloading: 'Downloading',
                 updateSuccess: 'Update downloaded successfully! Ready to reboot.',
                 uploadFirmware: 'Or upload firmware file',
@@ -84,6 +90,8 @@
                 deviceRebooting: 'Device is rebooting... Please wait.',
                 deviceRebootTimeout: 'Device did not respond after reboot. Please refresh the page manually.',
                 invalidFileType: 'Invalid file type. Please select a .bin file.',
+                checkFailed: 'Failed to check for updates',
+                noDownloadUrl: 'No firmware binary found in release',
                 
                 // Settings - Security
                 security: 'Security',
@@ -178,6 +186,12 @@
                 // Settings - Firmware
                 firmwareUpdates: 'Mises à jour du firmware',
                 currentVersion: 'Version actuelle',
+                latestVersion: 'Dernière version',
+                checkForUpdates: 'Vérifier les mises à jour',
+                checking: 'Vérification...',
+                updateAvailable: 'Mise à jour disponible!',
+                upToDate: 'Vous êtes à jour',
+                installUpdate: 'Installer la mise à jour',
                 downloading: 'Téléchargement',
                 updateSuccess: 'Mise à jour téléchargée! Prêt à redémarrer.',
                 uploadFirmware: 'Ou téléverser un fichier firmware',
@@ -191,6 +205,8 @@
                 deviceRebooting: "L'appareil redémarre... Veuillez patienter.",
                 deviceRebootTimeout: "L'appareil n'a pas répondu. Actualisez la page manuellement.",
                 invalidFileType: 'Type de fichier invalide. Veuillez sélectionner un fichier .bin.',
+                checkFailed: 'Échec de la vérification des mises à jour',
+                noDownloadUrl: 'Aucun fichier binaire trouvé dans la version',
                 
                 // Settings - Security
                 security: 'Sécurité',
@@ -285,6 +301,12 @@
                 // Settings - Firmware
                 firmwareUpdates: 'Actualizaciones de firmware',
                 currentVersion: 'Versión actual',
+                latestVersion: 'Última versión',
+                checkForUpdates: 'Buscar actualizaciones',
+                checking: 'Verificando...',
+                updateAvailable: '¡Actualización disponible!',
+                upToDate: 'Está actualizado',
+                installUpdate: 'Instalar actualización',
                 downloading: 'Descargando',
                 updateSuccess: '¡Actualización descargada! Listo para reiniciar.',
                 uploadFirmware: 'O subir archivo de firmware',
@@ -298,6 +320,8 @@
                 deviceRebooting: 'El dispositivo está reiniciando... Por favor espere.',
                 deviceRebootTimeout: 'El dispositivo no respondió. Por favor actualice la página manualmente.',
                 invalidFileType: 'Tipo de archivo inválido. Por favor seleccione un archivo .bin.',
+                checkFailed: 'Error al buscar actualizaciones',
+                noDownloadUrl: 'No se encontró archivo binario en la versión',
                 
                 // Settings - Security
                 security: 'Seguridad',
@@ -1123,6 +1147,65 @@
                                         <span class="value" x-text="'v' + ota.current_version"></span>
                                     </div>
                                     
+                                    <!-- GitHub Update Check -->
+                                    <div style="margin: 1rem 0; padding: 1rem; background: var(--bg-tertiary); border-radius: 8px;">
+                                        <template x-if="!github.checked && !github.checking">
+                                            <button class="btn btn-primary" style="width: 100%;" 
+                                                    @click="checkForUpdates()" 
+                                                    :disabled="loading || ota.state === 'downloading'"
+                                                    x-text="t('checkForUpdates')"></button>
+                                        </template>
+                                        
+                                        <template x-if="github.checking">
+                                            <div style="text-align: center; color: var(--text-secondary);">
+                                                <span>🔍</span> <span x-text="t('checking')"></span>
+                                            </div>
+                                        </template>
+                                        
+                                        <template x-if="github.checked && !github.checking">
+                                            <div>
+                                                <template x-if="github.error">
+                                                    <div class="alert alert-error" x-text="github.error"></div>
+                                                </template>
+                                                
+                                                <template x-if="!github.error && github.updateAvailable">
+                                                    <div>
+                                                        <div class="alert alert-success" style="margin-bottom: 0.75rem;">
+                                                            🎉 <span x-text="t('updateAvailable')"></span>
+                                                        </div>
+                                                        <div class="info-row">
+                                                            <span class="label" x-text="t('latestVersion')"></span>
+                                                            <span class="value" style="color: var(--success);" x-text="github.latestVersion"></span>
+                                                        </div>
+                                                        <template x-if="github.releaseNotes">
+                                                            <div style="margin: 0.75rem 0; padding: 0.75rem; background: var(--bg-secondary); border-radius: 6px; font-size: 0.9rem; color: var(--text-secondary); max-height: 100px; overflow-y: auto;">
+                                                                <span x-text="github.releaseNotes.substring(0, 300) + (github.releaseNotes.length > 300 ? '...' : '')"></span>
+                                                            </div>
+                                                        </template>
+                                                        <button class="btn btn-primary" style="width: 100%;" 
+                                                                @click="startGithubUpdate()" 
+                                                                :disabled="loading || ota.state === 'downloading' || !github.downloadReady"
+                                                                x-text="t('installUpdate')"></button>
+                                                        <template x-if="!github.downloadReady">
+                                                            <div style="margin-top: 0.5rem; color: var(--warning); font-size: 0.85rem;" x-text="t('noDownloadUrl')"></div>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                                
+                                                <template x-if="!github.error && !github.updateAvailable">
+                                                    <div style="text-align: center; color: var(--success);">
+                                                        ✅ <span x-text="t('upToDate')"></span>
+                                                    </div>
+                                                </template>
+                                                
+                                                <button class="btn btn-secondary" style="width: 100%; margin-top: 0.75rem;" 
+                                                        @click="checkForUpdates()" 
+                                                        :disabled="loading || ota.state === 'downloading'"
+                                                        x-text="t('checkForUpdates')"></button>
+                                            </div>
+                                        </template>
+                                    </div>
+                                    
                                     <template x-if="ota.state === 'downloading'">
                                         <div>
                                             <div class="progress-bar">
@@ -1144,7 +1227,7 @@
                                     </template>
                                     
                                     <!-- File Upload (URL updates restricted to GitHub releases for security) -->
-                                    <div class="form-group">
+                                    <div class="form-group" style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border);">
                                         <label x-text="t('uploadFirmware')"></label>
                                         
                                         <!-- Upload Progress UI -->
@@ -1298,6 +1381,17 @@
                 wifi: {},
                 heatpump: { compressor: false, fans: false, pump: false, error: null },
                 ota: { state: 'idle', progress: 0, current_version: '--' },
+                
+                // GitHub update state
+                github: {
+                    checking: false,
+                    checked: false,
+                    updateAvailable: false,
+                    latestVersion: '',
+                    releaseNotes: '',
+                    downloadReady: false,
+                    error: ''
+                },
                 
                 timeConfig: { timezone: 'EST5EDT,M3.2.0,M11.1.0', format24h: true, synced: false },
                 security: { webAuthEnabled: false, apiAuthEnabled: false, username: '', newPassword: '', apiKey: '' },
@@ -1480,6 +1574,52 @@
                         // Placeholder - endpoint might not exist yet
                         this.heatpump = { compressor: false, fans: false, pump: false, error: null };
                     }
+                },
+                
+                async checkForUpdates() {
+                    this.github.checking = true;
+                    this.github.error = '';
+                    
+                    try {
+                        const res = await fetch('/api/ota/releases');
+                        if (!res.ok) {
+                            const err = await res.json();
+                            this.github.error = err.error || this.t('checkFailed');
+                        } else {
+                            const data = await res.json();
+                            this.github.updateAvailable = data.update_available;
+                            this.github.latestVersion = data.latest_version;
+                            this.github.releaseNotes = data.release_notes || '';
+                            this.github.downloadReady = data.download_ready;
+                        }
+                        this.github.checked = true;
+                    } catch (e) {
+                        console.error(e);
+                        this.github.error = this.t('checkFailed');
+                        this.github.checked = true;
+                    }
+                    
+                    this.github.checking = false;
+                },
+                
+                async startGithubUpdate() {
+                    if (!this.github.updateAvailable || !this.github.downloadReady) return;
+                    
+                    this.loading = true;
+                    try {
+                        const res = await fetch('/api/ota/github', { method: 'POST' });
+                        if (!res.ok) {
+                            const err = await res.json();
+                            this.showToast(err.error || 'Update failed', 'error');
+                        } else {
+                            this.showToast('Update started - downloading...', 'info');
+                            // Polling will pick up the progress
+                        }
+                    } catch (e) {
+                        console.error(e);
+                        this.showToast('Failed to start update', 'error');
+                    }
+                    this.loading = false;
                 },
                 
                 async saveTimeConfig() {


### PR DESCRIPTION
Adds GitHub release checking for firmware updates, allowing users to check for and install updates directly from GitHub releases. Also includes several web UI fixes and improvements.

New Features
GitHub OTA Updates

Check for firmware updates from GitHub releases via web UI
Automatic version comparison (semantic versioning)
One-click update installation from GitHub releases
Auto-reboot after successful OTA update
Build Gate

GitHub Actions now runs on push/PR to [main](vscode-file://vscode-app/c:/Users/Stefan/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) branch
Ensures all PRs pass build before merge
Bug Fixes
Timezone persistence - Fixed timezone dropdown reverting when switching tabs (changed x-if to x-show to prevent DOM destruction)
Max URI handlers - Increased from 24 to 32 to fix silent 404s when all handlers couldn't be registered
URI registration failures - Added [REGISTER_URI](vscode-file://vscode-app/c:/Users/Stefan/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) macro that aborts with clear error message instead of silently failing
UI Improvements
Faster OTA progress updates (500ms polling during updates vs 5s normally)
Auto-reboot after OTA instead of manual "Reboot Now" button
Reset GitHub update state after OTA completes
Cleaner firmware update section (removed release notes display)