### PR TITLE
Feat/log api

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,9 @@
 - After completing file operations, confirm briefly rather than restating what was done.
 - When committing, write clear conventional-commit messages (e.g. `feat:`, `fix:`,
   `docs:`, `ci:`, `refactor:`, `test:`).
+- **Always work on a feature branch** — never commit directly to `main`. Create a
+  branch (e.g. `feat/log-api`, `fix/modbus-timeout`) before making changes. The user
+  will merge via PR.
 
 ## Project Overview
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@
 - **Always work on a feature branch** — never commit directly to `main`. Create a
   branch (e.g. `feat/log-api`, `fix/modbus-timeout`) before making changes. The user
   will merge via PR.
+- When asked for a PR description, always output it in **Markdown** format.
 
 ## Project Overview
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,11 @@ REST API + WebSocket dashboard for monitoring and control.
 - LVGL widgets use `lv_obj_set_user_data()` with string tags for test addressability
 - All user-facing strings go through the i18n translation layer (`i18n.h`)
 - Three languages: English, French, Spanish — update all three when adding strings
+
+### Web Dashboard (`main/web/index.html`)
+- After editing `index.html`, run `idf.py reconfigure` before `idf.py build`.
+  The gzip compression step only runs during CMake configure, not on every ninja
+  build. Without reconfigure, the firmware will embed a stale `index.html.gz`.
 - Test-only code is guarded by `#ifdef CONFIG_TEST_ENDPOINTS`
 - When adding HTTP endpoints: bump `max_uri_handlers` in `api_server.cpp` if needed
   (currently 80 = ~40 production + ~32 test + headroom)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -124,7 +124,7 @@ jobs:
             ```bash
             curl -X POST http://arctic.local/api/ota/update \
               -H "Content-Type: application/json" \
-              -d '{"url":"http://your-server/arctic_controller.bin"}'
+              -d '{"url":"https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/arctic_controller.bin"}'
             ```
           files: |
             build/arctic_controller.bin

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -30,7 +30,7 @@ permissions:
   checks: write
 
 jobs:
-  build-test-firmware:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -64,8 +64,8 @@ jobs:
             build/flasher_args.json
           retention-days: 7
 
-  run-device-tests:
-    needs: build-test-firmware
+  device-tests:
+    needs: build
     runs-on: [self-hosted, tab5]
     timeout-minutes: 30
     env:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -63,6 +63,8 @@ tags:
     description: Heat pump status and control
   - name: Events
     description: Operational event log
+  - name: Logs
+    description: System debug log buffer
 
 paths:
   /login:
@@ -1574,6 +1576,102 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/logs:
+    get:
+      tags:
+        - Logs
+      summary: Get system log entries
+      description: |
+        Returns ESP_LOG output captured in a RAM ring buffer (max 256 entries).
+        Supports incremental fetching via the `since` parameter and filtering by log level.
+        Entries are returned in chronological order (oldest first).
+      operationId: getLogs
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      parameters:
+        - name: since
+          in: query
+          description: Only return entries with sequence number greater than this value (for incremental polling)
+          required: false
+          schema:
+            type: integer
+            example: 0
+        - name: level
+          in: query
+          description: |
+            Minimum log level filter:
+            - `E` — errors only
+            - `W` — warnings and errors
+            - `I` — info, warnings, and errors
+            - `D` — debug and above
+            - `V` — all (verbose), this is the default
+          required: false
+          schema:
+            type: string
+            enum: [E, W, I, D, V]
+            default: V
+        - name: limit
+          in: query
+          description: Maximum number of entries to return
+          required: false
+          schema:
+            type: integer
+            default: 256
+      responses:
+        '200':
+          description: Log entries retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total number of entries currently in the buffer
+                    example: 42
+                  latest_seq:
+                    type: integer
+                    description: Sequence number of the most recent entry (use as `since` for next poll)
+                    example: 128
+                  entries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LogEntry'
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      tags:
+        - Logs
+      summary: Clear log buffer
+      description: Deletes all entries from the log buffer. Sequence numbers continue to increment.
+      operationId: clearLogs
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      responses:
+        '200':
+          description: Log buffer cleared
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   securitySchemes:
     apiKey:
@@ -1594,6 +1692,32 @@ components:
         error:
           type: string
           description: Error message
