### PR TITLE
chore: bump version to 2.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.3.3")
+set(PROJECT_VER "2.3.4")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS


### PR DESCRIPTION
Bump to test the fixed release workflow (v2, draft:false, consistent token).