### PR TITLE
fix(ci): parse JUnit testsuites wrapper for badge extraction

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -232,24 +232,34 @@ jobs:
               if not os.path.exists(path):
                   return 0, 0, 0
               root = ET.parse(path).getroot()
-              tests = int(root.get('tests', 0))
-              failures = int(root.get('failures', 0)) + int(root.get('errors', 0))
-              skipped = int(root.get('skipped', 0))
+              # pytest wraps results in <testsuites><testsuite ...></testsuites>
+              if root.tag == 'testsuites':
+                  suites = root.findall('testsuite')
+              else:
+                  suites = [root]
+              tests = sum(int(s.get('tests', 0)) for s in suites)
+              failures = sum(int(s.get('failures', 0)) + int(s.get('errors', 0)) for s in suites)
+              skipped = sum(int(s.get('skipped', 0)) for s in suites)
               return tests - failures - skipped, failures, skipped
 
+          any_results = False
           with open(os.environ['GITHUB_OUTPUT'], 'a') as gh:
               for name, path in [('ui', 'test-results.xml'), ('api', 'api-test-results.xml'), ('web', 'web-test-results.xml')]:
                   p, f, s = parse_junit(path)
+                  total = p + f + s
+                  if total > 0:
+                      any_results = True
                   msg = f'{p} passed'
                   if s: msg += f', {s} skipped'
                   if f: msg += f', {f} failed'
                   color = 'red' if f > 0 else 'brightgreen'
                   gh.write(f'{name}_msg={msg}\n')
                   gh.write(f'{name}_color={color}\n')
+              gh.write(f'has_results={\"true\" if any_results else \"false\"}\n')
           "
 
       - name: Update Device UI Tests badge
-        if: always() && steps.test_results.outcome == 'success'
+        if: always() && steps.test_results.outputs.has_results == 'true'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
@@ -260,7 +270,7 @@ jobs:
           color: ${{ steps.test_results.outputs.ui_color }}
 
       - name: Update API Contract Tests badge
-        if: always() && steps.test_results.outcome == 'success'
+        if: always() && steps.test_results.outputs.has_results == 'true'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
@@ -271,7 +281,7 @@ jobs:
           color: ${{ steps.test_results.outputs.api_color }}
 
       - name: Update Web Dashboard Tests badge
-        if: always() && steps.test_results.outcome == 'success'
+        if: always() && steps.test_results.outputs.has_results == 'true'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}


### PR DESCRIPTION
pytest wraps JUnit XML in a \<testsuites>\ root element. The badge extraction step was reading attributes from the root, which has no \	ests\ count — resulting in '0 passed' badges. This fix iterates over child \<testsuite>\ elements and sums their counts. Also adds a guard to only update badge gist when test results are non-zero, preventing empty runs from zeroing out badges.