+
+    LogEntry:
+      type: object
+      description: A single captured ESP_LOG entry
+      properties:
+        seq:
+          type: integer
+          description: Monotonically increasing sequence number (unique across clears)
+          example: 42
+        uptime_ms:
+          type: integer
+          description: Device uptime in milliseconds when logged
+          example: 12345
+        level:
+          type: string
+          description: Log level character
+          enum: [E, W, I, D, V]
+          example: I
+        tag:
+          type: string
+          description: ESP_LOG component tag
+          example: api_server
+        message:
+          type: string
+          description: Log message text (without level/tag prefix)
+          example: HTTP server started successfully
 
     EventEntry:
       type: object

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -44,6 +44,7 @@ idf_component_register(
         "heatpump_errors.cpp"
         "event_log.cpp"
         "event_log_screen.cpp"
+        "log_buffer.cpp"
         "settings/settings_menu.cpp"
         "settings/settings_wifi_screen.cpp"
         "settings/keyboard_maps.c"

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -15,6 +15,7 @@
 #include "heatpump_params.h"
 #include "heatpump_errors.h"
 #include "event_log.h"
+#include "log_buffer.h"
 #include "app_preferences.h"
 #include "test_endpoints.h"
 #include <esp_http_server.h>
@@ -86,6 +87,8 @@ static esp_err_t events_get_handler(httpd_req_t* req);
 static esp_err_t events_clear_handler(httpd_req_t* req);
 static esp_err_t display_brightness_get_handler(httpd_req_t* req);
 static esp_err_t preferences_get_handler(httpd_req_t* req);
+static esp_err_t logs_get_handler(httpd_req_t* req);
+static esp_err_t logs_clear_handler(httpd_req_t* req);
 
 // ============================================================================
 // Authentication Helpers
@@ -265,7 +268,7 @@ bool api_server_start(void)
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
     config.uri_match_fn = httpd_uri_match_wildcard;
-    config.max_uri_handlers = 80;  // 40 api_server + 32 test_endpoints = 72 needed
+    config.max_uri_handlers = 82;  // 42 api_server + 32 test_endpoints = 74 needed
     config.stack_size = 16384;     // Larger stack for tree walker + file upload
     config.max_resp_headers = 16;  // More response headers
     config.recv_wait_timeout = 10; // 10 second receive timeout
@@ -652,6 +655,24 @@ bool api_server_start(void)
         .user_ctx = NULL
     };
     REGISTER_URI(preferences_uri);
+
+    // GET /api/logs - Get log buffer entries
+    httpd_uri_t logs_get_uri = {
+        .uri = "/api/logs",
+        .method = HTTP_GET,
+        .handler = logs_get_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(logs_get_uri);
+
+    // DELETE /api/logs - Clear log buffer
+    httpd_uri_t logs_clear_uri = {
+        .uri = "/api/logs",
+        .method = HTTP_DELETE,
+        .handler = logs_clear_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(logs_clear_uri);
 
 #ifdef CONFIG_TEST_ENDPOINTS
     test_endpoints_register(server);
@@ -2509,5 +2530,91 @@ static esp_err_t preferences_get_handler(httpd_req_t* req)
     httpd_resp_sendstr(req, json);
     free(json);
     cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// ============================================================================
+// Logs API
+// ============================================================================
+
+static esp_err_t logs_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    set_json_content_type(req);
+
+    // Parse query parameters: ?since=<seq>&level=<E|W|I|D|V>&limit=<n>
+    uint32_t since_seq = 0;
+    esp_log_level_t min_level = ESP_LOG_VERBOSE;  // Default: all levels
+    int limit = LOG_BUFFER_MAX_ENTRIES;
+
+    char query[128] = {0};
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+        char param[32];
+
+        if (httpd_query_key_value(query, "since", param, sizeof(param)) == ESP_OK) {
+            since_seq = (uint32_t)atoi(param);
+        }
+        if (httpd_query_key_value(query, "limit", param, sizeof(param)) == ESP_OK) {
+            int l = atoi(param);
+            if (l > 0 && l < limit) limit = l;
+        }
+        if (httpd_query_key_value(query, "level", param, sizeof(param)) == ESP_OK) {
+            switch (param[0]) {
+                case 'E': case 'e': min_level = ESP_LOG_ERROR;   break;
+                case 'W': case 'w': min_level = ESP_LOG_WARN;    break;
+                case 'I': case 'i': min_level = ESP_LOG_INFO;    break;
+                case 'D': case 'd': min_level = ESP_LOG_DEBUG;   break;
+                case 'V': case 'v': min_level = ESP_LOG_VERBOSE; break;
+            }
+        }
+    }
+
+    // Allocate entries on heap (each entry is ~220 bytes, 256 entries = ~56 KB)
+    log_entry_t* entries = (log_entry_t*)malloc(limit * sizeof(log_entry_t));
+    if (!entries) {
+        send_json_error(req, "500 Internal Server Error", "Out of memory");
+        return ESP_OK;
+    }
+
+    int count = log_buffer_get(entries, limit, since_seq, min_level);
+
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "total", log_buffer_count());
+    cJSON_AddNumberToObject(root, "latest_seq", log_buffer_get_latest_seq());
+    cJSON* arr = cJSON_AddArrayToObject(root, "entries");
+
+    for (int i = 0; i < count; i++) {
+        cJSON* entry = cJSON_CreateObject();
+        cJSON_AddNumberToObject(entry, "seq", entries[i].seq);
+        cJSON_AddNumberToObject(entry, "uptime_ms", entries[i].uptime_ms);
+        cJSON_AddStringToObject(entry, "level", log_level_char(entries[i].level));
+        cJSON_AddStringToObject(entry, "tag", entries[i].tag);
+        cJSON_AddStringToObject(entry, "message", entries[i].message);
+        cJSON_AddItemToArray(arr, entry);
+    }
+
+    free(entries);
+
+    char* json_str = cJSON_PrintUnformatted(root);
+    httpd_resp_sendstr(req, json_str);
+    free(json_str);
+    cJSON_Delete(root);
+
+    return ESP_OK;
+}
+
+static esp_err_t logs_clear_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+    set_json_content_type(req);
+
+    log_buffer_clear();
+    httpd_resp_sendstr(req, "{\"success\":true}");
     return ESP_OK;
 }

