### PR TITLE
fix(ci): upgrade gh-release to v2, explicit draft:false, consistent token

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -186,19 +186,19 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Arctic Controller ${{ steps.version.outputs.tag }}
           body_path: /tmp/release_body.md
+          draft: false
           files: |
             build/arctic_controller.bin
             build/bootloader/bootloader.bin
             build/partition_table/partition-table.bin
             build/ota_data_initial.bin
-          generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ARCTIC_RELEASE_TOKEN }}
 
       - name: Release summary
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
Fixes the v2.3.2 draft release issue by:
- Upgrading softprops/action-gh-release from v1 to v2
- Adding explicit \draft: false\ to prevent ambiguous release state
- Using \ARCTIC_RELEASE_TOKEN\ consistently for both tag push and release creation (was using \GITHUB_TOKEN\ for release, which could cause permission mismatches)
- Removing \generate_release_notes: true\ since we now generate our own changelog from conventional commits