### PR TITLE
Feature/event log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.0.0")
+set(PROJECT_VER "2.1.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -61,6 +61,8 @@ tags:
     description: Session and API key authentication
   - name: HeatPump
     description: Heat pump status and control
+  - name: Events
+    description: Operational event log
 
 paths:
   /login:
@@ -1509,6 +1511,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/events:
+    get:
+      tags:
+        - Events
+      summary: Get event log
+      description: |
+        Returns all recorded operational events, newest first.
+        Events are stored in a RAM ring buffer (max 128 entries) and are lost on reboot.
+        Each event has a type, optional payload, wall-clock timestamp, and uptime.
+      operationId: getEvents
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      responses:
+        '200':
+          description: Event log retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total number of events in the log
+                    example: 12
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EventEntry'
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      tags:
+        - Events
+      summary: Clear event log
+      description: Deletes all events from the ring buffer.
+      operationId: clearEvents
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      responses:
+        '200':
+          description: Event log cleared
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   securitySchemes:
     apiKey:
@@ -1529,6 +1594,52 @@ components:
         error:
           type: string
           description: Error message
+
+    EventEntry:
+      type: object
+      description: A single operational event
+      properties:
+        type:
+          type: string
+          description: Event type identifier
+          enum:
+            - system_start
+            - power_on
+            - power_off
+            - mode_changed
+            - setpoint_changed
+            - compressor_on
+            - compressor_off
+            - fan_on
+            - fan_off
+            - pump_on
+            - pump_off
+            - aux_heater_on
+            - aux_heater_off
+            - defrost_start
+            - defrost_end
+            - error_appeared
+            - error_cleared
+            - connected
+            - disconnected
+          example: power_on
+        timestamp:
+          type: integer
+          description: Unix timestamp (seconds since epoch), 0 if NTP not synced
+          example: 1739404800
+        uptime_ms:
+          type: integer
+          description: Device uptime in milliseconds when event occurred
+          example: 125340
+        payload:
+          type: integer
+          description: |
+            Event-specific payload data:
+            - `mode_changed`: `(old_mode << 8) | new_mode`
+            - `setpoint_changed`: `(type << 16) | (old_val << 8) | new_val` where type: 0=cooling, 1=heating, 2=hot_water
+            - `error_appeared` / `error_cleared`: `(register << 16) | bit_mask` where register is 1 or 2
+            - All other events: 0
+          example: 0
 
     HeatPumpParam:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28,7 +28,7 @@ info:
     The API key can be retrieved from the web interface settings.
     
     Both authentication types can be independently enabled/disabled via `/api/auth/config`.
-  version: 2.0.0
+  version: 2.1.0
   contact:
     name: Arctic Controller
   license:

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -42,6 +42,8 @@ idf_component_register(
         "app_preferences.cpp"
         "heatpump_params.cpp"
         "heatpump_errors.cpp"
+        "event_log.cpp"
+        "event_log_screen.cpp"
         "settings/settings_menu.cpp"
         "settings/settings_wifi_screen.cpp"
         "settings/keyboard_maps.c"

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -11,6 +11,7 @@
 #include "modbus/arctic_registers.h"
 #include "heatpump_params.h"
 #include "heatpump_errors.h"
+#include "event_log.h"
 #include "app_preferences.h"
 #include <esp_http_server.h>
 #include <esp_log.h>
@@ -77,6 +78,8 @@ static esp_err_t heatpump_setpoints_put_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_get_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_clear_handler(httpd_req_t* req);
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req);
+static esp_err_t events_get_handler(httpd_req_t* req);
+static esp_err_t events_clear_handler(httpd_req_t* req);
 
 // ============================================================================
 // Authentication Helpers
@@ -608,9 +611,27 @@ bool api_server_start(void)
     };
     REGISTER_URI(heatpump_demo_uri);
     
+    // GET /api/events - Get event log
+    httpd_uri_t events_get_uri = {
+        .uri = "/api/events",
+        .method = HTTP_GET,
+        .handler = events_get_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(events_get_uri);
+    
+    // DELETE /api/events - Clear event log
+    httpd_uri_t events_clear_uri = {
+        .uri = "/api/events",
+        .method = HTTP_DELETE,
+        .handler = events_clear_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(events_clear_uri);
+    
     #undef REGISTER_URI
     
-    ESP_LOGI(TAG, "HTTP server started successfully (32 URI handlers registered)");
+    ESP_LOGI(TAG, "HTTP server started successfully (34 URI handlers registered)");
     ESP_LOGI(TAG, "Web UI: http://%s.local/", hostname);
     
     return true;
@@ -2375,5 +2396,55 @@ static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
     free(json_str2);
     cJSON_Delete(resp);
     
+    return ESP_OK;
+}
+
+// ============================================================================
+// Events API
+// ============================================================================
+
+static esp_err_t events_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    set_json_content_type(req);
+    
+    // Get events (newest first, up to 128)
+    event_entry_t events[128];
+    int count = event_log_get(events, 128, 0);
+    
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "total", event_log_count());
+    cJSON* arr = cJSON_AddArrayToObject(root, "events");
+    
+    for (int i = 0; i < count; i++) {
+        cJSON* evt = cJSON_CreateObject();
+        cJSON_AddStringToObject(evt, "type", event_type_name(events[i].type));
+        cJSON_AddNumberToObject(evt, "timestamp", events[i].timestamp);
+        cJSON_AddNumberToObject(evt, "uptime_ms", events[i].uptime_ms);
+        cJSON_AddNumberToObject(evt, "payload", events[i].payload);
+        cJSON_AddItemToArray(arr, evt);
+    }
+    
+    char* json_str = cJSON_PrintUnformatted(root);
+    httpd_resp_sendstr(req, json_str);
+    free(json_str);
+    cJSON_Delete(root);
+    
+    return ESP_OK;
+}
+
+static esp_err_t events_clear_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    set_json_content_type(req);
+    
+    event_log_clear();
+    httpd_resp_sendstr(req, "{\"success\":true}");
     return ESP_OK;
 }

--- a/main/event_log.cpp
+++ b/main/event_log.cpp
@@ -1,0 +1,159 @@
+/*
+ * Arctic Heat Pump Controller
+ * Event Log Implementation - RAM ring buffer for system events
+ */
+
+#include "event_log.h"
+#include "time_manager.h"
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <string.h>
+
+static const char* TAG = "event_log";
+
+// ============================================================================
+// Ring Buffer State
+// ============================================================================
+
+static event_entry_t s_buffer[EVENT_LOG_MAX_ENTRIES];
+static int s_head = 0;       // Next write position
+static int s_count = 0;      // Number of valid entries
+static SemaphoreHandle_t s_mutex = nullptr;
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+static uint32_t get_uptime_ms(void) {
+    return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+
+static uint32_t get_unix_timestamp(void) {
+    // Use time_manager if available
+    time_t now;
+    time(&now);
+    // If time is before 2024, it's probably not synced
+    if (now < 1704067200) return 0;
+    return (uint32_t)now;
+}
+
+// ============================================================================
+// Event type names (for API/logging)
+// ============================================================================
+
+static const char* s_event_names[] = {
+    "system_start",
+    "power_on",
+    "power_off",
+    "mode_changed",
+    "setpoint_changed",
+    "compressor_on",
+    "compressor_off",
+    "fan_on",
+    "fan_off",
+    "pump_on",
+    "pump_off",
+    "aux_heater_on",
+    "aux_heater_off",
+    "defrost_start",
+    "defrost_end",
+    "error_appeared",
+    "error_cleared",
+    "connected",
+    "disconnected",
+};
+
+_Static_assert(sizeof(s_event_names) / sizeof(s_event_names[0]) == EVENT_TYPE_COUNT,
+               "s_event_names must match EVENT_TYPE_COUNT");
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void event_log_init(void) {
+    if (s_mutex == nullptr) {
+        s_mutex = xSemaphoreCreateMutex();
+    }
+    s_head = 0;
+    s_count = 0;
+    memset(s_buffer, 0, sizeof(s_buffer));
+    
+    // First event
+    event_log_record(EVENT_SYSTEM_START, 0);
+    ESP_LOGI(TAG, "Event log initialized (%d entry capacity)", EVENT_LOG_MAX_ENTRIES);
+}
+
+void event_log_record(event_type_t type, uint32_t payload) {
+    if (s_mutex == nullptr) return;
+    if (type >= EVENT_TYPE_COUNT) return;
+    
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    
+    event_entry_t* entry = &s_buffer[s_head];
+    entry->timestamp = get_unix_timestamp();
+    entry->uptime_ms = get_uptime_ms();
+    entry->type = type;
+    entry->payload = payload;
+    
+    s_head = (s_head + 1) % EVENT_LOG_MAX_ENTRIES;
+    if (s_count < EVENT_LOG_MAX_ENTRIES) {
+        s_count++;
+    }
+    
+    xSemaphoreGive(s_mutex);
+    
+    // Also log to serial for debugging
+    if (payload != 0) {
+        ESP_LOGI(TAG, "Event: %s (payload: 0x%08lx)", event_type_name(type), (unsigned long)payload);
+    } else {
+        ESP_LOGI(TAG, "Event: %s", event_type_name(type));
+    }
+}
+
+int event_log_count(void) {
+    if (s_mutex == nullptr) return 0;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    int count = s_count;
+    xSemaphoreGive(s_mutex);
+    return count;
+}
+
+int event_log_get(event_entry_t* out, int max_out, int offset) {
+    if (s_mutex == nullptr || out == nullptr || max_out <= 0) return 0;
+    
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    
+    int available = s_count - offset;
+    if (available <= 0) {
+        xSemaphoreGive(s_mutex);
+        return 0;
+    }
+    
+    int to_copy = (available < max_out) ? available : max_out;
+    
+    // Read newest first: head-1 is the newest entry
+    for (int i = 0; i < to_copy; i++) {
+        int idx = (s_head - 1 - offset - i + EVENT_LOG_MAX_ENTRIES * 2) % EVENT_LOG_MAX_ENTRIES;
+        out[i] = s_buffer[idx];
+    }
+    
+    xSemaphoreGive(s_mutex);
+    return to_copy;
+}
+
+void event_log_clear(void) {
+    if (s_mutex == nullptr) return;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    s_head = 0;
+    s_count = 0;
+    memset(s_buffer, 0, sizeof(s_buffer));
+    xSemaphoreGive(s_mutex);
+    ESP_LOGI(TAG, "Event log cleared");
+}
+
+const char* event_type_name(event_type_t type) {
+    if (type >= EVENT_TYPE_COUNT) return "unknown";
+    return s_event_names[type];
+}

--- a/main/event_log.h
+++ b/main/event_log.h
@@ -1,0 +1,104 @@
+/*
+ * Arctic Heat Pump Controller
+ * Event Log - Records significant system events in a RAM ring buffer
+ * 
+ * Events are operational records (power changes, mode switches, component
+ * state changes, errors) — not debug logs. Lost on reboot by design.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+typedef enum {
+    EVENT_SYSTEM_START = 0,     // Controller booted
+    EVENT_POWER_ON,             // Heat pump powered on
+    EVENT_POWER_OFF,            // Heat pump powered off
+    EVENT_MODE_CHANGED,         // Working mode changed (payload: old<<8 | new)
+    EVENT_SETPOINT_CHANGED,     // Setpoint changed (payload: type<<16 | old<<8 | new)
+    EVENT_COMPRESSOR_ON,        // Compressor started
+    EVENT_COMPRESSOR_OFF,       // Compressor stopped
+    EVENT_FAN_ON,               // Fan started
+    EVENT_FAN_OFF,              // Fan stopped
+    EVENT_PUMP_ON,              // Water pump started
+    EVENT_PUMP_OFF,             // Water pump stopped
+    EVENT_AUX_HEATER_ON,       // Auxiliary heater activated
+    EVENT_AUX_HEATER_OFF,      // Auxiliary heater deactivated
+    EVENT_DEFROST_START,        // Defrost cycle started
+    EVENT_DEFROST_END,          // Defrost cycle ended
+    EVENT_ERROR_APPEARED,       // Error code appeared (payload: error code)
+    EVENT_ERROR_CLEARED,        // Error code cleared (payload: error code)
+    EVENT_CONNECTED,            // Heat pump connected (Modbus OK)
+    EVENT_DISCONNECTED,         // Heat pump disconnected (Modbus lost)
+    EVENT_TYPE_COUNT
+} event_type_t;
+
+// ============================================================================
+// Event Entry
+// ============================================================================
+
+typedef struct {
+    uint32_t timestamp;       // Unix timestamp (seconds since epoch), 0 if time not synced
+    uint32_t uptime_ms;       // Uptime in milliseconds (always valid)
+    event_type_t type;        // Event type
+    uint32_t payload;         // Type-specific data (mode value, error code, etc.)
+} event_entry_t;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+#define EVENT_LOG_MAX_ENTRIES  128   // Max events in ring buffer (~2.5 KB)
+
+// ============================================================================
+// API
+// ============================================================================
+
+/**
+ * @brief Initialize the event log. Call once at startup.
+ *        Automatically logs EVENT_SYSTEM_START.
+ */
+void event_log_init(void);
+
+/**
+ * @brief Record an event.
+ * @param type    Event type
+ * @param payload Optional data (0 if unused)
+ */
+void event_log_record(event_type_t type, uint32_t payload);
+
+/**
+ * @brief Get count of events currently in the buffer.
+ */
+int event_log_count(void);
+
+/**
+ * @brief Get events from the log, newest first.
+ * @param out     Output buffer
+ * @param max_out Maximum entries to copy
+ * @param offset  Skip this many newest entries (for pagination)
+ * @return Number of entries actually copied
+ */
+int event_log_get(event_entry_t* out, int max_out, int offset);
+
+/**
+ * @brief Clear all events from the log.
+ */
+void event_log_clear(void);
+
+/**
+ * @brief Get a short English description for an event type.
+ */
+const char* event_type_name(event_type_t type);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/event_log_screen.cpp
+++ b/main/event_log_screen.cpp
@@ -7,6 +7,7 @@
 
 #include "event_log_screen.h"
 #include "event_log.h"
+#include "heatpump_errors.h"
 #include "ui_common.h"
 #include "fonts/fonts.h"
 #include "i18n/i18n.h"
@@ -68,6 +69,31 @@ static string_id_t event_type_to_str_id(event_type_t type) {
         case EVENT_CONNECTED:       return STR_EVENT_CONNECTED;
         case EVENT_DISCONNECTED:    return STR_EVENT_DISCONNECTED;
         default:                    return STR_EVENT_SYSTEM_START;
+    }
+}
+
+static const char* event_type_icon(event_type_t type) {
+    switch (type) {
+        case EVENT_SYSTEM_START:    return LV_SYMBOL_CHARGE;
+        case EVENT_POWER_ON:        return LV_SYMBOL_POWER;
+        case EVENT_POWER_OFF:       return LV_SYMBOL_POWER;
+        case EVENT_MODE_CHANGED:    return LV_SYMBOL_LOOP;
+        case EVENT_SETPOINT_CHANGED:return LV_SYMBOL_EDIT;
+        case EVENT_COMPRESSOR_ON:   return LV_SYMBOL_SETTINGS;
+        case EVENT_COMPRESSOR_OFF:  return LV_SYMBOL_SETTINGS;
+        case EVENT_FAN_ON:          return LV_SYMBOL_SHUFFLE;
+        case EVENT_FAN_OFF:         return LV_SYMBOL_SHUFFLE;
+        case EVENT_PUMP_ON:         return LV_SYMBOL_TINT;
+        case EVENT_PUMP_OFF:        return LV_SYMBOL_TINT;
+        case EVENT_AUX_HEATER_ON:   return LV_SYMBOL_PLUS;
+        case EVENT_AUX_HEATER_OFF:  return LV_SYMBOL_PLUS;
+        case EVENT_DEFROST_START:   return LV_SYMBOL_REFRESH;
+        case EVENT_DEFROST_END:     return LV_SYMBOL_REFRESH;
+        case EVENT_ERROR_APPEARED:  return LV_SYMBOL_WARNING;
+        case EVENT_ERROR_CLEARED:   return LV_SYMBOL_OK;
+        case EVENT_CONNECTED:       return LV_SYMBOL_WIFI;
+        case EVENT_DISCONNECTED:    return LV_SYMBOL_WIFI;
+        default:                    return LV_SYMBOL_FILE;
     }
 }
 
