### PR TITLE
docs: add OTA test coverage items for all update paths

### DIFF
--- a/tests/device/TODO.md
+++ b/tests/device/TODO.md
@@ -133,6 +133,54 @@ These can run in the normal test suite without risk:
 - [ ] Verify OTA update check works from settings menu (UI test)
 - [ ] Confirm firmware version displays correctly on settings screen (UI test)
 
+### OTA via Device UI (Tier 1 — safe, no real update)
+
+The device screen tests (`test_firmware.py`) cover check/mock but not the full
+update flow UI. These tests use `firmware_mock()` to simulate update states
+without triggering a real OTA.
+
+- [ ] **Progress bar display** — mock OTA state to DOWNLOADING with progress 0→50→100,
+      verify progress bar widget appears and updates
+- [ ] **Status text updates** — verify status label changes through states:
+      "Checking...", "Downloading...", "Verifying...", "Ready to reboot"
+- [ ] **Error state UI** — mock a failed download, verify error message displays
+      on the update screen
+- [ ] **Install button behavior** — when update is available (mocked), verify
+      install button is visible and tappable (but don't actually trigger OTA)
+- [ ] **Cancel/dismiss during update check** — verify user can navigate away
+      from the update screen during a check
+
+### OTA via Web Dashboard (Tier 1 — safe, no real update)
+
+The web tests (`test_settings.py`) verify UI elements exist but don't test the
+OTA flow. These tests use API mocking to simulate update states.
+
+- [ ] **Check for Updates button** — click button, verify spinner/loading state
+      appears, then result (no update / update available)
+- [ ] **Update available card** — mock `GET /api/ota/releases` to return a newer
+      version, click check, verify "Update Available" banner with version + release
+      notes appears
+- [ ] **Install Update button** — when update available, verify install button
+      appears and is clickable (intercept the POST to avoid real install)
+- [ ] **File upload via drag-and-drop zone** — upload a small invalid .bin file,
+      verify error message appears (header validation rejects it)
+- [ ] **File upload via file picker** — use the hidden file input to select a
+      .bin file, verify upload starts (intercept to avoid real flash)
+- [ ] **Upload progress display** — verify progress bar appears during file upload
+- [ ] **OTA status polling** — verify the web dashboard polls `/api/ota/status`
+      and reflects state changes (idle → downloading → complete/failed)
+
+### Cross-path OTA consistency
+
+Verify that OTA state is consistent across all three interfaces.
+
+- [ ] **API-triggered update visible on web** — start OTA via API, verify web
+      dashboard shows download progress
+- [ ] **API-triggered update visible on device UI** — start OTA via API, verify
+      device screen shows update status
+- [ ] **Web-triggered update visible via API** — start OTA from web dashboard,
+      verify `/api/ota/status` reflects progress
+
 ### Tier 2 — Real OTA (requires reboot)
 
 These tests trigger an actual firmware update. The device reboots, so the test

--- a/todo.md
+++ b/todo.md
@@ -240,3 +240,43 @@ Test flow: pytest script → sets state on simulator via REST → waits for Tab5
 > **Test backlog and coverage details have moved to [`tests/device/TODO.md`](tests/device/TODO.md).**
 > See [`tests/device/README.md`](tests/device/README.md) for architecture,
 > setup instructions, and how to write new tests.
+
+## Cloud Telemetry (Azure)
+
+Send heat pump operational data to Azure for long-term monitoring, analytics,
+and alerting. The device already has all sensor data via Modbus — this adds
+cloud connectivity to enable remote dashboards, historical trends, and
+anomaly detection.
+
+### Phase 1 — Device to Cloud
+
+- [ ] **Azure IoT Hub integration** — register device, authenticate via SAS token
+      or X.509 cert, send telemetry via MQTT (ESP-IDF `esp-mqtt` or Azure IoT SDK)
+- [ ] **Telemetry payload** — periodic messages (every 30–60s) with: temperatures
+      (water tank, outdoor, discharge, suction, condenser, evaporator), compressor
+      frequency, fan speed, power state, working mode, error codes, COP metrics
+- [ ] **Connection management** — reconnect on WiFi drop, buffer unsent messages
+      in PSRAM, backoff on repeated failures
+- [ ] **Device twin / desired properties** — allow cloud-side configuration of
+      poll interval, telemetry fields, alert thresholds
+- [ ] **Kconfig option** — `CONFIG_CLOUD_TELEMETRY` to enable/disable at build
+      time (off by default, no impact on production binary size when disabled)
+
+### Phase 2 — Cloud Backend
+
+- [ ] **IoT Hub → Event Hubs / Stream Analytics** — route telemetry for processing
+- [ ] **Azure Data Explorer or Cosmos DB** — store time-series data for historical
+      queries (temperature trends, runtime hours, defrost cycles)
+- [ ] **Azure Monitor / Alerts** — trigger alerts on error codes, unusual temps,
+      compressor stalls, or extended defrost cycles
+- [ ] **Power BI / Grafana dashboard** — visualize historical data, COP trends,
+      energy consumption patterns
+
+### Phase 3 — Cloud to Device
+
+- [ ] **Remote commands** — change mode, setpoints, power on/off from cloud
+      dashboard (via IoT Hub direct methods or cloud-to-device messages)
+- [ ] **OTA from cloud** — trigger firmware updates via IoT Hub instead of
+      direct API (useful for fleet management with multiple controllers)
+- [ ] **Remote diagnostics** — pull device logs, capture screenshots, check
+      health status from cloud portal


### PR DESCRIPTION
Adds TODO items for OTA testing across all three interfaces:

- **Device UI** (5 items): progress bar, status text, error state, install button, cancel/dismiss
- **Web Dashboard** (7 items): check button, update available card, install button, file upload (drag-drop + picker), upload progress, status polling
- **Cross-path consistency** (3 items): API→web, API→device UI, web→API state visibility

Currently only the API path has tests (41 in test_ota_api.py). The device UI tests only cover check/mock (test_firmware.py, 5 tests) and web tests only verify element presence (test_settings.py, 3 tests).