### PR TITLE
fix(ci): exclude markdown files from device-tests path filter

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -19,6 +19,7 @@ on:
       - 'repos.json'
       - 'fetch_repos.py'
       - 'tests/**'
+      - '!tests/**/*.md'
       - '.github/workflows/device-tests.yml'
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
## Problem

Changes to \	ests/device/TODO.md\ were triggering the Device Tests workflow because \	ests/**\ in the \paths:\ filter matches all files under \	ests/\, including markdown.

## Fix

Added \!tests/**/*.md\ exclusion to the \paths:\ filter in \device-tests.yml\. This prevents doc-only changes (README, TODO) under \	ests/\ from triggering unnecessary device test runs.

\uild.yml\ is unaffected — it doesn't include \	ests/**\ in its paths.