--- a/main/log_buffer.cpp
+++ b/main/log_buffer.cpp
@@ -1,0 +1,247 @@
+/*
+ * Arctic Heat Pump Controller
+ * Log Buffer Implementation - RAM ring buffer capturing ESP_LOG output
+ *
+ * Uses esp_log_set_vprintf() to intercept log output. The hook parses the
+ * ESP-IDF log format "X (tag) message\n" to extract level, tag, and message,
+ * then stores them as structured entries. Original serial output is preserved
+ * by calling the default vprintf after capture.
+ */
+
+#include "log_buffer.h"
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+// ============================================================================
+// Ring Buffer State
+// ============================================================================
+
+static log_entry_t s_buffer[LOG_BUFFER_MAX_ENTRIES];
+static int s_head = 0;           // Next write position
+static int s_count = 0;          // Number of valid entries
+static uint32_t s_next_seq = 1;  // Next sequence number to assign
+static SemaphoreHandle_t s_mutex = NULL;
+static vprintf_like_t s_original_vprintf = NULL;  // Original log output function
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+static uint32_t get_uptime_ms(void)
+{
+    return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+
+/**
+ * Parse the ESP-IDF log format: "X (%u) %s: message\n"
+ * where X is the level char (E/W/I/D/V), (%u) is the timestamp, %s is the tag.
+ *
+ * The formatted string from esp_log has the format:
+ *   "\033[0;31mE (%u) %s: message\033[0m\n"  (with color codes)
+ * or:
+ *   "E (%u) %s: message\n"  (without color codes)
+ *
+ * We parse the level from the first letter after any ANSI escape, then extract
+ * the tag between ") " and ": ", and the message after ": ".
+ */
+static void parse_and_store(const char* formatted, int len)
+{
+    if (len <= 0 || !formatted) return;
+
+    // Skip ANSI escape sequence if present: \033[...m
+    const char* p = formatted;
+    const char* end = formatted + len;
+    if (*p == '\033') {
+        while (p < end && *p != 'm') p++;
+        if (p < end) p++;  // skip 'm'
+    }
+
+    // Parse level character
+    esp_log_level_t level;
+    if (p >= end) return;
+    switch (*p) {
+        case 'E': level = ESP_LOG_ERROR;   break;
+        case 'W': level = ESP_LOG_WARN;    break;
+        case 'I': level = ESP_LOG_INFO;    break;
+        case 'D': level = ESP_LOG_DEBUG;   break;
+        case 'V': level = ESP_LOG_VERBOSE; break;
+        default:  return;  // Not a standard log line, skip
+    }
+
+    // Find tag: skip past ") " to get tag start
+    const char* tag_start = NULL;
+    const char* paren_close = (const char*)memchr(p, ')', end - p);
+    if (paren_close && paren_close + 2 < end && paren_close[1] == ' ') {
+        tag_start = paren_close + 2;
+    }
+    if (!tag_start) return;
+
+    // Find tag end: look for ": " separator
+    const char* colon = strstr(tag_start, ": ");
+    if (!colon || colon >= end) return;
+
+    // Find message: everything after ": " until end (strip trailing ANSI + newline)
+    const char* msg_start = colon + 2;
+    const char* msg_end = end;
+
+    // Strip trailing newline(s)
+    while (msg_end > msg_start && (msg_end[-1] == '\n' || msg_end[-1] == '\r')) {
+        msg_end--;
+    }
+    // Strip trailing ANSI reset: \033[0m
+    if (msg_end - msg_start >= 4 && msg_end[-1] == 'm' && msg_end[-4] == '\033') {
+        msg_end -= 4;
+    }
+
+    // Store entry
+    if (s_mutex) {
+        xSemaphoreTake(s_mutex, portMAX_DELAY);
+    }
+
+    log_entry_t* entry = &s_buffer[s_head];
+    entry->seq = s_next_seq++;
+    entry->uptime_ms = get_uptime_ms();
+    entry->level = level;
+
+    // Copy tag (truncate if needed)
+    int tag_len = colon - tag_start;
+    if (tag_len >= LOG_BUFFER_TAG_SIZE) tag_len = LOG_BUFFER_TAG_SIZE - 1;
+    memcpy(entry->tag, tag_start, tag_len);
+    entry->tag[tag_len] = '\0';
+
+    // Copy message (truncate if needed)
+    int msg_len = msg_end - msg_start;
+    if (msg_len >= LOG_BUFFER_MSG_SIZE) msg_len = LOG_BUFFER_MSG_SIZE - 1;
+    if (msg_len > 0) {
+        memcpy(entry->message, msg_start, msg_len);
+    }
+    entry->message[msg_len > 0 ? msg_len : 0] = '\0';
+
+    s_head = (s_head + 1) % LOG_BUFFER_MAX_ENTRIES;
+    if (s_count < LOG_BUFFER_MAX_ENTRIES) s_count++;
+
+    if (s_mutex) {
+        xSemaphoreGive(s_mutex);
+    }
+}
+
+// ============================================================================
+// vprintf Hook
+// ============================================================================
+
+static int log_buffer_vprintf(const char* fmt, va_list args)
+{
+    // Format the string into a temporary buffer for parsing
+    char buf[LOG_BUFFER_MSG_SIZE + LOG_BUFFER_TAG_SIZE + 64];
+    int len = vsnprintf(buf, sizeof(buf), fmt, args);
+    if (len > 0) {
+        int actual_len = len < (int)sizeof(buf) ? len : (int)sizeof(buf) - 1;
+        parse_and_store(buf, actual_len);
+    }
+
+    // Always forward to original output (serial console)
+    // We need to re-format since we consumed the va_list
+    // Instead, we just write our already-formatted buffer to stdout
+    if (len > 0) {
+        fwrite(buf, 1, len < (int)sizeof(buf) ? len : (int)sizeof(buf) - 1, stdout);
+        // If the original message was longer than our buffer, it's truncated on serial too
+        // This is acceptable — the buffer is 280 chars which covers virtually all log lines
+    }
+
+    return len;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void log_buffer_init(void)
+{
+    s_mutex = xSemaphoreCreateMutex();
+    s_head = 0;
+    s_count = 0;
+    s_next_seq = 1;
+    memset(s_buffer, 0, sizeof(s_buffer));
+
+    // Install our hook, saving the original handler
+    s_original_vprintf = esp_log_set_vprintf(log_buffer_vprintf);
+}
+
+int log_buffer_get(log_entry_t* out, int max_count, uint32_t since_seq,
+                   esp_log_level_t min_level)
+{
+    if (!s_mutex || !out || max_count <= 0) return 0;
+
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+
+    // Calculate start index (oldest entry)
+    int start;
+    if (s_count < LOG_BUFFER_MAX_ENTRIES) {
+        start = 0;
+    } else {
+        start = s_head;  // head points to next write = oldest when full
+    }
+
+    int written = 0;
+    for (int i = 0; i < s_count && written < max_count; i++) {
+        int idx = (start + i) % LOG_BUFFER_MAX_ENTRIES;
+        log_entry_t* e = &s_buffer[idx];
+
+        // Filter by sequence number
+        if (since_seq > 0 && e->seq <= since_seq) continue;
+
+        // Filter by level (lower number = more severe)
+        if (min_level > 0 && e->level > min_level) continue;
+
+        memcpy(&out[written], e, sizeof(log_entry_t));
+        written++;
+    }
+
+    xSemaphoreGive(s_mutex);
+    return written;
+}
+
+int log_buffer_count(void)
+{
+    if (!s_mutex) return 0;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    int count = s_count;
+    xSemaphoreGive(s_mutex);
+    return count;
+}
+
+uint32_t log_buffer_get_latest_seq(void)
+{
+    if (!s_mutex) return 0;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    uint32_t seq = s_next_seq > 1 ? s_next_seq - 1 : 0;
+    xSemaphoreGive(s_mutex);
+    return seq;
+}
+
+void log_buffer_clear(void)
+{
+    if (!s_mutex) return;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    s_head = 0;
+    s_count = 0;
+    memset(s_buffer, 0, sizeof(s_buffer));
+    // Don't reset s_next_seq — clients tracking by seq need monotonic growth
+    xSemaphoreGive(s_mutex);
+}
+
+const char* log_level_char(esp_log_level_t level)
+{
+    switch (level) {
+        case ESP_LOG_ERROR:   return "E";
+        case ESP_LOG_WARN:    return "W";
+        case ESP_LOG_INFO:    return "I";
+        case ESP_LOG_DEBUG:   return "D";
+        case ESP_LOG_VERBOSE: return "V";
+        default:              return "?";
+    }
+}

--- a/main/log_buffer.h
+++ b/main/log_buffer.h
@@ -1,0 +1,95 @@
+/*
+ * Arctic Heat Pump Controller
+ * Log Buffer - Captures ESP_LOG output into a RAM ring buffer
+ *
+ * Hooks into esp_log_set_vprintf() to intercept all ESP_LOG* output,
+ * storing structured entries for retrieval via the REST API.
+ * Serial output continues unaffected.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <esp_log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+#define LOG_BUFFER_MAX_ENTRIES   256     // Max entries in ring buffer
+#define LOG_BUFFER_MSG_SIZE     192     // Max message length per entry (truncated if longer)
+#define LOG_BUFFER_TAG_SIZE     24      // Max tag length
+
+// ============================================================================
+// Log Entry
+// ============================================================================
+
+typedef struct {
+    uint32_t seq;                           // Monotonically increasing sequence number
+    uint32_t uptime_ms;                     // Uptime in milliseconds when logged
+    esp_log_level_t level;                  // Log level (E/W/I/D/V)
+    char tag[LOG_BUFFER_TAG_SIZE];          // Component tag
+    char message[LOG_BUFFER_MSG_SIZE];      // Log message (without level/tag prefix)
+} log_entry_t;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * @brief Initialize the log buffer and install the vprintf hook
+ *
+ * Should be called as early as possible in app_main() to capture boot logs.
+ * Safe to call before most other subsystems are initialized.
+ */
+void log_buffer_init(void);
+
+/**
+ * @brief Get log entries from the buffer
+ *
+ * Returns entries in chronological order (oldest first).
+ *
+ * @param out        Output array to fill
+ * @param max_count  Maximum entries to return
+ * @param since_seq  Only return entries with seq > since_seq (0 = all)
+ * @param min_level  Minimum log level (ESP_LOG_ERROR=1 most restrictive,
+ *                   ESP_LOG_VERBOSE=5 least restrictive). Pass 0 or
+ *                   ESP_LOG_VERBOSE to get all.
+ * @return Number of entries written to out
+ */
+int log_buffer_get(log_entry_t* out, int max_count, uint32_t since_seq,
+                   esp_log_level_t min_level);
+
+/**
+ * @brief Get the number of entries currently in the buffer
+ */
+int log_buffer_count(void);
+
+/**
+ * @brief Get the sequence number of the latest entry
+ *
+ * Useful for clients to track their position for incremental fetching.
+ * Returns 0 if no entries have been recorded.
+ */
+uint32_t log_buffer_get_latest_seq(void);
+
+/**
+ * @brief Clear all entries from the buffer
+ */
+void log_buffer_clear(void);
+
+/**
+ * @brief Get single-character representation of a log level
+ *
+ * @param level  ESP log level
+ * @return "E", "W", "I", "D", "V", or "?"
+ */
+const char* log_level_char(esp_log_level_t level);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -26,6 +26,7 @@
 #include "heatpump_screen.h"
 #include "app_preferences.h"
 #include "event_log.h"
+#include "log_buffer.h"
 
 static const char* TAG = "main";
 
@@ -77,6 +78,9 @@ static void show_error_message(const char* message)
 
 extern "C" void app_main(void)
 {
+    // Initialize log buffer first to capture boot logs
+    log_buffer_init();
+
     mclog::tagInfo(TAG, "Arctic Heat Pump Controller Starting...");
 
     // Initialize NVS (required for storing settings like timezone, WiFi credentials, etc.)

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -244,7 +244,22 @@
                 evtErrorAppeared: 'Error Appeared',
                 evtErrorCleared: 'Error Cleared',
                 evtConnected: 'Connected',
-                evtDisconnected: 'Disconnected'
+                evtDisconnected: 'Disconnected',
+
+                // Logs
+                logs: 'Logs',
+                noLogs: 'No log entries',
+                clearLogs: 'Clear Logs',
+                clearLogsConfirm: 'Clear all log entries?',
+                logsCleared: 'Logs cleared',
+                logsClearFailed: 'Failed to clear logs',
+                logLevelAll: 'All',
+                logLevelError: 'Error',
+                logLevelWarn: 'Warn',
+                logLevelInfo: 'Info',
+                logLevelDebug: 'Debug',
+                logAutoScroll: 'Auto-scroll',
+                logPaused: 'Paused'
             },
             fr: {
                 // Header & Navigation
@@ -482,7 +497,22 @@
                 evtErrorAppeared: 'Erreur apparue',
                 evtErrorCleared: 'Erreur effac\u00e9e',
                 evtConnected: 'Connect\u00e9',
-                evtDisconnected: 'D\u00e9connect\u00e9'
+                evtDisconnected: 'D\u00e9connect\u00e9',
+
+                // Logs
+                logs: 'Journaux',
+                noLogs: 'Aucune entr\u00e9e',
+                clearLogs: 'Effacer',
+                clearLogsConfirm: 'Effacer tous les journaux ?',
+                logsCleared: 'Journaux effac\u00e9s',
+                logsClearFailed: '\u00c9chec de la suppression',
+                logLevelAll: 'Tout',
+                logLevelError: 'Erreur',
+                logLevelWarn: 'Avert.',
+                logLevelInfo: 'Info',
+                logLevelDebug: 'D\u00e9bug',
+                logAutoScroll: 'D\u00e9fil. auto',
+                logPaused: 'En pause'
             },
             es: {
                 // Header & Navigation
@@ -720,7 +750,22 @@
                 evtErrorAppeared: 'Error detectado',
                 evtErrorCleared: 'Error eliminado',
                 evtConnected: 'Conectado',
-                evtDisconnected: 'Desconectado'
+                evtDisconnected: 'Desconectado',
+
+                // Logs
+                logs: 'Registros',
+                noLogs: 'Sin entradas',
+                clearLogs: 'Borrar',
+                clearLogsConfirm: '\u00bfBorrar todos los registros?',
+                logsCleared: 'Registros borrados',
+                logsClearFailed: 'Error al borrar registros',
+                logLevelAll: 'Todo',
+                logLevelError: 'Error',
+                logLevelWarn: 'Advert.',
+                logLevelInfo: 'Info',
+                logLevelDebug: 'Depura.',
+                logAutoScroll: 'Auto-despl.',
+                logPaused: 'Pausado'
             }
         };
     </script>
@@ -1940,6 +1985,93 @@
             margin-top: 0.2rem;
         }
         
