### PR TITLE
ci: add daily scheduled device test run

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -1,6 +1,9 @@
 name: Device Tests
 
 on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
   pull_request:
     branches:
       - main

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -510,8 +510,13 @@ class TestHeatpumpErrors:
     def test_errors_with_injected_error(self):
         """Injecting an error should appear in active errors."""
         _inject_demo({"error1": 1})  # Bit 0
-        time.sleep(0.3)
-        data = _get("/api/heatpump/errors").json()
+        # Poll until the error propagates (up to 3s)
+        data = None
+        for _ in range(6):
+            time.sleep(0.5)
+            data = _get("/api/heatpump/errors").json()
+            if data["has_errors"]:
+                break
         assert data["has_errors"] is True
         assert data["error_count"] > 0
         assert len(data["active"]) > 0

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -14,6 +14,7 @@ Prerequisites:
 
 import os
 import re
+import time
 
 import pytest
 import requests
@@ -471,7 +472,15 @@ class TestOtaAuthEnforcement:
 
     def test_upload_rejects_bad_key(self):
         """POST /api/ota/upload with invalid API key → 401."""
-        r = _post_raw_with_bad_key("/api/ota/upload", data=b"\x00")
+        # Retry on transient connection timeouts (mDNS/network flakes)
+        for attempt in range(3):
+            try:
+                r = _post_raw_with_bad_key("/api/ota/upload", data=b"\x00")
+                break
+            except requests.exceptions.ConnectionError:
+                if attempt == 2:
+                    raise
+                time.sleep(2)
         assert r.status_code == 401
 
     def test_reboot_rejects_bad_key(self):


### PR DESCRIPTION
Adds a daily cron schedule (6 AM UTC) to the device-tests workflow. This catches environment regressions and keeps the test badges fresh.