@@ -135,8 +161,28 @@ static void format_event_detail(char* buf, size_t buf_size, const event_entry_t*
         case EVENT_ERROR_APPEARED:
         case EVENT_ERROR_CLEARED: {
             int reg = (p >> 16) & 0xFFFF;
-            int bit = p & 0xFFFF;
-            snprintf(buf, buf_size, "Reg %d bit %d", reg, bit);
+            uint16_t bit = p & 0xFFFF;
+            // Look up error code and description from error definitions
+            const arctic::ErrorDef* defs = nullptr;
+            int count = 0;
+            if (reg == 1) {
+                defs = arctic::getError1Definitions(&count);
+            } else if (reg == 2) {
+                defs = arctic::getError2Definitions(&count);
+            }
+            bool found = false;
+            if (defs) {
+                for (int i = 0; i < count; i++) {
+                    if (defs[i].mask == bit) {
+                        snprintf(buf, buf_size, "(%s) %s", defs[i].code, defs[i].description);
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (!found) {
+                snprintf(buf, buf_size, "Reg %d bit 0x%04X", reg, bit);
+            }
             break;
         }
         default:
@@ -160,6 +206,9 @@ static void format_event_time(char* buf, size_t buf_size, const event_entry_t* e
     }
 }
 
+// Forward declarations
+static void clear_btn_cb(lv_event_t* e);
+
 // ============================================================================
 // Build / Rebuild Event List
 // ============================================================================
@@ -170,6 +219,36 @@ static void rebuild_event_list() {
     // Remove all children from content
     lv_obj_clean(state.content);
     
+    // Clear History button row (inline, matching errors screen style)
+    lv_obj_t* clear_row = lv_obj_create(state.content);
+    lv_obj_set_size(clear_row, LV_PCT(100), 55);
+    lv_obj_set_style_bg_opa(clear_row, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_border_width(clear_row, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(clear_row, 0, LV_PART_MAIN);
+    lv_obj_set_layout(clear_row, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(clear_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(clear_row, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(clear_row, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* clear_btn = lv_btn_create(clear_row);
+    lv_obj_set_size(clear_btn, LV_SIZE_CONTENT, 50);
+    lv_obj_set_style_min_width(clear_btn, 100, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(clear_btn, lv_color_hex(0x3d4f6f), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(clear_btn, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(clear_btn, 8, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(clear_btn, 0, LV_PART_MAIN);
+    lv_obj_set_style_border_width(clear_btn, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_color(clear_btn, COLOR_WARNING, LV_PART_MAIN);
+    lv_obj_set_style_border_opa(clear_btn, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_set_style_pad_hor(clear_btn, 25, LV_PART_MAIN);
+    lv_obj_add_event_cb(clear_btn, clear_btn_cb, LV_EVENT_CLICKED, nullptr);
+
+    lv_obj_t* clear_label = lv_label_create(clear_btn);
+    lv_label_set_text(clear_label, i18n_get(STR_HP_CLEAR_HISTORY));
+    lv_obj_set_style_text_font(clear_label, UI_FONT_BODY, LV_PART_MAIN);
+    lv_obj_set_style_text_color(clear_label, COLOR_WARNING, LV_PART_MAIN);
+    lv_obj_center(clear_label);
+
     int count = event_log_count();
     
     // Update count label in header
@@ -195,26 +274,36 @@ static void rebuild_event_list() {
     event_entry_t events[EVENT_LOG_MAX_ENTRIES];
     int got = event_log_get(events, EVENT_LOG_MAX_ENTRIES, 0);
     
-    char detail_buf[64];
+    char detail_buf[128];
     char time_buf[32];
     
     for (int i = 0; i < got; i++) {
         const event_entry_t* evt = &events[i];
         
-        // Row container
+        // Row container - flex column layout like error cards
         lv_obj_t* row = lv_obj_create(state.content);
         lv_obj_set_size(row, LV_PCT(100), LV_SIZE_CONTENT);
-        lv_obj_set_style_min_height(row, 65, LV_PART_MAIN);
         lv_obj_set_style_bg_color(row, COLOR_CARD_BG, LV_PART_MAIN);
         lv_obj_set_style_border_width(row, 0, LV_PART_MAIN);
         lv_obj_set_style_radius(row, 12, LV_PART_MAIN);
-        lv_obj_set_style_pad_all(row, 12, LV_PART_MAIN);
+        lv_obj_set_style_pad_all(row, 15, LV_PART_MAIN);
+        lv_obj_set_layout(row, LV_LAYOUT_FLEX);
+        lv_obj_set_flex_flow(row, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_style_pad_row(row, 6, LV_PART_MAIN);
         lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+        
+        // Top row: event name + timestamp
+        lv_obj_t* top_row = lv_obj_create(row);
+        lv_obj_set_size(top_row, LV_PCT(100), LV_SIZE_CONTENT);
+        lv_obj_set_style_bg_opa(top_row, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_border_width(top_row, 0, LV_PART_MAIN);
+        lv_obj_set_style_pad_all(top_row, 0, LV_PART_MAIN);
+        lv_obj_clear_flag(top_row, LV_OBJ_FLAG_SCROLLABLE);
         
         // Color indicator bar on left
         lv_color_t evt_color = event_type_color(evt->type);
-        lv_obj_t* indicator = lv_obj_create(row);
-        lv_obj_set_size(indicator, 4, LV_PCT(80));
+        lv_obj_t* indicator = lv_obj_create(top_row);
+        lv_obj_set_size(indicator, 4, LV_PCT(100));
         lv_obj_align(indicator, LV_ALIGN_LEFT_MID, 0, 0);
         lv_obj_set_style_bg_color(indicator, evt_color, LV_PART_MAIN);
         lv_obj_set_style_bg_opa(indicator, LV_OPA_COVER, LV_PART_MAIN);
@@ -222,30 +311,33 @@ static void rebuild_event_list() {
         lv_obj_set_style_radius(indicator, 2, LV_PART_MAIN);
         lv_obj_clear_flag(indicator, LV_OBJ_FLAG_SCROLLABLE);
         
-        // Event type name
-        lv_obj_t* name_lbl = lv_label_create(row);
-        lv_label_set_text(name_lbl, i18n_get(event_type_to_str_id(evt->type)));
-        lv_obj_set_style_text_font(name_lbl, &montserrat_24_latin, LV_PART_MAIN);
+        // Event type icon + name
+        char name_buf[96];
+        snprintf(name_buf, sizeof(name_buf), "%s  %s", event_type_icon(evt->type), i18n_get(event_type_to_str_id(evt->type)));
+        lv_obj_t* name_lbl = lv_label_create(top_row);
+        lv_label_set_text(name_lbl, name_buf);
+        lv_obj_set_style_text_font(name_lbl, &montserrat_32_latin, LV_PART_MAIN);
         lv_obj_set_style_text_color(name_lbl, evt_color, LV_PART_MAIN);
-        lv_obj_align(name_lbl, LV_ALIGN_TOP_LEFT, 16, 0);
+        lv_obj_align(name_lbl, LV_ALIGN_LEFT_MID, 16, 0);
         
-        // Detail text (mode change, setpoint, error code)
+        // Timestamp on the right
+        format_event_time(time_buf, sizeof(time_buf), evt);
+        lv_obj_t* time_lbl = lv_label_create(top_row);
+        lv_label_set_text(time_lbl, time_buf);
+        lv_obj_set_style_text_font(time_lbl, &montserrat_24_latin, LV_PART_MAIN);
+        lv_obj_set_style_text_color(time_lbl, COLOR_TEXT_DIM, LV_PART_MAIN);
+        lv_obj_align(time_lbl, LV_ALIGN_RIGHT_MID, 0, 0);
+        
+        // Detail text (mode change, setpoint, error description)
         format_event_detail(detail_buf, sizeof(detail_buf), evt);
         if (detail_buf[0] != '\0') {
             lv_obj_t* detail_lbl = lv_label_create(row);
             lv_label_set_text(detail_lbl, detail_buf);
-            lv_obj_set_style_text_font(detail_lbl, &montserrat_16_latin, LV_PART_MAIN);
+            lv_label_set_long_mode(detail_lbl, LV_LABEL_LONG_WRAP);
+            lv_obj_set_width(detail_lbl, LV_PCT(100));
+            lv_obj_set_style_text_font(detail_lbl, &montserrat_24_latin, LV_PART_MAIN);
             lv_obj_set_style_text_color(detail_lbl, COLOR_TEXT_DIM, LV_PART_MAIN);
-            lv_obj_align(detail_lbl, LV_ALIGN_BOTTOM_LEFT, 16, 0);
         }
-        
-        // Timestamp on the right
-        format_event_time(time_buf, sizeof(time_buf), evt);
-        lv_obj_t* time_lbl = lv_label_create(row);
-        lv_label_set_text(time_lbl, time_buf);
-        lv_obj_set_style_text_font(time_lbl, &montserrat_16_latin, LV_PART_MAIN);
-        lv_obj_set_style_text_color(time_lbl, COLOR_TEXT_DIM, LV_PART_MAIN);
-        lv_obj_align(time_lbl, LV_ALIGN_TOP_RIGHT, 0, 0);
     }
     
     state.last_count = count;
@@ -345,25 +437,6 @@ void event_log_screen_show(event_log_screen_close_cb_t on_close) {
     lv_obj_set_style_text_font(back_icon, &montserrat_32_latin, LV_PART_MAIN);
     lv_obj_set_style_text_color(back_icon, COLOR_ACCENT, LV_PART_MAIN);
     lv_obj_center(back_icon);
-    
-    // Clear button (trash icon) to the left of close button
-    lv_obj_t* clear_btn = lv_btn_create(header);
-    lv_obj_set_size(clear_btn, 50, 50);
-    lv_obj_align(clear_btn, LV_ALIGN_RIGHT_MID, -60, 0);
-    lv_obj_set_style_bg_color(clear_btn, lv_color_hex(0x3d4f6f), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(clear_btn, LV_OPA_COVER, LV_PART_MAIN);
-    lv_obj_set_style_radius(clear_btn, LV_RADIUS_CIRCLE, LV_PART_MAIN);
-    lv_obj_set_style_shadow_width(clear_btn, 0, LV_PART_MAIN);
-    lv_obj_set_style_border_width(clear_btn, 2, LV_PART_MAIN);
-    lv_obj_set_style_border_color(clear_btn, COLOR_WARNING, LV_PART_MAIN);
-    lv_obj_set_style_border_opa(clear_btn, LV_OPA_50, LV_PART_MAIN);
-    lv_obj_add_event_cb(clear_btn, clear_btn_cb, LV_EVENT_CLICKED, nullptr);
-    
-    lv_obj_t* clear_icon = lv_label_create(clear_btn);
-    lv_label_set_text(clear_icon, LV_SYMBOL_TRASH);
-    lv_obj_set_style_text_font(clear_icon, &montserrat_24_latin, LV_PART_MAIN);
-    lv_obj_set_style_text_color(clear_icon, COLOR_WARNING, LV_PART_MAIN);
-    lv_obj_center(clear_icon);
     
     // Title
     state.count_label = lv_label_create(header);

--- a/main/event_log_screen.cpp
+++ b/main/event_log_screen.cpp
@@ -1,0 +1,430 @@
+/*
+ * Arctic Heat Pump Controller
+ * Event Log Screen Implementation
+ * 
+ * Full-screen scrollable list of recent operational events, newest first.
+ */
+
+#include "event_log_screen.h"
+#include "event_log.h"
+#include "ui_common.h"
+#include "fonts/fonts.h"
+#include "i18n/i18n.h"
+#include <esp_log.h>
+#include <stdio.h>
+#include <time.h>
+
+static const char* TAG = "evt_screen";
+
+// ============================================================================
+// Colors
+// ============================================================================
+#define COLOR_BG            lv_color_hex(0x1a1a2e)
+#define COLOR_CARD_BG       lv_color_hex(0x16213e)
+#define COLOR_HEADER_BG     lv_color_hex(0x0f1a2e)
+#define COLOR_TEXT          lv_color_hex(0xeaeaea)
+#define COLOR_TEXT_DIM      lv_color_hex(0x888888)
+#define COLOR_ACCENT        lv_color_hex(0x00d4ff)
+#define COLOR_SUCCESS       lv_color_hex(0x4ade80)
+#define COLOR_WARNING       lv_color_hex(0xfbbf24)
+#define COLOR_ERROR         lv_color_hex(0xef4444)
+
+// ============================================================================
+// State
+// ============================================================================
+static struct {
+    bool shown = false;
+    lv_obj_t* screen = nullptr;
+    event_log_screen_close_cb_t on_close = nullptr;
+    lv_timer_t* update_timer = nullptr;
+    lv_obj_t* content = nullptr;
+    lv_obj_t* count_label = nullptr;
+    int last_count = -1;    // Force rebuild on first update
+} state;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+static string_id_t event_type_to_str_id(event_type_t type) {
+    switch (type) {
+        case EVENT_SYSTEM_START:    return STR_EVENT_SYSTEM_START;
+        case EVENT_POWER_ON:        return STR_EVENT_POWER_ON;
+        case EVENT_POWER_OFF:       return STR_EVENT_POWER_OFF;
+        case EVENT_MODE_CHANGED:    return STR_EVENT_MODE_CHANGED;
+        case EVENT_SETPOINT_CHANGED:return STR_EVENT_SETPOINT_CHANGED;
+        case EVENT_COMPRESSOR_ON:   return STR_EVENT_COMPRESSOR_ON;
+        case EVENT_COMPRESSOR_OFF:  return STR_EVENT_COMPRESSOR_OFF;
+        case EVENT_FAN_ON:          return STR_EVENT_FAN_ON;
+        case EVENT_FAN_OFF:         return STR_EVENT_FAN_OFF;
+        case EVENT_PUMP_ON:         return STR_EVENT_PUMP_ON;
+        case EVENT_PUMP_OFF:        return STR_EVENT_PUMP_OFF;
+        case EVENT_AUX_HEATER_ON:   return STR_EVENT_AUX_HEATER_ON;
+        case EVENT_AUX_HEATER_OFF:  return STR_EVENT_AUX_HEATER_OFF;
+        case EVENT_DEFROST_START:   return STR_EVENT_DEFROST_START;
+        case EVENT_DEFROST_END:     return STR_EVENT_DEFROST_END;
+        case EVENT_ERROR_APPEARED:  return STR_EVENT_ERROR_APPEARED;
+        case EVENT_ERROR_CLEARED:   return STR_EVENT_ERROR_CLEARED;
+        case EVENT_CONNECTED:       return STR_EVENT_CONNECTED;
+        case EVENT_DISCONNECTED:    return STR_EVENT_DISCONNECTED;
+        default:                    return STR_EVENT_SYSTEM_START;
+    }
+}
+
+static lv_color_t event_type_color(event_type_t type) {
+    switch (type) {
+        case EVENT_POWER_ON:
+        case EVENT_COMPRESSOR_ON:
+        case EVENT_FAN_ON:
+        case EVENT_PUMP_ON:
+        case EVENT_AUX_HEATER_ON:
+        case EVENT_CONNECTED:
+        case EVENT_DEFROST_END:
+        case EVENT_ERROR_CLEARED:
+            return COLOR_SUCCESS;
+        
+        case EVENT_ERROR_APPEARED:
+            return COLOR_ERROR;
+        
+        case EVENT_DEFROST_START:
+        case EVENT_AUX_HEATER_OFF:
+            return COLOR_WARNING;
+        
+        case EVENT_MODE_CHANGED:
+        case EVENT_SETPOINT_CHANGED:
+        case EVENT_SYSTEM_START:
+            return COLOR_ACCENT;
+        
+        default:
+            return COLOR_TEXT_DIM;
+    }
+}
+
+static const char* mode_name_i18n(int mode) {
+    switch (mode) {
+        case 0: return i18n_get(STR_HP_MODE_COOLING);
+        case 1: return i18n_get(STR_HP_MODE_FLOOR_HEAT);
+        case 2: return i18n_get(STR_HP_MODE_FAN_HEAT);
+        case 5: return i18n_get(STR_HP_MODE_HOT_WATER);
+        case 6: return i18n_get(STR_HP_MODE_AUTO);
+        default: return "?";
+    }
+}
+
+static void format_event_detail(char* buf, size_t buf_size, const event_entry_t* evt) {
+    uint32_t p = evt->payload;
+    
+    switch (evt->type) {
+        case EVENT_MODE_CHANGED: {
+            int old_mode = (p >> 8) & 0xFF;
+            int new_mode = p & 0xFF;
+            snprintf(buf, buf_size, "%s → %s", mode_name_i18n(old_mode), mode_name_i18n(new_mode));
+            break;
+        }
+        case EVENT_SETPOINT_CHANGED: {
+            int sp_type = (p >> 16) & 0xFF;
+            int old_val = (p >> 8) & 0xFF;
+            int new_val = p & 0xFF;
+            const char* sp_names[] = {
+                "Cooling", "Heating", "Hot Water"
+            };
+            const char* name = (sp_type < 3) ? sp_names[sp_type] : "?";
+            snprintf(buf, buf_size, "%s: %d° → %d°", name, old_val, new_val);
+            break;
+        }
+        case EVENT_ERROR_APPEARED:
+        case EVENT_ERROR_CLEARED: {
+            int reg = (p >> 16) & 0xFFFF;
+            int bit = p & 0xFFFF;
+            snprintf(buf, buf_size, "Reg %d bit %d", reg, bit);
+            break;
+        }
+        default:
+            buf[0] = '\0';
+            break;
+    }
+}
+
+static void format_event_time(char* buf, size_t buf_size, const event_entry_t* evt) {
+    if (evt->timestamp > 0) {
+        time_t t = (time_t)evt->timestamp;
+        struct tm tm;
+        localtime_r(&t, &tm);
+        snprintf(buf, buf_size, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min, tm.tm_sec);
+    } else {
+        // Use uptime
+        uint32_t sec = evt->uptime_ms / 1000;
+        uint32_t min = sec / 60;
+        uint32_t hr = min / 60;
+        snprintf(buf, buf_size, "+%luh%02lum%02lus", (unsigned long)hr, (unsigned long)(min % 60), (unsigned long)(sec % 60));
+    }
+}
+
+// ============================================================================
+// Build / Rebuild Event List
+// ============================================================================
+
+static void rebuild_event_list() {
+    if (!state.content) return;
+    
+    // Remove all children from content
+    lv_obj_clean(state.content);
+    
+    int count = event_log_count();
+    
+    // Update count label in header
+    if (state.count_label) {
+        char title_buf[64];
+        snprintf(title_buf, sizeof(title_buf), "%s (%d)", i18n_get(STR_EVENT_LOG), count);
+        lv_label_set_text(state.count_label, title_buf);
+    }
+    
+    if (count == 0) {
+        // Show "no events" message
+        lv_obj_t* msg = lv_label_create(state.content);
+        lv_label_set_text(msg, i18n_get(STR_EVENT_NO_EVENTS));
+        lv_obj_set_style_text_color(msg, COLOR_TEXT_DIM, LV_PART_MAIN);
+        lv_obj_set_style_text_font(msg, &montserrat_24_latin, LV_PART_MAIN);
+        lv_obj_set_width(msg, LV_PCT(100));
+        lv_obj_set_style_text_align(msg, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+        lv_obj_set_style_pad_top(msg, 40, LV_PART_MAIN);
+        return;
+    }
+    
+    // Get all events (newest first)
+    event_entry_t events[EVENT_LOG_MAX_ENTRIES];
+    int got = event_log_get(events, EVENT_LOG_MAX_ENTRIES, 0);
+    
+    char detail_buf[64];
+    char time_buf[32];
+    
+    for (int i = 0; i < got; i++) {
+        const event_entry_t* evt = &events[i];
+        
+        // Row container
+        lv_obj_t* row = lv_obj_create(state.content);
+        lv_obj_set_size(row, LV_PCT(100), LV_SIZE_CONTENT);
+        lv_obj_set_style_min_height(row, 65, LV_PART_MAIN);
+        lv_obj_set_style_bg_color(row, COLOR_CARD_BG, LV_PART_MAIN);
+        lv_obj_set_style_border_width(row, 0, LV_PART_MAIN);
+        lv_obj_set_style_radius(row, 12, LV_PART_MAIN);
+        lv_obj_set_style_pad_all(row, 12, LV_PART_MAIN);
+        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+        
+        // Color indicator bar on left
+        lv_color_t evt_color = event_type_color(evt->type);
+        lv_obj_t* indicator = lv_obj_create(row);
+        lv_obj_set_size(indicator, 4, LV_PCT(80));
+        lv_obj_align(indicator, LV_ALIGN_LEFT_MID, 0, 0);
+        lv_obj_set_style_bg_color(indicator, evt_color, LV_PART_MAIN);
+        lv_obj_set_style_bg_opa(indicator, LV_OPA_COVER, LV_PART_MAIN);
+        lv_obj_set_style_border_width(indicator, 0, LV_PART_MAIN);
+        lv_obj_set_style_radius(indicator, 2, LV_PART_MAIN);
+        lv_obj_clear_flag(indicator, LV_OBJ_FLAG_SCROLLABLE);
+        
+        // Event type name
+        lv_obj_t* name_lbl = lv_label_create(row);
+        lv_label_set_text(name_lbl, i18n_get(event_type_to_str_id(evt->type)));
+        lv_obj_set_style_text_font(name_lbl, &montserrat_24_latin, LV_PART_MAIN);
+        lv_obj_set_style_text_color(name_lbl, evt_color, LV_PART_MAIN);
+        lv_obj_align(name_lbl, LV_ALIGN_TOP_LEFT, 16, 0);
+        
+        // Detail text (mode change, setpoint, error code)
+        format_event_detail(detail_buf, sizeof(detail_buf), evt);
+        if (detail_buf[0] != '\0') {
+            lv_obj_t* detail_lbl = lv_label_create(row);
+            lv_label_set_text(detail_lbl, detail_buf);
+            lv_obj_set_style_text_font(detail_lbl, &montserrat_16_latin, LV_PART_MAIN);
+            lv_obj_set_style_text_color(detail_lbl, COLOR_TEXT_DIM, LV_PART_MAIN);
+            lv_obj_align(detail_lbl, LV_ALIGN_BOTTOM_LEFT, 16, 0);
+        }
+        
+        // Timestamp on the right
+        format_event_time(time_buf, sizeof(time_buf), evt);
+        lv_obj_t* time_lbl = lv_label_create(row);
+        lv_label_set_text(time_lbl, time_buf);
+        lv_obj_set_style_text_font(time_lbl, &montserrat_16_latin, LV_PART_MAIN);
+        lv_obj_set_style_text_color(time_lbl, COLOR_TEXT_DIM, LV_PART_MAIN);
+        lv_obj_align(time_lbl, LV_ALIGN_TOP_RIGHT, 0, 0);
+    }
+    
+    state.last_count = count;
+}
+
+// ============================================================================
+// Timer callback - only rebuild if count changed
+// ============================================================================
+
+static void update_timer_cb(lv_timer_t* timer) {
+    if (!state.shown) return;
+    int count = event_log_count();
+    if (count != state.last_count) {
+        rebuild_event_list();
+    }
+}
+
+// ============================================================================
+// Callbacks
+// ============================================================================
+
+static void back_btn_cb(lv_event_t* e) {
+    (void)e;
+    ESP_LOGI(TAG, "Back button clicked");
+    
+    // Stop timer first to prevent use-after-free
+    if (state.update_timer) {
+        lv_timer_del(state.update_timer);
+        state.update_timer = nullptr;
+    }
+    
+    // Save and clear callback
+    event_log_screen_close_cb_t cb = state.on_close;
+    state.on_close = nullptr;
+    state.shown = false;
+    state.screen = nullptr;
+    state.content = nullptr;
+    state.count_label = nullptr;
+    state.last_count = -1;
+    
+    // Call callback - it will load the previous screen with auto_del=true
+    if (cb) {
+        cb();
+    }
+}
+
+static void clear_btn_cb(lv_event_t* e) {
+    (void)e;
+    ESP_LOGI(TAG, "Clear events");
+    event_log_clear();
+    rebuild_event_list();
+}
+
+// ============================================================================
+// Public Functions
+// ============================================================================
+
+void event_log_screen_show(event_log_screen_close_cb_t on_close) {
+    if (state.shown) {
+        return;
+    }
+    
+    ESP_LOGI(TAG, "Showing event log screen");
+    state.on_close = on_close;
+    
+    // Create screen
+    state.screen = lv_obj_create(NULL);
+    lv_obj_set_size(state.screen, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_color(state.screen, COLOR_BG, LV_PART_MAIN);
+    lv_obj_clear_flag(state.screen, LV_OBJ_FLAG_SCROLLABLE);
+    
+    // Header (8% height)
+    lv_obj_t* header = lv_obj_create(state.screen);
+    lv_obj_set_size(header, LV_PCT(100), LV_PCT(8));
+    lv_obj_align(header, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_bg_color(header, COLOR_HEADER_BG, LV_PART_MAIN);
+    lv_obj_set_style_border_width(header, 0, LV_PART_MAIN);
+    lv_obj_set_style_radius(header, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_hor(header, 15, LV_PART_MAIN);
+    lv_obj_clear_flag(header, LV_OBJ_FLAG_SCROLLABLE);
+    
+    // Close button (X on right) with circular background
+    lv_obj_t* back_btn = lv_btn_create(header);
+    lv_obj_set_size(back_btn, 50, 50);
+    lv_obj_align(back_btn, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_obj_set_style_bg_color(back_btn, lv_color_hex(0x3d4f6f), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(back_btn, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(back_btn, LV_RADIUS_CIRCLE, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(back_btn, 0, LV_PART_MAIN);
+    lv_obj_set_style_border_width(back_btn, 2, LV_PART_MAIN);
+    lv_obj_set_style_border_color(back_btn, COLOR_ACCENT, LV_PART_MAIN);
+    lv_obj_set_style_border_opa(back_btn, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_add_event_cb(back_btn, back_btn_cb, LV_EVENT_CLICKED, nullptr);
+    
+    lv_obj_t* back_icon = lv_label_create(back_btn);
+    lv_label_set_text(back_icon, LV_SYMBOL_CLOSE);
+    lv_obj_set_style_text_font(back_icon, &montserrat_32_latin, LV_PART_MAIN);
+    lv_obj_set_style_text_color(back_icon, COLOR_ACCENT, LV_PART_MAIN);
+    lv_obj_center(back_icon);
+    
+    // Clear button (trash icon) to the left of close button
+    lv_obj_t* clear_btn = lv_btn_create(header);
+    lv_obj_set_size(clear_btn, 50, 50);
+    lv_obj_align(clear_btn, LV_ALIGN_RIGHT_MID, -60, 0);
+    lv_obj_set_style_bg_color(clear_btn, lv_color_hex(0x3d4f6f), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(clear_btn, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(clear_btn, LV_RADIUS_CIRCLE, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(clear_btn, 0, LV_PART_MAIN);
+    lv_obj_set_style_border_width(clear_btn, 2, LV_PART_MAIN);
+    lv_obj_set_style_border_color(clear_btn, COLOR_WARNING, LV_PART_MAIN);
+    lv_obj_set_style_border_opa(clear_btn, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_add_event_cb(clear_btn, clear_btn_cb, LV_EVENT_CLICKED, nullptr);
+    
+    lv_obj_t* clear_icon = lv_label_create(clear_btn);
+    lv_label_set_text(clear_icon, LV_SYMBOL_TRASH);
+    lv_obj_set_style_text_font(clear_icon, &montserrat_24_latin, LV_PART_MAIN);
+    lv_obj_set_style_text_color(clear_icon, COLOR_WARNING, LV_PART_MAIN);
+    lv_obj_center(clear_icon);
+    
+    // Title
+    state.count_label = lv_label_create(header);
+    char title_buf[64];
+    snprintf(title_buf, sizeof(title_buf), "%s (%d)", i18n_get(STR_EVENT_LOG), event_log_count());
+    lv_label_set_text(state.count_label, title_buf);
+    lv_obj_set_style_text_color(state.count_label, COLOR_TEXT, LV_PART_MAIN);
+    lv_obj_set_style_text_font(state.count_label, UI_FONT_HEADER, LV_PART_MAIN);
+    lv_obj_align(state.count_label, LV_ALIGN_LEFT_MID, 10, 0);
+    
+    // Scrollable content
+    state.content = lv_obj_create(state.screen);
+    lv_obj_set_size(state.content, LV_PCT(100), LV_PCT(92));
+    lv_obj_align(state.content, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_opa(state.content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_border_width(state.content, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(state.content, 15, LV_PART_MAIN);
+    lv_obj_set_flex_flow(state.content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_row(state.content, 8, LV_PART_MAIN);
+    lv_obj_set_scrollbar_mode(state.content, LV_SCROLLBAR_MODE_AUTO);
+    
+    state.shown = true;
+    state.last_count = -1;  // Force initial build
+    
+    // Build the event list
+    rebuild_event_list();
+    
+    // Update timer (check for new events every 2 seconds)
+    state.update_timer = lv_timer_create(update_timer_cb, 2000, nullptr);
+    
+    // Load with fade animation
+    lv_screen_load_anim(state.screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, false);
+}
+
+void event_log_screen_hide(void) {
+    if (!state.shown) {
+        return;
+    }
+    
+    ESP_LOGI(TAG, "Hiding event log screen");
+    
+    if (state.update_timer) {
+        lv_timer_del(state.update_timer);
+        state.update_timer = nullptr;
+    }
+    
+    event_log_screen_close_cb_t cb = state.on_close;
+    
+    state.shown = false;
+    state.on_close = nullptr;
+    state.screen = nullptr;
+    state.content = nullptr;
+    state.count_label = nullptr;
+    state.last_count = -1;
+    
+    // Call callback to restore previous screen
+    if (cb) {
+        cb();
+    }
+}
+
+bool event_log_screen_is_shown(void) {
+    return state.shown;
+}

--- a/main/event_log_screen.h
+++ b/main/event_log_screen.h
@@ -1,0 +1,38 @@
+/*
+ * Arctic Heat Pump Controller
+ * Event Log Screen
+ * 
+ * Full-screen display of recent operational events
+ */
+#pragma once
+
+#include <lvgl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Callback when screen is closed
+ */
+typedef void (*event_log_screen_close_cb_t)(void);
+
+/**
+ * @brief Show the event log screen
+ * @param on_close Callback when screen is closed
+ */
+void event_log_screen_show(event_log_screen_close_cb_t on_close);
+
+/**
+ * @brief Hide/close the event log screen
+ */
+void event_log_screen_hide(void);
+
+/**
+ * @brief Check if event log screen is visible
+ */
+bool event_log_screen_is_shown(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/heatpump_screen.cpp
+++ b/main/heatpump_screen.cpp
@@ -9,6 +9,7 @@
 #include "heatpump_control_screen.h"
 #include "heatpump_errors_screen.h"
 #include "heatpump_errors.h"
+#include "event_log_screen.h"
 #include "modbus/arctic_heatpump.h"
 #include "modbus/arctic_registers.h"
 #include "app_preferences.h"
@@ -164,9 +165,11 @@ static struct {
     lv_obj_t* temps_btn = nullptr;
     lv_obj_t* system_btn = nullptr;
     lv_obj_t* controls_btn = nullptr;
+    lv_obj_t* events_btn = nullptr;
     lv_obj_t* temps_btn_label = nullptr;
     lv_obj_t* system_btn_label = nullptr;
     lv_obj_t* controls_btn_label = nullptr;
+    lv_obj_t* events_btn_label = nullptr;
     
     // Saved screen for returning from details/controls
     lv_obj_t* saved_screen = nullptr;
@@ -496,6 +499,19 @@ static void controls_btn_cb(lv_event_t* e) {
     heatpump_control_show(on_control_close);
 }
 
+static void on_events_close(void) {
+    if (state.saved_screen) {
+        lv_screen_load_anim(state.saved_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, true);
+        state.saved_screen = nullptr;
+    }
+}
+
+static void events_btn_cb(lv_event_t* e) {
+    (void)e;
+    state.saved_screen = lv_scr_act();
+    event_log_screen_show(on_events_close);
+}
+
 // ============================================================================
 // Timer Callback
 // ============================================================================
@@ -786,7 +802,7 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     create_value_column(energy_row, i18n_get(STR_HP_LABEL_COP), &state.energy_cop_value);
     
     // =========================================================================
-    // FIXED FOOTER: Three button bar - Temps | System | Advanced
+    // FIXED FOOTER: Four button bar - Temps | System | Control | Events
     // =========================================================================
     lv_obj_t* btn_row = lv_obj_create(parent);
     lv_obj_set_size(btn_row, LV_PCT(100), FOOTER_H);
@@ -800,7 +816,7 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     lv_obj_set_style_pad_all(btn_row, 10, LV_PART_MAIN);
 
     state.temps_btn = lv_btn_create(btn_row);
-    lv_obj_set_size(state.temps_btn, 200, 60);
+    lv_obj_set_size(state.temps_btn, 155, 60);
     lv_obj_set_style_bg_color(state.temps_btn, COLOR_CARD_BG, LV_PART_MAIN);
     lv_obj_set_style_bg_color(state.temps_btn, lv_color_hex(0x2a3a5e), LV_STATE_PRESSED);
     lv_obj_set_style_border_color(state.temps_btn, COLOR_ACCENT, LV_PART_MAIN);
@@ -815,7 +831,7 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     lv_obj_center(state.temps_btn_label);
     
     state.system_btn = lv_btn_create(btn_row);
-    lv_obj_set_size(state.system_btn, 200, 60);
+    lv_obj_set_size(state.system_btn, 155, 60);
     lv_obj_set_style_bg_color(state.system_btn, COLOR_CARD_BG, LV_PART_MAIN);
     lv_obj_set_style_bg_color(state.system_btn, lv_color_hex(0x2a3a5e), LV_STATE_PRESSED);
     lv_obj_set_style_border_color(state.system_btn, COLOR_WARNING, LV_PART_MAIN);
@@ -830,7 +846,7 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     lv_obj_center(state.system_btn_label);
     
     state.controls_btn = lv_btn_create(btn_row);
-    lv_obj_set_size(state.controls_btn, 200, 60);
+    lv_obj_set_size(state.controls_btn, 155, 60);
     lv_obj_set_style_bg_color(state.controls_btn, COLOR_CARD_BG, LV_PART_MAIN);
     lv_obj_set_style_bg_color(state.controls_btn, lv_color_hex(0x2a3a5e), LV_STATE_PRESSED);
     lv_obj_set_style_border_color(state.controls_btn, COLOR_SUCCESS, LV_PART_MAIN);
@@ -843,6 +859,21 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     lv_obj_set_style_text_font(state.controls_btn_label, UI_FONT_BODY, LV_PART_MAIN);
     lv_obj_set_style_text_color(state.controls_btn_label, COLOR_TEXT, LV_PART_MAIN);
     lv_obj_center(state.controls_btn_label);
+    
+    state.events_btn = lv_btn_create(btn_row);
+    lv_obj_set_size(state.events_btn, 155, 60);
+    lv_obj_set_style_bg_color(state.events_btn, COLOR_CARD_BG, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(state.events_btn, lv_color_hex(0x2a3a5e), LV_STATE_PRESSED);
+    lv_obj_set_style_border_color(state.events_btn, lv_color_hex(0xa78bfa), LV_PART_MAIN);
+    lv_obj_set_style_border_width(state.events_btn, 2, LV_PART_MAIN);
+    lv_obj_set_style_radius(state.events_btn, 12, LV_PART_MAIN);
+    lv_obj_add_event_cb(state.events_btn, events_btn_cb, LV_EVENT_CLICKED, nullptr);
+    
+    state.events_btn_label = lv_label_create(state.events_btn);
+    lv_label_set_text(state.events_btn_label, i18n_get(STR_EVENT_LOG));
+    lv_obj_set_style_text_font(state.events_btn_label, UI_FONT_BODY, LV_PART_MAIN);
+    lv_obj_set_style_text_color(state.events_btn_label, COLOR_TEXT, LV_PART_MAIN);
+    lv_obj_center(state.events_btn_label);
 
     state.created = true;
     
@@ -864,6 +895,7 @@ void heatpump_screen_update(void) {
     if (state.temps_btn_label) lv_label_set_text(state.temps_btn_label, i18n_get(STR_HP_BTN_TEMPS));
     if (state.system_btn_label) lv_label_set_text(state.system_btn_label, i18n_get(STR_HP_BTN_SYSTEM));
     if (state.controls_btn_label) lv_label_set_text(state.controls_btn_label, i18n_get(STR_HP_BTN_ADVANCED));
+    if (state.events_btn_label) lv_label_set_text(state.events_btn_label, i18n_get(STR_EVENT_LOG));
     if (state.hero_tank_desc) lv_label_set_text(state.hero_tank_desc, i18n_get(STR_HP_TANK_TEMPERATURE));
     
     // =====================================================================

--- a/main/i18n/i18n.cpp
+++ b/main/i18n/i18n.cpp
@@ -271,6 +271,30 @@ static const char* strings_en[STR_COUNT] = {
     [STR_HP_LABEL_LO_PRESS] = "LOW PRESS",
     [STR_HP_LABEL_POWER_IN] = "POWER IN",
     [STR_HP_LABEL_HEAT_OUT] = "HEAT OUT",
+
+    // Event Log
+    [STR_EVENT_LOG] = "Events",
+    [STR_EVENT_SYSTEM_START] = "System Start",
+    [STR_EVENT_POWER_ON] = "Power ON",
+    [STR_EVENT_POWER_OFF] = "Power OFF",
+    [STR_EVENT_MODE_CHANGED] = "Mode Changed",
+    [STR_EVENT_SETPOINT_CHANGED] = "Setpoint Changed",
+    [STR_EVENT_COMPRESSOR_ON] = "Compressor ON",
+    [STR_EVENT_COMPRESSOR_OFF] = "Compressor OFF",
+    [STR_EVENT_FAN_ON] = "Fan ON",
+    [STR_EVENT_FAN_OFF] = "Fan OFF",
+    [STR_EVENT_PUMP_ON] = "Water Pump ON",
+    [STR_EVENT_PUMP_OFF] = "Water Pump OFF",
+    [STR_EVENT_AUX_HEATER_ON] = "Aux Heater ON",
+    [STR_EVENT_AUX_HEATER_OFF] = "Aux Heater OFF",
+    [STR_EVENT_DEFROST_START] = "Defrost Start",
+    [STR_EVENT_DEFROST_END] = "Defrost End",
+    [STR_EVENT_ERROR_APPEARED] = "Error Appeared",
+    [STR_EVENT_ERROR_CLEARED] = "Error Cleared",
+    [STR_EVENT_CONNECTED] = "Connected",
+    [STR_EVENT_DISCONNECTED] = "Disconnected",
+    [STR_EVENT_CLEAR] = "Clear Events",
+    [STR_EVENT_NO_EVENTS] = "No events recorded",
 };
 
 // French strings
@@ -523,6 +547,30 @@ static const char* strings_fr[STR_COUNT] = {
     [STR_HP_LABEL_LO_PRESS] = "BASSE PR.",
     [STR_HP_LABEL_POWER_IN] = "PUISS. IN",
     [STR_HP_LABEL_HEAT_OUT] = "CHALEUR",
+
+    // Event Log
+    [STR_EVENT_LOG] = "Événements",
+    [STR_EVENT_SYSTEM_START] = "Démarrage système",
+    [STR_EVENT_POWER_ON] = "Mise en marche",
+    [STR_EVENT_POWER_OFF] = "Arrêt",
+    [STR_EVENT_MODE_CHANGED] = "Mode changé",
+    [STR_EVENT_SETPOINT_CHANGED] = "Consigne modifiée",
+    [STR_EVENT_COMPRESSOR_ON] = "Compresseur ON",
+    [STR_EVENT_COMPRESSOR_OFF] = "Compresseur OFF",
+    [STR_EVENT_FAN_ON] = "Ventilateur ON",
+    [STR_EVENT_FAN_OFF] = "Ventilateur OFF",
+    [STR_EVENT_PUMP_ON] = "Pompe à eau ON",
+    [STR_EVENT_PUMP_OFF] = "Pompe à eau OFF",
+    [STR_EVENT_AUX_HEATER_ON] = "Chauff. aux ON",
+    [STR_EVENT_AUX_HEATER_OFF] = "Chauff. aux OFF",
+    [STR_EVENT_DEFROST_START] = "Début dégivrage",
+    [STR_EVENT_DEFROST_END] = "Fin dégivrage",
+    [STR_EVENT_ERROR_APPEARED] = "Erreur apparue",
+    [STR_EVENT_ERROR_CLEARED] = "Erreur effacée",
+    [STR_EVENT_CONNECTED] = "Connecté",
+    [STR_EVENT_DISCONNECTED] = "Déconnecté",
+    [STR_EVENT_CLEAR] = "Effacer événements",
+    [STR_EVENT_NO_EVENTS] = "Aucun événement",
 };
 
 // Spanish strings
@@ -775,6 +823,30 @@ static const char* strings_es[STR_COUNT] = {
     [STR_HP_LABEL_LO_PRESS] = "PRES. BAJA",
     [STR_HP_LABEL_POWER_IN] = "POT. ENTR.",
     [STR_HP_LABEL_HEAT_OUT] = "CALOR",
+
+    // Event Log
+    [STR_EVENT_LOG] = "Eventos",
+    [STR_EVENT_SYSTEM_START] = "Inicio del sistema",
+    [STR_EVENT_POWER_ON] = "Encendido",
+    [STR_EVENT_POWER_OFF] = "Apagado",
+    [STR_EVENT_MODE_CHANGED] = "Modo cambiado",
+    [STR_EVENT_SETPOINT_CHANGED] = "Consigna cambiada",
+    [STR_EVENT_COMPRESSOR_ON] = "Compresor ON",
+    [STR_EVENT_COMPRESSOR_OFF] = "Compresor OFF",
+    [STR_EVENT_FAN_ON] = "Ventilador ON",
+    [STR_EVENT_FAN_OFF] = "Ventilador OFF",
+    [STR_EVENT_PUMP_ON] = "Bomba de agua ON",
+    [STR_EVENT_PUMP_OFF] = "Bomba de agua OFF",
+    [STR_EVENT_AUX_HEATER_ON] = "Calef. aux ON",
+    [STR_EVENT_AUX_HEATER_OFF] = "Calef. aux OFF",
+    [STR_EVENT_DEFROST_START] = "Inicio descongelación",
+    [STR_EVENT_DEFROST_END] = "Fin descongelación",
+    [STR_EVENT_ERROR_APPEARED] = "Error detectado",
+    [STR_EVENT_ERROR_CLEARED] = "Error eliminado",
+    [STR_EVENT_CONNECTED] = "Conectado",
+    [STR_EVENT_DISCONNECTED] = "Desconectado",
+    [STR_EVENT_CLEAR] = "Borrar eventos",
+    [STR_EVENT_NO_EVENTS] = "Sin eventos registrados",
 };
 
 // Language names in their own language (native names)

--- a/main/i18n/strings.h
+++ b/main/i18n/strings.h
@@ -297,6 +297,32 @@ typedef enum {
     STR_HP_LABEL_HEAT_OUT,
 
     // ========================================================================
+    // Event Log
+    // ========================================================================
+    STR_EVENT_LOG,
+    STR_EVENT_SYSTEM_START,
+    STR_EVENT_POWER_ON,
+    STR_EVENT_POWER_OFF,
+    STR_EVENT_MODE_CHANGED,
+    STR_EVENT_SETPOINT_CHANGED,
+    STR_EVENT_COMPRESSOR_ON,
+    STR_EVENT_COMPRESSOR_OFF,
+    STR_EVENT_FAN_ON,
+    STR_EVENT_FAN_OFF,
+    STR_EVENT_PUMP_ON,
+    STR_EVENT_PUMP_OFF,
+    STR_EVENT_AUX_HEATER_ON,
+    STR_EVENT_AUX_HEATER_OFF,
+    STR_EVENT_DEFROST_START,
+    STR_EVENT_DEFROST_END,
+    STR_EVENT_ERROR_APPEARED,
+    STR_EVENT_ERROR_CLEARED,
+    STR_EVENT_CONNECTED,
+    STR_EVENT_DISCONNECTED,
+    STR_EVENT_CLEAR,
+    STR_EVENT_NO_EVENTS,
+
+    // ========================================================================
     // Must be last - used for array sizing
     // ========================================================================
     STR_COUNT

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -25,6 +25,7 @@
 #include "modbus/arctic_heatpump.h"
 #include "heatpump_screen.h"
 #include "app_preferences.h"
+#include "event_log.h"
 
 static const char* TAG = "main";
 
@@ -150,6 +151,9 @@ extern "C" void app_main(void)
 
     // Initialize app preferences (demo mode, temp units, etc.)
     app_prefs_init();
+
+    // Initialize event log (RAM ring buffer for system events)
+    event_log_init();
 
     // Initialize Modbus and Arctic heat pump communication (skip in demo mode)
     if (app_prefs_is_demo_mode()) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -159,6 +159,7 @@ extern "C" void app_main(void)
     if (app_prefs_is_demo_mode()) {
         mclog::tagInfo(TAG, "Demo mode enabled - initializing demo state");
         arctic::initDemoState();
+        arctic::startPolling();
     } else {
         esp_err_t modbus_ret = modbus::init();
         if (modbus_ret == ESP_OK) {

--- a/main/modbus/arctic_heatpump.cpp
+++ b/main/modbus/arctic_heatpump.cpp
@@ -5,6 +5,7 @@
 #include "arctic_heatpump.h"
 #include "modbus_manager.h"
 #include "heatpump_errors.h"
+#include "event_log.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
@@ -27,6 +28,21 @@ static bool s_demo_mode = false;
 // Connection state tracking
 static const uint8_t MAX_CONSECUTIVE_FAILURES = 5;
 static bool s_was_connected = false;  // For logging state changes
+
+// Previous state for event detection (compared each poll cycle)
+static bool s_prev_unit_on = false;
+static WorkingMode s_prev_mode = WorkingMode::COOLING;
+static bool s_prev_compressor = false;
+static bool s_prev_fan = false;
+static bool s_prev_pump = false;
+static bool s_prev_aux_heater = false;
+static bool s_prev_defrosting = false;
+static uint16_t s_prev_error1 = 0;
+static uint16_t s_prev_error2 = 0;
+static int16_t s_prev_cooling_sp = 0;
+static int16_t s_prev_heating_sp = 0;
+static int16_t s_prev_hotwater_sp = 0;
+static bool s_prev_state_valid = false;  // False until first successful poll
 
 // Get current time in milliseconds
 static uint32_t getTimeMs() {
@@ -166,7 +182,82 @@ static void pollTask(void* param) {
             if (!s_was_connected) {
                 ESP_LOGI(TAG, "Heat pump connected");
                 s_was_connected = true;
+                event_log_record(EVENT_CONNECTED, 0);
             }
+            
+            // ---- Event detection: compare current vs previous state ----
+            if (s_prev_state_valid) {
+                // Power on/off
+                if (s_state.unit_on != s_prev_unit_on) {
+                    event_log_record(s_state.unit_on ? EVENT_POWER_ON : EVENT_POWER_OFF, 0);
+                }
+                // Mode changed
+                if (s_state.working_mode != s_prev_mode) {
+                    uint32_t payload = ((uint32_t)s_prev_mode << 8) | (uint32_t)s_state.working_mode;
+                    event_log_record(EVENT_MODE_CHANGED, payload);
+                }
+                // Setpoint changes
+                if (s_state.cooling_setpoint != s_prev_cooling_sp) {
+                    uint32_t payload = (0 << 16) | ((uint16_t)s_prev_cooling_sp << 8) | (uint16_t)s_state.cooling_setpoint;
+                    event_log_record(EVENT_SETPOINT_CHANGED, payload);
+                }
+                if (s_state.heating_setpoint != s_prev_heating_sp) {
+                    uint32_t payload = (1 << 16) | ((uint16_t)s_prev_heating_sp << 8) | (uint16_t)s_state.heating_setpoint;
+                    event_log_record(EVENT_SETPOINT_CHANGED, payload);
+                }
+                if (s_state.hot_water_setpoint != s_prev_hotwater_sp) {
+                    uint32_t payload = (2 << 16) | ((uint16_t)s_prev_hotwater_sp << 8) | (uint16_t)s_state.hot_water_setpoint;
+                    event_log_record(EVENT_SETPOINT_CHANGED, payload);
+                }
+                // Component state changes
+                bool cur_comp = s_state.isCompressorRunning();
+                if (cur_comp != s_prev_compressor) {
+                    event_log_record(cur_comp ? EVENT_COMPRESSOR_ON : EVENT_COMPRESSOR_OFF, 0);
+                }
+                bool cur_fan = s_state.isFanRunning();
+                if (cur_fan != s_prev_fan) {
+                    event_log_record(cur_fan ? EVENT_FAN_ON : EVENT_FAN_OFF, 0);
+                }
+                bool cur_pump = s_state.isWaterPumpRunning();
+                if (cur_pump != s_prev_pump) {
+                    event_log_record(cur_pump ? EVENT_PUMP_ON : EVENT_PUMP_OFF, 0);
+                }
+                bool cur_aux = s_state.isBackupHeaterOn();
+                if (cur_aux != s_prev_aux_heater) {
+                    event_log_record(cur_aux ? EVENT_AUX_HEATER_ON : EVENT_AUX_HEATER_OFF, 0);
+                }
+                // Defrost
+                bool cur_defrost = s_state.isDefrosting();
+                if (cur_defrost != s_prev_defrosting) {
+                    event_log_record(cur_defrost ? EVENT_DEFROST_START : EVENT_DEFROST_END, 0);
+                }
+                // Error changes (check individual bits)
+                uint16_t new_err1 = s_state.error1 & ~s_prev_error1;
+                uint16_t clr_err1 = s_prev_error1 & ~s_state.error1;
+                uint16_t new_err2 = s_state.error2 & ~s_prev_error2;
+                uint16_t clr_err2 = s_prev_error2 & ~s_state.error2;
+                for (int b = 0; b < 16; b++) {
+                    if (new_err1 & (1 << b)) event_log_record(EVENT_ERROR_APPEARED, (1 << 16) | (1 << b));
+                    if (clr_err1 & (1 << b)) event_log_record(EVENT_ERROR_CLEARED, (1 << 16) | (1 << b));
+                    if (new_err2 & (1 << b)) event_log_record(EVENT_ERROR_APPEARED, (2 << 16) | (1 << b));
+                    if (clr_err2 & (1 << b)) event_log_record(EVENT_ERROR_CLEARED, (2 << 16) | (1 << b));
+                }
+            }
+            
+            // Update previous state
+            s_prev_unit_on = s_state.unit_on;
+            s_prev_mode = s_state.working_mode;
+            s_prev_cooling_sp = s_state.cooling_setpoint;
+            s_prev_heating_sp = s_state.heating_setpoint;
+            s_prev_hotwater_sp = s_state.hot_water_setpoint;
+            s_prev_compressor = s_state.isCompressorRunning();
+            s_prev_fan = s_state.isFanRunning();
+            s_prev_pump = s_state.isWaterPumpRunning();
+            s_prev_aux_heater = s_state.isBackupHeaterOn();
+            s_prev_defrosting = s_state.isDefrosting();
+            s_prev_error1 = s_state.error1;
+            s_prev_error2 = s_state.error2;
+            s_prev_state_valid = true;
         } else {
             s_state.consecutive_failures++;
             
@@ -178,6 +269,7 @@ static void pollTask(void* param) {
                 if (s_was_connected) {
                     ESP_LOGW(TAG, "Heat pump disconnected: %s", modbus::getLastError());
                     s_was_connected = false;
+                    event_log_record(EVENT_DISCONNECTED, 0);
                 }
             }
         }

--- a/main/modbus/arctic_heatpump.cpp
+++ b/main/modbus/arctic_heatpump.cpp
@@ -49,10 +49,39 @@ static uint32_t getTimeMs() {
     return (uint32_t)(esp_timer_get_time() / 1000);
 }
 
+// ============================================================================
+// Demo Register Array
+// ============================================================================
+// In demo mode, poll functions read from this array instead of Modbus.
+// Setters write here instead of via Modbus. Covers addresses 2000-2138.
+static const uint16_t DEMO_REG_BASE = 2000;
+static const uint16_t DEMO_REG_COUNT = 139; // 2000..2138 inclusive
+static uint16_t s_demo_regs[DEMO_REG_COUNT];
+
+// Read multiple registers - from demo array in demo mode, Modbus otherwise
+static esp_err_t readRegisters(uint16_t address, uint16_t count, uint16_t* data) {
+    if (s_demo_mode) {
+        uint16_t offset = address - DEMO_REG_BASE;
+        memcpy(data, &s_demo_regs[offset], count * sizeof(uint16_t));
+        return ESP_OK;
+    }
+    return modbus::readHoldingRegisters(SLAVE_ADDRESS, address, count, data);
+}
+
+// Write a single register - to demo array in demo mode, Modbus otherwise
+static esp_err_t writeSingleReg(uint16_t address, uint16_t value) {
+    if (s_demo_mode) {
+        uint16_t offset = address - DEMO_REG_BASE;
+        s_demo_regs[offset] = value;
+        return ESP_OK;
+    }
+    return modbus::writeSingleRegister(SLAVE_ADDRESS, address, value);
+}
+
 // Poll holding registers (settings)
 static bool pollHoldingRegisters() {
     uint16_t data[8];
-    esp_err_t err = modbus::readHoldingRegisters(SLAVE_ADDRESS, reg::UNIT_ON_OFF, 8, data);
+    esp_err_t err = readRegisters(reg::UNIT_ON_OFF, 8, data);
     
     if (err != ESP_OK) {
         return false;
@@ -72,7 +101,7 @@ static bool pollHoldingRegisters() {
 // Poll temperature registers (2100-2117)
 static bool pollTemperatures() {
     uint16_t data[18];  // 2100-2117
-    esp_err_t err = modbus::readHoldingRegisters(SLAVE_ADDRESS, reg::WATER_TANK_TEMP, 18, data);
+    esp_err_t err = readRegisters(reg::WATER_TANK_TEMP, 18, data);
     
     if (err != ESP_OK) {
         return false;
@@ -101,7 +130,7 @@ static bool pollTemperatures() {
 // Poll system readings (2118-2127)
 static bool pollSystemReadings() {
     uint16_t data[10];  // 2118-2127
-    esp_err_t err = modbus::readHoldingRegisters(SLAVE_ADDRESS, reg::COMPRESSOR_FREQ, 10, data);
+    esp_err_t err = readRegisters(reg::COMPRESSOR_FREQ, 10, data);
     
     if (err != ESP_OK) {
         return false;
@@ -125,11 +154,8 @@ static bool pollSystemReadings() {
 
 // Poll status and error registers (2135-2138)
 static bool pollStatus() {
-    // Read registers 2135-2138 (but they're not contiguous from previous reads)
-    // We need to read starting from 2135, which is 2135-2100=35 registers after 2100
-    // Or we can read just 4 registers starting at 2135
     uint16_t data[4];
-    esp_err_t err = modbus::readHoldingRegisters(SLAVE_ADDRESS, reg::STATUS_1, 4, data);
+    esp_err_t err = readRegisters(reg::STATUS_1, 4, data);
     
     if (err != ESP_OK) {
         return false;
@@ -307,51 +333,57 @@ void initDemoState() {
     
     s_demo_mode = true;
     
-    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-    s_state = HeatPumpState();
+    // Populate demo registers with realistic initial values
+    memset(s_demo_regs, 0, sizeof(s_demo_regs));
     
-    // Connection
-    s_state.connected = true;
-    s_state.last_successful_read_ms = getTimeMs();
-    
-    // Settings
-    s_state.unit_on = true;
-    s_state.working_mode = WorkingMode::FLOOR_HEATING;
-    s_state.cooling_setpoint = 18;
-    s_state.heating_setpoint = 45;
-    s_state.hot_water_setpoint = 50;
+    // Settings (2000-2007)
+    s_demo_regs[reg::UNIT_ON_OFF - DEMO_REG_BASE]       = 1;  // ON
+    s_demo_regs[reg::WORKING_MODE - DEMO_REG_BASE]      = static_cast<uint16_t>(WorkingMode::FLOOR_HEATING);
+    s_demo_regs[reg::COOLING_SETPOINT - DEMO_REG_BASE]  = 18;
+    s_demo_regs[reg::HEATING_SETPOINT - DEMO_REG_BASE]  = 45;
+    s_demo_regs[reg::HOT_WATER_SETPOINT - DEMO_REG_BASE] = 50;
     
     // Temperatures (°C)
-    s_state.water_tank_temp = 42;
-    s_state.outlet_water_temp = 45;
-    s_state.inlet_water_temp = 38;
-    s_state.discharge_temp = 85;
-    s_state.suction_temp = 12;
-    s_state.outdoor_coil_temp = 35;
-    s_state.indoor_coil_temp = 40;
-    s_state.outdoor_ambient_temp = 22;
-    s_state.ipm_temp = 55;
+    s_demo_regs[reg::WATER_TANK_TEMP - DEMO_REG_BASE]    = 42;
+    s_demo_regs[reg::OUTLET_WATER_TEMP - DEMO_REG_BASE]  = 45;
+    s_demo_regs[reg::INLET_WATER_TEMP - DEMO_REG_BASE]   = 38;
+    s_demo_regs[reg::DISCHARGE_TEMP - DEMO_REG_BASE]     = 85;
+    s_demo_regs[reg::SUCTION_TEMP - DEMO_REG_BASE]       = 12;
+    s_demo_regs[reg::OUTDOOR_COIL_TEMP - DEMO_REG_BASE]  = 35;
+    s_demo_regs[reg::INDOOR_COIL_TEMP - DEMO_REG_BASE]   = 40;
+    s_demo_regs[reg::OUTDOOR_AMBIENT_TEMP - DEMO_REG_BASE] = 22;
+    s_demo_regs[reg::IPM_TEMP - DEMO_REG_BASE]           = 55;
     
     // System readings
-    s_state.compressor_freq = 60;
-    s_state.fan_speed = 850;
-    s_state.ac_voltage = 230;
-    s_state.ac_current = 52;     // tenths of amps → 5.2A → ~1200W
-    s_state.dc_voltage = 3800;   // ÷10 = 380V
-    s_state.dc_current = 3;
-    s_state.primary_eev_opening = 320;
-    s_state.secondary_eev_opening = 0;
-    s_state.high_pressure = 280; // ÷100 = 2.80 MPa
-    s_state.low_pressure = 85;   // ÷100 = 0.85 MPa
+    s_demo_regs[reg::COMPRESSOR_FREQ - DEMO_REG_BASE]      = 60;
+    s_demo_regs[reg::FAN_SPEED - DEMO_REG_BASE]            = 850;
+    s_demo_regs[reg::AC_VOLTAGE - DEMO_REG_BASE]           = 230;
+    s_demo_regs[reg::AC_CURRENT - DEMO_REG_BASE]           = 52;    // tenths of amps → 5.2A
+    s_demo_regs[reg::DC_VOLTAGE - DEMO_REG_BASE]           = 3800;  // ÷10 = 380V
+    s_demo_regs[reg::DC_CURRENT - DEMO_REG_BASE]           = 3;
+    s_demo_regs[reg::PRIMARY_EEV_OPENING - DEMO_REG_BASE]  = 320;
+    s_demo_regs[reg::SECONDARY_EEV_OPENING - DEMO_REG_BASE] = 0;
+    s_demo_regs[reg::HIGH_PRESSURE - DEMO_REG_BASE]        = 280;   // ÷100 = 2.80 MPa
+    s_demo_regs[reg::LOW_PRESSURE - DEMO_REG_BASE]         = 85;    // ÷100 = 0.85 MPa
     
     // Status - compressor, fan medium, water pump running
-    s_state.status1 = status1::UNIT_ON | status1::COMPRESSOR | status1::FAN_MED | status1::WATER_PUMP;
-    s_state.status2 = 0;
+    s_demo_regs[reg::STATUS_1 - DEMO_REG_BASE] = status1::UNIT_ON | status1::COMPRESSOR | status1::FAN_MED | status1::WATER_PUMP;
+    s_demo_regs[reg::STATUS_2 - DEMO_REG_BASE] = 0;
     
     // Errors - P02 high pressure active
-    s_state.error1 = 0;
-    s_state.error2 = error2::HIGH_PRESSURE;
+    s_demo_regs[reg::ERROR_1 - DEMO_REG_BASE] = 0;
+    s_demo_regs[reg::ERROR_2 - DEMO_REG_BASE] = error2::HIGH_PRESSURE;
     
+    // Sync demo registers into s_state via the poll functions
+    pollStatus();
+    pollTemperatures();
+    pollSystemReadings();
+    pollHoldingRegisters();
+    
+    // Mark as connected
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    s_state.connected = true;
+    s_state.last_successful_read_ms = getTimeMs();
     xSemaphoreGive(s_state_mutex);
     
     // Seed error history with the current error state
@@ -368,17 +400,12 @@ bool isDemoMode() {
 }
 
 void startPolling() {
-    if (s_demo_mode) {
-        ESP_LOGI(TAG, "Demo mode - polling disabled");
-        return;
-    }
-    
     if (s_poll_task != nullptr) {
         ESP_LOGW(TAG, "Polling already running");
         return;
     }
     
-    if (!modbus::isInitialized()) {
+    if (!s_demo_mode && !modbus::isInitialized()) {
         ESP_LOGE(TAG, "Cannot start polling: Modbus not initialized");
         return;
     }
@@ -440,20 +467,7 @@ bool isConnected() {
 // ============================================================================
 
 bool setUnitPower(bool on) {
-    if (s_demo_mode) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.unit_on = on;
-        if (on) {
-            s_state.status1 = status1::UNIT_ON | status1::COMPRESSOR | status1::FAN_MED | status1::WATER_PUMP;
-        } else {
-            s_state.status1 = 0;
-        }
-        xSemaphoreGive(s_state_mutex);
-        ESP_LOGI(TAG, "[DEMO] Unit power set to %s", on ? "ON" : "OFF");
-        return true;
-    }
-    
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, reg::UNIT_ON_OFF, on ? 1 : 0);
+    esp_err_t err = writeSingleReg(reg::UNIT_ON_OFF, on ? 1 : 0);
     if (err == ESP_OK) {
         xSemaphoreTake(s_state_mutex, portMAX_DELAY);
         s_state.unit_on = on;
@@ -466,15 +480,7 @@ bool setUnitPower(bool on) {
 }
 
 bool setWorkingMode(WorkingMode mode) {
-    if (s_demo_mode) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.working_mode = mode;
-        xSemaphoreGive(s_state_mutex);
-        ESP_LOGI(TAG, "[DEMO] Working mode set to %s", workingModeToString(mode));
-        return true;
-    }
-    
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, reg::WORKING_MODE, static_cast<uint16_t>(mode));
+    esp_err_t err = writeSingleReg(reg::WORKING_MODE, static_cast<uint16_t>(mode));
     if (err == ESP_OK) {
         xSemaphoreTake(s_state_mutex, portMAX_DELAY);
         s_state.working_mode = mode;
@@ -487,15 +493,7 @@ bool setWorkingMode(WorkingMode mode) {
 }
 
 bool setCoolingSetpoint(int16_t temp) {
-    if (s_demo_mode) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.cooling_setpoint = temp;
-        xSemaphoreGive(s_state_mutex);
-        ESP_LOGI(TAG, "[DEMO] Cooling setpoint set to %d", temp);
-        return true;
-    }
-    
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, reg::COOLING_SETPOINT, static_cast<uint16_t>(temp));
+    esp_err_t err = writeSingleReg(reg::COOLING_SETPOINT, static_cast<uint16_t>(temp));
     if (err == ESP_OK) {
         xSemaphoreTake(s_state_mutex, portMAX_DELAY);
         s_state.cooling_setpoint = temp;
@@ -508,15 +506,7 @@ bool setCoolingSetpoint(int16_t temp) {
 }
 
 bool setHeatingSetpoint(int16_t temp) {
-    if (s_demo_mode) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.heating_setpoint = temp;
-        xSemaphoreGive(s_state_mutex);
-        ESP_LOGI(TAG, "[DEMO] Heating setpoint set to %d", temp);
-        return true;
-    }
-    
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, reg::HEATING_SETPOINT, static_cast<uint16_t>(temp));
+    esp_err_t err = writeSingleReg(reg::HEATING_SETPOINT, static_cast<uint16_t>(temp));
     if (err == ESP_OK) {
         xSemaphoreTake(s_state_mutex, portMAX_DELAY);
         s_state.heating_setpoint = temp;
@@ -529,15 +519,7 @@ bool setHeatingSetpoint(int16_t temp) {
 }
 
 bool setHotWaterSetpoint(int16_t temp) {
-    if (s_demo_mode) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.hot_water_setpoint = temp;
-        xSemaphoreGive(s_state_mutex);
-        ESP_LOGI(TAG, "[DEMO] Hot water setpoint set to %d", temp);
-        return true;
-    }
-    
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, reg::HOT_WATER_SETPOINT, static_cast<uint16_t>(temp));
+    esp_err_t err = writeSingleReg(reg::HOT_WATER_SETPOINT, static_cast<uint16_t>(temp));
     if (err == ESP_OK) {
         xSemaphoreTake(s_state_mutex, portMAX_DELAY);
         s_state.hot_water_setpoint = temp;
@@ -550,18 +532,13 @@ bool setHotWaterSetpoint(int16_t temp) {
 }
 
 bool writeRegister(uint16_t address, uint16_t value) {
-    if (s_demo_mode) {
-        ESP_LOGI(TAG, "[DEMO] Register %d set to %d (ignored)", address, value);
-        return true;
-    }
-    
     // Validate address is in writable range (2000-2057)
     if (address < 2000 || address > 2057) {
         ESP_LOGE(TAG, "Invalid register address %d (must be 2000-2057)", address);
         return false;
     }
     
-    esp_err_t err = modbus::writeSingleRegister(SLAVE_ADDRESS, address, value);
+    esp_err_t err = writeSingleReg(address, value);
     if (err == ESP_OK) {
         ESP_LOGI(TAG, "Register %d set to %d", address, value);
         return true;
@@ -575,13 +552,7 @@ bool readRegister(uint16_t address, uint16_t* value_out) {
         return false;
     }
     
-    if (s_demo_mode) {
-        *value_out = 0;
-        ESP_LOGD(TAG, "[DEMO] Register %d read = 0", address);
-        return true;
-    }
-    
-    esp_err_t err = modbus::readHoldingRegisters(SLAVE_ADDRESS, address, 1, value_out);
+    esp_err_t err = readRegisters(address, 1, value_out);
     if (err == ESP_OK) {
         ESP_LOGD(TAG, "Register %d = %d", address, *value_out);
         return true;
@@ -678,55 +649,46 @@ void forcePoll() {
 bool setDemoField(const char* field, int32_t value) {
     if (!s_demo_mode) return false;
     
-    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-    bool found = true;
+    // Map field name to register address
+    uint16_t addr = 0;
     
     // Temperatures
-    if (strcmp(field, "water_tank_temp") == 0)       s_state.water_tank_temp = (int16_t)value;
-    else if (strcmp(field, "outlet_water_temp") == 0) s_state.outlet_water_temp = (int16_t)value;
-    else if (strcmp(field, "inlet_water_temp") == 0)  s_state.inlet_water_temp = (int16_t)value;
-    else if (strcmp(field, "discharge_temp") == 0)    s_state.discharge_temp = (int16_t)value;
-    else if (strcmp(field, "suction_temp") == 0)      s_state.suction_temp = (int16_t)value;
-    else if (strcmp(field, "outdoor_coil_temp") == 0) s_state.outdoor_coil_temp = (int16_t)value;
-    else if (strcmp(field, "indoor_coil_temp") == 0)  s_state.indoor_coil_temp = (int16_t)value;
-    else if (strcmp(field, "outdoor_ambient_temp") == 0) s_state.outdoor_ambient_temp = (int16_t)value;
-    else if (strcmp(field, "ipm_temp") == 0)          s_state.ipm_temp = (int16_t)value;
+    if (strcmp(field, "water_tank_temp") == 0)            addr = reg::WATER_TANK_TEMP;
+    else if (strcmp(field, "outlet_water_temp") == 0)     addr = reg::OUTLET_WATER_TEMP;
+    else if (strcmp(field, "inlet_water_temp") == 0)      addr = reg::INLET_WATER_TEMP;
+    else if (strcmp(field, "discharge_temp") == 0)        addr = reg::DISCHARGE_TEMP;
+    else if (strcmp(field, "suction_temp") == 0)          addr = reg::SUCTION_TEMP;
+    else if (strcmp(field, "outdoor_coil_temp") == 0)     addr = reg::OUTDOOR_COIL_TEMP;
+    else if (strcmp(field, "indoor_coil_temp") == 0)      addr = reg::INDOOR_COIL_TEMP;
+    else if (strcmp(field, "outdoor_ambient_temp") == 0)  addr = reg::OUTDOOR_AMBIENT_TEMP;
+    else if (strcmp(field, "ipm_temp") == 0)              addr = reg::IPM_TEMP;
     // System readings
-    else if (strcmp(field, "compressor_freq") == 0)   s_state.compressor_freq = (uint16_t)value;
-    else if (strcmp(field, "fan_speed") == 0)         s_state.fan_speed = (uint16_t)value;
-    else if (strcmp(field, "ac_voltage") == 0)        s_state.ac_voltage = (uint16_t)value;
-    else if (strcmp(field, "ac_current") == 0)        s_state.ac_current = (uint16_t)value;
-    else if (strcmp(field, "dc_voltage") == 0)        s_state.dc_voltage = (uint16_t)value;
-    else if (strcmp(field, "dc_current") == 0)        s_state.dc_current = (uint16_t)value;
-    else if (strcmp(field, "primary_eev_opening") == 0) s_state.primary_eev_opening = (uint16_t)value;
-    else if (strcmp(field, "secondary_eev_opening") == 0) s_state.secondary_eev_opening = (uint16_t)value;
-    else if (strcmp(field, "high_pressure") == 0)     s_state.high_pressure = (uint16_t)value;
-    else if (strcmp(field, "low_pressure") == 0)      s_state.low_pressure = (uint16_t)value;
+    else if (strcmp(field, "compressor_freq") == 0)       addr = reg::COMPRESSOR_FREQ;
+    else if (strcmp(field, "fan_speed") == 0)             addr = reg::FAN_SPEED;
+    else if (strcmp(field, "ac_voltage") == 0)            addr = reg::AC_VOLTAGE;
+    else if (strcmp(field, "ac_current") == 0)            addr = reg::AC_CURRENT;
+    else if (strcmp(field, "dc_voltage") == 0)            addr = reg::DC_VOLTAGE;
+    else if (strcmp(field, "dc_current") == 0)            addr = reg::DC_CURRENT;
+    else if (strcmp(field, "primary_eev_opening") == 0)   addr = reg::PRIMARY_EEV_OPENING;
+    else if (strcmp(field, "secondary_eev_opening") == 0) addr = reg::SECONDARY_EEV_OPENING;
+    else if (strcmp(field, "high_pressure") == 0)         addr = reg::HIGH_PRESSURE;
+    else if (strcmp(field, "low_pressure") == 0)          addr = reg::LOW_PRESSURE;
     // Status/error registers
-    else if (strcmp(field, "status1") == 0)           s_state.status1 = (uint16_t)value;
-    else if (strcmp(field, "status2") == 0)           s_state.status2 = (uint16_t)value;
-    else if (strcmp(field, "error1") == 0)            s_state.error1 = (uint16_t)value;
-    else if (strcmp(field, "error2") == 0)            s_state.error2 = (uint16_t)value;
-    // Settings (writable, but also accessible here)
-    else if (strcmp(field, "unit_on") == 0)           s_state.unit_on = (value != 0);
-    else if (strcmp(field, "working_mode") == 0)      s_state.working_mode = static_cast<WorkingMode>(value);
-    else if (strcmp(field, "cooling_setpoint") == 0)  s_state.cooling_setpoint = (int16_t)value;
-    else if (strcmp(field, "heating_setpoint") == 0)  s_state.heating_setpoint = (int16_t)value;
-    else if (strcmp(field, "hot_water_setpoint") == 0) s_state.hot_water_setpoint = (int16_t)value;
-    else found = false;
+    else if (strcmp(field, "status1") == 0)               addr = reg::STATUS_1;
+    else if (strcmp(field, "status2") == 0)               addr = reg::STATUS_2;
+    else if (strcmp(field, "error1") == 0)                addr = reg::ERROR_1;
+    else if (strcmp(field, "error2") == 0)                addr = reg::ERROR_2;
+    // Settings
+    else if (strcmp(field, "unit_on") == 0)               addr = reg::UNIT_ON_OFF;
+    else if (strcmp(field, "working_mode") == 0)          addr = reg::WORKING_MODE;
+    else if (strcmp(field, "cooling_setpoint") == 0)      addr = reg::COOLING_SETPOINT;
+    else if (strcmp(field, "heating_setpoint") == 0)      addr = reg::HEATING_SETPOINT;
+    else if (strcmp(field, "hot_water_setpoint") == 0)    addr = reg::HOT_WATER_SETPOINT;
+    else return false;
     
-    xSemaphoreGive(s_state_mutex);
-    
-    // If an error register changed, update error history so cleared errors
-    // transition properly (get a cleared timestamp, move to history)
-    if (found && (strcmp(field, "error1") == 0 || strcmp(field, "error2") == 0)) {
-        updateErrorHistory(s_state.error1, s_state.error2);
-    }
-    
-    if (found) {
-        ESP_LOGI(TAG, "[DEMO] Field '%s' set to %ld", field, (long)value);
-    }
-    return found;
+    s_demo_regs[addr - DEMO_REG_BASE] = (uint16_t)value;
+    ESP_LOGI(TAG, "[DEMO] Field '%s' (reg %d) set to %ld", field, addr, (long)value);
+    return true;
 }
 
 }  // namespace arctic

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -2725,7 +2725,6 @@
                             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                                 <h2 x-text="t('events') + (eventLogTotal ? ' (' + eventLogTotal + ')' : '')"></h2>
                                 <div style="display: flex; gap: 0.5rem;">
-                                    <button class="btn btn-secondary" style="padding: 0.3rem 0.8rem; font-size: 0.8rem;" @click="loadEvents()">↻</button>
                                     <button class="btn btn-secondary" style="padding: 0.3rem 0.8rem; font-size: 0.8rem;" x-show="eventLog.length > 0" @click="clearEventLog()" x-text="t('clearEvents')"></button>
                                 </div>
                             </div>
@@ -3315,6 +3314,7 @@
                             await this.loadStatus();
                             await this.loadHeatpump();
                             await this.loadErrors();
+                            if (this.page === 'events') await this.loadEvents();
                             this.lastUpdate = Date.now();
                         }
                         
@@ -3994,7 +3994,43 @@
                     if (evt.type === 'error_appeared' || evt.type === 'error_cleared') {
                         const reg = (p >> 16) & 0xFFFF;
                         const bit = p & 0xFFFF;
-                        return 'Reg ' + reg + ' bit ' + bit;
+                        const errorMap = {
+                            // Error register 1 (2137)
+                            '1_1':    '(E27) Indoor unit EEPROM error',
+                            '1_2':    '(E28) Outdoor unit EEPROM fault',
+                            '1_4':    '(E19) Inlet water temperature sensor fault',
+                            '1_8':    '(E18) Outlet water temperature sensor fault',
+                            '1_16':   '(E13) Cooling coil temperature sensor fault',
+                            '1_32':   '(E05) Heat pump coil temperature sensor fault',
+                            '1_64':   '(E01) Compressor discharge temp sensor fault',
+                            '1_128':  '(E09) Compressor suction temp sensor fault',
+                            '1_256':  '(E22) Outdoor ambient temp sensor fault',
+                            '1_512':  '(E10) Drive/main board communication error',
+                            '1_1024': '(E21) Wired controller communication fault',
+                            '1_2048': '(r02) Compressor start fault',
+                            '1_4096': '(E12) Indoor/outdoor unit communication error',
+                            '1_8192': '(r01) IPM module fault',
+                            '1_16384':'(PA) Tank temperature protection',
+                            '1_32768':'(r10) AC voltage protection',
+                            // Error register 2 (2138)
+                            '2_1':    '(P19) AC current protection',
+                            '2_2':    '(r06) Compressor phase current protection',
+                            '2_4':    '(FA) DC fan motor protection',
+                            '2_8':    '(r11) DC bus voltage protection',
+                            '2_16':   '(r05) IPM module temperature too high',
+                            '2_32':   '(P11) Compressor discharge temp too high',
+                            '2_64':   '(P02) High pressure protection',
+                            '2_128':  '(P06) Low pressure protection',
+                            '2_256':  '(P01) Water flow switch protection',
+                            '2_512':  '(P27) Cooling coil overheating protection',
+                            '2_1024': '(E26) Low ambient temperature protection',
+                            '2_2048': '(EC) EEV circuit low pressure protection',
+                            '2_4096': '(ED) Low pressure sensor protection',
+                            '2_8192': '(P15) Inlet/outlet temp difference too large',
+                            '2_16384':'(P16) Outlet water temperature too low',
+                            '2_32768':'(r20) Compressor protection',
+                        };
+                        return errorMap[reg + '_' + bit] || ('Reg ' + reg + ' bit 0x' + bit.toString(16));
                     }
                     return '';
                 },

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -217,7 +217,34 @@
                 // Dashboard panels
                 energy: 'Energy',
                 powerIn: 'Power In',
-                heatOut: 'Heat Out'
+                heatOut: 'Heat Out',
+
+                // Events
+                events: 'Events',
+                noEvents: 'No events recorded',
+                clearEvents: 'Clear Events',
+                clearEventsConfirm: 'Clear all events?',
+                eventsCleared: 'Events cleared',
+                eventsClearFailed: 'Failed to clear events',
+                evtSystemStart: 'System Start',
+                evtPowerOn: 'Power ON',
+                evtPowerOff: 'Power OFF',
+                evtModeChanged: 'Mode Changed',
+                evtSetpointChanged: 'Setpoint Changed',
+                evtCompressorOn: 'Compressor ON',
+                evtCompressorOff: 'Compressor OFF',
+                evtFanOn: 'Fan ON',
+                evtFanOff: 'Fan OFF',
+                evtPumpOn: 'Water Pump ON',
+                evtPumpOff: 'Water Pump OFF',
+                evtAuxHeaterOn: 'Aux Heater ON',
+                evtAuxHeaterOff: 'Aux Heater OFF',
+                evtDefrostStart: 'Defrost Start',
+                evtDefrostEnd: 'Defrost End',
+                evtErrorAppeared: 'Error Appeared',
+                evtErrorCleared: 'Error Cleared',
+                evtConnected: 'Connected',
+                evtDisconnected: 'Disconnected'
             },
             fr: {
                 // Header & Navigation
@@ -428,7 +455,34 @@
                 // Dashboard panels
                 energy: '\u00c9nergie',
                 powerIn: 'Puiss. entr\u00e9e',
-                heatOut: 'Chaleur sort.'
+                heatOut: 'Chaleur sort.',
+
+                // Events
+                events: '\u00c9v\u00e9nements',
+                noEvents: 'Aucun \u00e9v\u00e9nement',
+                clearEvents: 'Effacer',
+                clearEventsConfirm: 'Effacer tous les \u00e9v\u00e9nements ?',
+                eventsCleared: '\u00c9v\u00e9nements effac\u00e9s',
+                eventsClearFailed: '\u00c9chec de la suppression',
+                evtSystemStart: 'D\u00e9marrage syst\u00e8me',
+                evtPowerOn: 'Mise en marche',
+                evtPowerOff: 'Arr\u00eat',
+                evtModeChanged: 'Mode chang\u00e9',
+                evtSetpointChanged: 'Consigne modifi\u00e9e',
+                evtCompressorOn: 'Compresseur ON',
+                evtCompressorOff: 'Compresseur OFF',
+                evtFanOn: 'Ventilateur ON',
+                evtFanOff: 'Ventilateur OFF',
+                evtPumpOn: 'Pompe \u00e0 eau ON',
+                evtPumpOff: 'Pompe \u00e0 eau OFF',
+                evtAuxHeaterOn: 'Chauff. aux ON',
+                evtAuxHeaterOff: 'Chauff. aux OFF',
+                evtDefrostStart: 'D\u00e9but d\u00e9givrage',
+                evtDefrostEnd: 'Fin d\u00e9givrage',
+                evtErrorAppeared: 'Erreur apparue',
+                evtErrorCleared: 'Erreur effac\u00e9e',
+                evtConnected: 'Connect\u00e9',
+                evtDisconnected: 'D\u00e9connect\u00e9'
             },
             es: {
                 // Header & Navigation
@@ -639,7 +693,34 @@
                 // Dashboard panels
                 energy: 'Energ\u00eda',
                 powerIn: 'Pot. entrada',
-                heatOut: 'Calor salida'
+                heatOut: 'Calor salida',
+
+                // Events
+                events: 'Eventos',
+                noEvents: 'Sin eventos registrados',
+                clearEvents: 'Borrar',
+                clearEventsConfirm: '\u00bfBorrar todos los eventos?',
+                eventsCleared: 'Eventos borrados',
+                eventsClearFailed: 'Error al borrar eventos',
+                evtSystemStart: 'Inicio del sistema',
+                evtPowerOn: 'Encendido',
+                evtPowerOff: 'Apagado',
+                evtModeChanged: 'Modo cambiado',
+                evtSetpointChanged: 'Consigna cambiada',
+                evtCompressorOn: 'Compresor ON',
+                evtCompressorOff: 'Compresor OFF',
+                evtFanOn: 'Ventilador ON',
+                evtFanOff: 'Ventilador OFF',
+                evtPumpOn: 'Bomba de agua ON',
+                evtPumpOff: 'Bomba de agua OFF',
+                evtAuxHeaterOn: 'Calef. aux ON',
+                evtAuxHeaterOff: 'Calef. aux OFF',
+                evtDefrostStart: 'Inicio descong.',
+                evtDefrostEnd: 'Fin descong.',
+                evtErrorAppeared: 'Error detectado',
+                evtErrorCleared: 'Error eliminado',
+                evtConnected: 'Conectado',
+                evtDisconnected: 'Desconectado'
             }
         };
     </script>
@@ -726,11 +807,12 @@
             background: none;
             border: none;
             color: var(--text-secondary);
-            padding: 1rem 1.25rem;
+            padding: 1rem 1rem;
             cursor: pointer;
             font-size: 0.9rem;
             border-bottom: 2px solid transparent;
             transition: all 0.2s;
+            white-space: nowrap;
         }
         
         nav button:hover {
@@ -1819,6 +1901,45 @@
             margin-top: 0.25rem;
         }
         
+        /* Event Log */
+        .event-list {
+            max-height: 70vh;
+            overflow-y: auto;
+        }
+        .event-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.75rem;
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid var(--border);
+        }
+        .event-item:last-child {
+            border-bottom: none;
+        }
+        .event-icon {
+            font-size: 1.2rem;
+            flex-shrink: 0;
+            margin-top: 0.1rem;
+        }
+        .event-info {
+            flex: 1;
+            min-width: 0;
+        }
+        .event-name {
+            font-size: 0.9rem;
+            font-weight: 500;
+        }
+        .event-detail {
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            margin-top: 0.15rem;
+        }
+        .event-time {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            margin-top: 0.2rem;
+        }
+        
         /* Parameter Card */
         .param-category {
             margin-bottom: 1.5rem;
@@ -2201,6 +2322,7 @@
                 <nav>
                     <button :class="{ active: page === 'dashboard' }" @click="page = 'dashboard'" x-text="t('dashboard')"></button>
                     <button :class="{ active: page === 'parameters' }" @click="page = 'parameters'; loadParams()" x-text="t('parameters')"></button>
+                    <button :class="{ active: page === 'events' }" @click="page = 'events'; loadEvents()" x-text="t('events')"></button>
                     <button :class="{ active: page === 'settings' }" @click="page = 'settings'" x-text="t('settings')"></button>
                 </nav>
                 
@@ -2597,6 +2719,41 @@
                         </div>
                     </div>
                     
+                    <!-- Events Page -->
+                    <div x-show="page === 'events'">
+                        <div class="card">
+                            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
+                                <h2 x-text="t('events') + (eventLogTotal ? ' (' + eventLogTotal + ')' : '')"></h2>
+                                <div style="display: flex; gap: 0.5rem;">
+                                    <button class="btn btn-secondary" style="padding: 0.3rem 0.8rem; font-size: 0.8rem;" @click="loadEvents()">↻</button>
+                                    <button class="btn btn-secondary" style="padding: 0.3rem 0.8rem; font-size: 0.8rem;" x-show="eventLog.length > 0" @click="clearEventLog()" x-text="t('clearEvents')"></button>
+                                </div>
+                            </div>
+                            <div class="card-body" style="padding: 0;">
+                                <template x-if="eventLogLoading">
+                                    <div style="padding: 1.5rem; text-align: center; color: var(--text-secondary);" x-text="t('loadingParams')"></div>
+                                </template>
+                                <template x-if="!eventLogLoading && eventLog.length === 0">
+                                    <div style="padding: 1.5rem; text-align: center; color: var(--text-secondary);" x-text="t('noEvents')"></div>
+                                </template>
+                                <template x-if="!eventLogLoading && eventLog.length > 0">
+                                    <div class="event-list">
+                                        <template x-for="(evt, idx) in eventLog" :key="idx">
+                                            <div class="event-item">
+                                                <div class="event-icon" x-text="eventIcon(evt.type)"></div>
+                                                <div class="event-info">
+                                                    <div class="event-name" :style="'color:' + eventColor(evt.type)" x-text="eventTypeName(evt.type)"></div>
+                                                    <div class="event-detail" x-show="eventDetail(evt)" x-text="eventDetail(evt)"></div>
+                                                    <div class="event-time" x-text="evt.timestamp ? formatTimestamp(evt.timestamp) : formatUptime(evt.uptime_ms)"></div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                    
                     <!-- Settings Page -->
                     <div x-show="page === 'settings'">
                             <!-- Device Info -->
@@ -2979,6 +3136,11 @@
                 
                 // Error state
                 errors: { active: [], history: [] },
+                
+                // Event log state
+                eventLog: [],
+                eventLogTotal: 0,
+                eventLogLoading: false,
                 
                 // Parameters state
                 params: {},
@@ -3732,6 +3894,109 @@
                         this.showToast(this.t('paramFailed'), 'error');
                     }
                     this.controlLoading = false;
+                },
+                
+                // ==========================================
+                // Event Log
+                // ==========================================
+                
+                async loadEvents() {
+                    this.eventLogLoading = true;
+                    try {
+                        const res = await this.apiFetch('/api/events');
+                        const data = await res.json();
+                        this.eventLog = data.events || [];
+                        this.eventLogTotal = data.total || 0;
+                    } catch (e) {
+                        console.error('Failed to load events:', e);
+                    }
+                    this.eventLogLoading = false;
+                },
+                
+                async clearEventLog() {
+                    if (!confirm(this.t('clearEventsConfirm'))) return;
+                    try {
+                        await this.apiFetch('/api/events', { method: 'DELETE' });
+                        this.eventLog = [];
+                        this.eventLogTotal = 0;
+                        this.showToast(this.t('eventsCleared'), 'success');
+                    } catch (e) {
+                        console.error(e);
+                        this.showToast(this.t('eventsClearFailed'), 'error');
+                    }
+                },
+                
+                eventTypeName(type) {
+                    const map = {
+                        'system_start': 'evtSystemStart',
+                        'power_on': 'evtPowerOn',
+                        'power_off': 'evtPowerOff',
+                        'mode_changed': 'evtModeChanged',
+                        'setpoint_changed': 'evtSetpointChanged',
+                        'compressor_on': 'evtCompressorOn',
+                        'compressor_off': 'evtCompressorOff',
+                        'fan_on': 'evtFanOn',
+                        'fan_off': 'evtFanOff',
+                        'pump_on': 'evtPumpOn',
+                        'pump_off': 'evtPumpOff',
+                        'aux_heater_on': 'evtAuxHeaterOn',
+                        'aux_heater_off': 'evtAuxHeaterOff',
+                        'defrost_start': 'evtDefrostStart',
+                        'defrost_end': 'evtDefrostEnd',
+                        'error_appeared': 'evtErrorAppeared',
+                        'error_cleared': 'evtErrorCleared',
+                        'connected': 'evtConnected',
+                        'disconnected': 'evtDisconnected'
+                    };
+                    return this.t(map[type] || type);
+                },
+                
+                eventIcon(type) {
+                    const icons = {
+                        'system_start': '\u26a1',
+                        'power_on': '\ud83d\udfe2', 'power_off': '\ud83d\udd34',
+                        'mode_changed': '\ud83d\udd04',
+                        'setpoint_changed': '\ud83c\udf21\ufe0f',
+                        'compressor_on': '\u2699\ufe0f', 'compressor_off': '\u2699\ufe0f',
+                        'fan_on': '\ud83c\udf2c\ufe0f', 'fan_off': '\ud83c\udf2c\ufe0f',
+                        'pump_on': '\ud83d\udca7', 'pump_off': '\ud83d\udca7',
+                        'aux_heater_on': '\ud83d\udd25', 'aux_heater_off': '\ud83d\udd25',
+                        'defrost_start': '\u2744\ufe0f', 'defrost_end': '\u2744\ufe0f',
+                        'error_appeared': '\u26a0\ufe0f', 'error_cleared': '\u2705',
+                        'connected': '\ud83d\udce1', 'disconnected': '\ud83d\udce1'
+                    };
+                    return icons[type] || '\u2139\ufe0f';
+                },
+                
+                eventColor(type) {
+                    if (type.includes('_on') || type === 'power_on' || type === 'connected' || type === 'defrost_end' || type === 'error_cleared') return 'var(--success)';
+                    if (type.includes('_off') || type === 'power_off' || type === 'disconnected' || type === 'defrost_start') return 'var(--text-secondary)';
+                    if (type.includes('error_appeared')) return 'var(--error)';
+                    if (type === 'mode_changed' || type === 'setpoint_changed') return 'var(--accent)';
+                    return 'var(--text-primary)';
+                },
+                
+                eventDetail(evt) {
+                    const p = evt.payload;
+                    if (evt.type === 'mode_changed') {
+                        const modes = ['Cooling', 'Floor Heating', 'Fan Heating', '', '', 'Hot Water', 'Auto'];
+                        const oldM = (p >> 8) & 0xFF;
+                        const newM = p & 0xFF;
+                        return (modes[oldM] || '?') + ' \u2192 ' + (modes[newM] || '?');
+                    }
+                    if (evt.type === 'setpoint_changed') {
+                        const types = ['Cooling', 'Heating', 'Hot Water'];
+                        const spType = (p >> 16) & 0xFF;
+                        const oldV = (p >> 8) & 0xFF;
+                        const newV = p & 0xFF;
+                        return (types[spType] || '?') + ': ' + oldV + '\u00b0 \u2192 ' + newV + '\u00b0';
+                    }
+                    if (evt.type === 'error_appeared' || evt.type === 'error_cleared') {
+                        const reg = (p >> 16) & 0xFFFF;
+                        const bit = p & 0xFFFF;
+                        return 'Reg ' + reg + ' bit ' + bit;
+                    }
+                    return '';
                 },
                 
                 capitalize(str) {

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,11 @@
 - [ ] Add COP/energy fields to REST API and demo mode injection
 - [ ] Add flow rate configuration to the Advanced/Params screen
 
+## Event Log Enhancements
+
+- [ ] Consider logging compressor frequency changes (e.g. significant jumps or thresholds)
+- [ ] Consider logging fan speed changes (RPM thresholds or level transitions)
+
 ## Main Screen Layout Redesign
 
 - [x] Hero state card with color-coded background (heating/cooling/defrost/fault/idle)


### PR DESCRIPTION
## Event Log System

Adds a complete operational event logging system that tracks heat pump state changes in a RAM ring buffer and surfaces them on both the device screen and web dashboard.

### Event Log Core
- **128-entry ring buffer** with mutex-protected access, storing event type, payload, wall-clock timestamp, and uptime
- **19 event types**: power on/off, mode changed, setpoint changed, compressor/fan/pump/aux heater on/off, defrost start/end, error appeared/cleared, connected/disconnected, system start
- **Automatic detection** in the poll loop — compares current vs previous state each cycle and records changes
- **Error event payloads** encode register number and bit mask: `(reg_num << 16) | bit_mask`
- REST API: `GET /api/events` returns JSON array (newest first), `DELETE /api/events` clears the log

### Device Event Log Screen
- Full-screen scrollable list accessible from the Events footer button
- Each card shows an **LVGL symbol icon** (power, gear, tint, warning, wifi, etc.) + translated event name + timestamp
- Error events display human-readable descriptions from `ErrorDef` lookup (e.g. `(P02) High pressure protection activated`)
- Cards use flex column layout with `montserrat_32` / `montserrat_24` fonts, matching the error screen style
- Inline **"Clear History"** button (right-aligned, warning-bordered) matching the alerts screen pattern
- Auto-refreshes every 2 seconds via LVGL timer
- Full i18n support — all 19 event names translated to EN/FR/ES

### Web Dashboard Events Page
- Events tab with color-coded cards and emoji icons per event type
- Error events resolved to human-readable names via a 32-entry JS lookup map
- **Auto-refreshes** via the existing 5-second polling loop (no manual refresh button needed)

### Demo Mode Refactor
- Replaced scattered `if (s_demo_mode)` branches with a **fake register array** (`s_demo_regs[139]`, addresses 2000–2138)
- Only two demo-mode checkpoints: `readRegisters()` and `writeSingleReg()`
- All 4 poll functions and 5 setter functions go through these helpers
- `startPolling()` now runs in demo mode (skips Modbus init check), so event detection works in demo
- `setDemoField()` maps field names → register addresses for API-driven injection
- `initDemoState()` populates registers with realistic values then syncs via poll functions

### Files Changed
| File | Change |
|------|--------|
| `event_log.h` / `.cpp` | New — ring buffer, event types, API |
| `event_log_screen.h` / `.cpp` | New — device UI screen |
| `arctic_heatpump.cpp` | Demo register refactor + event detection in poll loop |
| `api_server.cpp` | `GET/DELETE /api/events` endpoints |
| `heatpump_screen.cpp` | Events footer button + navigation |
| `index.html` | Events page, auto-refresh, error name lookup |
| `i18n.cpp` / `strings.h` | 22 new string IDs with EN/FR/ES translations |
| `main.cpp` | Start polling after demo init |
| `CMakeLists.txt` | Added new source files |
| `todo.md` | Future: consider logging freq/RPM changes |