+        /* Log Viewer */
+        .log-toolbar {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+        .log-level-filters {
+            display: flex;
+            gap: 0.25rem;
+        }
+        .log-level-filters button {
+            padding: 0.2rem 0.5rem;
+            font-size: 0.75rem;
+            border-radius: 4px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--text-secondary);
+            cursor: pointer;
+            transition: all 0.15s;
+        }
+        .log-level-filters button.active {
+            border-color: var(--accent);
+            color: var(--accent);
+            background: rgba(0, 212, 255, 0.1);
+        }
+        .log-container {
+            max-height: 70vh;
+            overflow-y: auto;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 0.78rem;
+            line-height: 1.5;
+            background: var(--bg-primary);
+            border-radius: 6px;
+            padding: 0.5rem;
+        }
+        .log-entry {
+            display: flex;
+            gap: 0.5rem;
+            padding: 0.15rem 0.25rem;
+            border-radius: 3px;
+        }
+        .log-entry:hover {
+            background: rgba(255, 255, 255, 0.03);
+        }
+        .log-seq {
+            color: var(--text-secondary);
+            opacity: 0.5;
+            flex-shrink: 0;
+            min-width: 3.5rem;
+            text-align: right;
+        }
+        .log-level {
+            flex-shrink: 0;
+            font-weight: 700;
+            min-width: 1rem;
+            text-align: center;
+        }
+        .log-level-E { color: var(--error); }
+        .log-level-W { color: var(--warning); }
+        .log-level-I { color: var(--accent); }
+        .log-level-D { color: var(--text-secondary); }
+        .log-level-V { color: var(--text-secondary); opacity: 0.6; }
+        .log-tag {
+            color: var(--accent-dim);
+            flex-shrink: 0;
+            max-width: 12rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .log-msg {
+            color: var(--text-primary);
+            word-break: break-all;
+            flex: 1;
+            min-width: 0;
+        }
+        .log-paused-banner {
+            text-align: center;
+            padding: 0.3rem;
+            background: rgba(251, 191, 36, 0.15);
+            color: var(--warning);
+            font-size: 0.8rem;
+            border-radius: 4px;
+            margin-bottom: 0.5rem;
+        }
+
         /* Parameter Card */
         .param-category {
             margin-bottom: 1.5rem;
@@ -2320,10 +2452,11 @@
                 </header>
                 
                 <nav>
-                    <button :class="{ active: page === 'dashboard' }" @click="page = 'dashboard'" x-text="t('dashboard')"></button>
-                    <button :class="{ active: page === 'parameters' }" @click="page = 'parameters'; loadParams()" x-text="t('parameters')"></button>
-                    <button :class="{ active: page === 'events' }" @click="page = 'events'; loadEvents()" x-text="t('events')"></button>
-                    <button :class="{ active: page === 'settings' }" @click="page = 'settings'" x-text="t('settings')"></button>
+                    <button :class="{ active: page === 'dashboard' }" @click="page = 'dashboard'; stopLogPolling()" x-text="t('dashboard')"></button>
+                    <button :class="{ active: page === 'parameters' }" @click="page = 'parameters'; stopLogPolling(); loadParams()" x-text="t('parameters')"></button>
+                    <button :class="{ active: page === 'events' }" @click="page = 'events'; stopLogPolling(); loadEvents()" x-text="t('events')"></button>
+                    <button :class="{ active: page === 'logs' }" @click="page = 'logs'; startLogPolling()" x-text="t('logs')"></button>
+                    <button :class="{ active: page === 'settings' }" @click="page = 'settings'; stopLogPolling()" x-text="t('settings')"></button>
                 </nav>
                 
                 <main>
@@ -2753,6 +2886,49 @@
                         </div>
                     </div>
                     
+                    <!-- Logs Page -->
+                    <div x-show="page === 'logs'">
+                        <div class="card">
+                            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem;">
+                                <h2 x-text="t('logs') + (logEntries.length ? ' (' + logEntries.length + ')' : '')"></h2>
+                                <div class="log-toolbar">
+                                    <div class="log-level-filters">
+                                        <button :class="{ active: logLevelFilter === 'V' }" @click="logLevelFilter = 'V'; logLatestSeq = 0; loadLogs(true)" x-text="t('logLevelAll')"></button>
+                                        <button :class="{ active: logLevelFilter === 'E' }" @click="logLevelFilter = 'E'; logLatestSeq = 0; loadLogs(true)" x-text="t('logLevelError')"></button>
+                                        <button :class="{ active: logLevelFilter === 'W' }" @click="logLevelFilter = 'W'; logLatestSeq = 0; loadLogs(true)" x-text="t('logLevelWarn')"></button>
+                                        <button :class="{ active: logLevelFilter === 'I' }" @click="logLevelFilter = 'I'; logLatestSeq = 0; loadLogs(true)" x-text="t('logLevelInfo')"></button>
+                                        <button :class="{ active: logLevelFilter === 'D' }" @click="logLevelFilter = 'D'; logLatestSeq = 0; loadLogs(true)" x-text="t('logLevelDebug')"></button>
+                                    </div>
+                                    <label style="display: flex; align-items: center; gap: 0.3rem; font-size: 0.8rem; color: var(--text-secondary); cursor: pointer;">
+                                        <input type="checkbox" x-model="logAutoScroll" style="accent-color: var(--accent);">
+                                        <span x-text="t('logAutoScroll')"></span>
+                                    </label>
+                                    <button class="btn btn-secondary" style="padding: 0.3rem 0.8rem; font-size: 0.8rem;" x-show="logEntries.length > 0" @click="clearLogs()" x-text="t('clearLogs')"></button>
+                                </div>
+                            </div>
+                            <div class="card-body" style="padding: 0.5rem;">
+                                <template x-if="logPaused">
+                                    <div class="log-paused-banner" x-text="t('logPaused')"></div>
+                                </template>
+                                <template x-if="filteredLogs().length === 0">
+                                    <div style="padding: 1.5rem; text-align: center; color: var(--text-secondary);" x-text="t('noLogs')"></div>
+                                </template>
+                                <template x-if="filteredLogs().length > 0">
+                                    <div class="log-container" x-ref="logContainer" @scroll="onLogScroll()">
+                                        <template x-for="entry in filteredLogs()" :key="entry.seq">
+                                            <div class="log-entry">
+                                                <span class="log-seq" x-text="entry.seq"></span>
+                                                <span class="log-level" :class="'log-level-' + entry.level" x-text="entry.level"></span>
+                                                <span class="log-tag" x-text="entry.tag"></span>
+                                                <span class="log-msg" x-text="entry.message"></span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Settings Page -->
                     <div x-show="page === 'settings'">
                             <!-- Device Info -->
@@ -3140,6 +3316,15 @@
                 eventLog: [],
                 eventLogTotal: 0,
                 eventLogLoading: false,
+                
+                // Log viewer state
+                logEntries: [],
+                logLatestSeq: 0,
+                logLevelFilter: 'V',       // V=all, I=info+warn+error, W=warn+error, E=error only, D=debug+
+                logAutoScroll: true,
+                logPaused: false,
+                logPollTimer: null,
+                logPollInterval: 2000,      // Poll every 2 seconds
                 
                 // Parameters state
                 params: {},
@@ -3923,6 +4108,97 @@
                     } catch (e) {
                         console.error(e);
                         this.showToast(this.t('eventsClearFailed'), 'error');
+                    }
+                },
+                
+                // ==========================================
+                // Log Viewer
+                // ==========================================
+                
+                startLogPolling() {
+                    // Stop any existing timer
+                    this.stopLogPolling();
+                    // Load initial batch
+                    this.loadLogs(true);
+                    // Start incremental polling
+                    this.logPollTimer = setInterval(() => {
+                        if (this.page === 'logs' && !this.logPaused) {
+                            this.loadLogs(false);
+                        }
+                    }, this.logPollInterval);
+                },
+                
+                stopLogPolling() {
+                    if (this.logPollTimer) {
+                        clearInterval(this.logPollTimer);
+                        this.logPollTimer = null;
+                    }
+                },
+                
+                async loadLogs(fullLoad) {
+                    try {
+                        const sinceParam = fullLoad ? 0 : this.logLatestSeq;
+                        const res = await this.apiFetch(`/api/logs?since=${sinceParam}&level=${this.logLevelFilter}`);
+                        const data = await res.json();
+                        
+                        if (fullLoad) {
+                            this.logEntries = data.entries || [];
+                        } else {
+                            // Append new entries
+                            const newEntries = data.entries || [];
+                            if (newEntries.length > 0) {
+                                this.logEntries = this.logEntries.concat(newEntries);
+                                // Cap at 1000 entries in the UI to prevent memory bloat
+                                if (this.logEntries.length > 1000) {
+                                    this.logEntries = this.logEntries.slice(-1000);
+                                }
+                            }
+                        }
+                        
+                        this.logLatestSeq = data.latest_seq || 0;
+                        
+                        // Auto-scroll to bottom
+                        if (this.logAutoScroll) {
+                            this.$nextTick(() => {
+                                const container = this.$refs.logContainer;
+                                if (container) {
+                                    container.scrollTop = container.scrollHeight;
+                                }
+                            });
+                        }
+                    } catch (e) {
+                        console.error('Failed to load logs:', e);
+                    }
+                },
+                
+                filteredLogs() {
+                    // Server-side filtering handles level. Client just returns all.
+                    // But if we had entries loaded at a broader level and user narrows,
+                    // we filter client-side too for instant feedback.
+                    const levels = { 'E': 1, 'W': 2, 'I': 3, 'D': 4, 'V': 5 };
+                    const maxLevel = levels[this.logLevelFilter] || 5;
+                    return this.logEntries.filter(e => (levels[e.level] || 5) <= maxLevel);
+                },
+                
+                onLogScroll() {
+                    // Pause auto-scroll if user scrolls up
+                    const container = this.$refs.logContainer;
+                    if (!container) return;
+                    const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
+                    this.logAutoScroll = atBottom;
+                    this.logPaused = !atBottom;
+                },
+                
+                async clearLogs() {
+                    if (!confirm(this.t('clearLogsConfirm'))) return;
+                    try {
+                        await this.apiFetch('/api/logs', { method: 'DELETE' });
+                        this.logEntries = [];
+                        this.logLatestSeq = 0;
+                        this.showToast(this.t('logsCleared'), 'success');
+                    } catch (e) {
+                        console.error(e);
+                        this.showToast(this.t('logsClearFailed'), 'error');
                     }
                 },
                 

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -259,7 +259,7 @@
                 logLevelInfo: 'Info',
                 logLevelDebug: 'Debug',
                 logAutoScroll: 'Auto-scroll',
-                logPaused: 'Paused'
+                logPaused: 'Paused — Jump to Live ↓',
             },
             fr: {
                 // Header & Navigation
@@ -512,7 +512,7 @@
                 logLevelInfo: 'Info',
                 logLevelDebug: 'D\u00e9bug',
                 logAutoScroll: 'D\u00e9fil. auto',
-                logPaused: 'En pause'
+                logPaused: 'En pause — Aller au direct ↓',
             },
             es: {
                 // Header & Navigation
@@ -765,7 +765,7 @@
                 logLevelInfo: 'Info',
                 logLevelDebug: 'Depura.',
                 logAutoScroll: 'Auto-despl.',
-                logPaused: 'Pausado'
+                logPaused: 'Pausado — Ir al directo ↓',
             }
         };
     </script>
@@ -2070,6 +2070,11 @@
             font-size: 0.8rem;
             border-radius: 4px;
             margin-bottom: 0.5rem;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .log-paused-banner:hover {
+            background: rgba(251, 191, 36, 0.3);
         }
 
         /* Parameter Card */
@@ -2908,7 +2913,7 @@
                             </div>
                             <div class="card-body" style="padding: 0.5rem;">
                                 <template x-if="logPaused">
-                                    <div class="log-paused-banner" x-text="t('logPaused')"></div>
+                                    <div class="log-paused-banner" @click="jumpToLive()" x-text="t('logPaused')"></div>
                                 </template>
                                 <template x-if="filteredLogs().length === 0">
                                     <div style="padding: 1.5rem; text-align: center; color: var(--text-secondary);" x-text="t('noLogs')"></div>
@@ -4187,6 +4192,17 @@
                     const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
                     this.logAutoScroll = atBottom;
                     this.logPaused = !atBottom;
+                },
+                
+                jumpToLive() {
+                    this.logAutoScroll = true;
+                    this.logPaused = false;
+                    this.$nextTick(() => {
+                        const container = this.$refs.logContainer;
+                        if (container) {
+                            container.scrollTop = container.scrollHeight;
+                        }
+                    });
                 },
                 
                 async clearLogs() {

--- a/tests/device/TODO.md
+++ b/tests/device/TODO.md
@@ -48,6 +48,11 @@ The following screens and features have **no automated test coverage** yet:
 - [ ] Verify API auth (missing/wrong API key returns 401)
 - [ ] Test API responses when device is disconnected (non-demo mode)
 - [ ] Verify `demo_mode` flag is present in all API responses
+- [ ] `GET /api/logs` — verify entries returned with seq, level, tag, message fields
+- [ ] `GET /api/logs?level=E` — verify only error-level entries returned
+- [ ] `GET /api/logs?since=N` — verify incremental fetch returns only newer entries
+- [ ] `GET /api/logs?limit=10` — verify at most 10 entries returned
+- [ ] `DELETE /api/logs` — verify buffer is cleared, seq numbers keep incrementing
 
 ## Web Dashboard Testing
 

--- a/todo.md
+++ b/todo.md
@@ -178,10 +178,11 @@ Test flow: pytest script → sets state on simulator via REST → waits for Tab5
 ## Logging
 
 - [ ] Audit and clean up serial log output (remove excessive/noisy ESP_LOGI/LOGD calls, standardize TAG usage)
-- [ ] Implement a circular RAM log buffer (e.g. 16–32 KB ring buffer) for recent log messages
-- [ ] Add `GET /api/logs` endpoint to retrieve buffered logs as JSON or plain text
-- [ ] Add a live log viewer panel to the web dashboard (auto-scroll, filterable by level)
-- [ ] Hook into `esp_log_set_vprintf()` to capture logs into the ring buffer alongside serial output
+- [x] Implement a circular RAM log buffer (256-entry ring buffer in `log_buffer.cpp`)
+- [x] Add `GET /api/logs` endpoint to retrieve buffered logs as JSON (with `since`, `level`, `limit` params)
+- [x] Add `DELETE /api/logs` endpoint to clear the log buffer
+- [x] Add a live log viewer panel to the web dashboard (auto-scroll, filterable by level, 2s polling)
+- [x] Hook into `esp_log_set_vprintf()` to capture logs into the ring buffer alongside serial output
 
 ## Testing
 


### PR DESCRIPTION
## System Log Buffer — REST API + Web Dashboard

Captures all `ESP_LOG` output into a 256-entry RAM ring buffer and exposes it via REST API and the web dashboard for real-time log viewing.

### New Files
- **`log_buffer.h` / `log_buffer.cpp`** — Ring buffer that hooks `esp_log_set_vprintf()` to parse ESP-IDF log format (`E (12345) tag: message`) into structured entries (seq, uptime_ms, level, tag, message). Serial output preserved.

### REST API
- **`GET /api/logs?since=N&level=E|W|I|D|V&limit=N`** — Returns `{total, latest_seq, entries[]}`. Use `since` for efficient incremental polling.
- **`DELETE /api/logs`** — Clears buffer (seq numbers keep incrementing for client consistency).

### Web Dashboard (Logs Tab)
- Monospace log viewer with color-coded levels (red=E, yellow=W, cyan=I, gray=D/V)
- Level filter buttons (All / Error / Warn / Info / Debug) — server-side + client-side filtering
- Auto-scroll that pauses when user scrolls up, with a clickable **"Paused — Jump to Live ↓"** banner to resume
- Clear button, 2s polling interval (only when Logs tab is active), capped at 1000 entries client-side
- Translations for EN / FR / ES

### Other Changes
- `main.cpp` — `log_buffer_init()` called first in `app_main()` to capture boot logs
- `api_server.cpp` — `max_uri_handlers` bumped from 80 → 82
- `docs/openapi.yaml` — Full spec for `/api/logs` endpoints + `LogEntry` schema
- `copilot-instructions.md` — Added "always work on a feature branch" rule, `idf.py reconfigure` note for HTML changes, PR markdown format rule
- `create-release.yml` — OTA curl command uses actual GitHub release URL
- `todo.md` / `tests/device/TODO.md` — Updated backlog

### Stats
- 13 files changed, +909 / −25
- Binary size: 1.9 MB (54% free in app partition)