### PR TITLE
feat: add diagnostic CSV download endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.5.0")
+set(PROJECT_VER "2.6.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1238,6 +1238,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/heatpump/diagnostic:
+    get:
+      tags:
+        - HeatPump
+      summary: Download diagnostic CSV report
+      description: |
+        Returns a comprehensive system diagnostic as a downloadable CSV file.
+        Includes all Modbus register values, sensor readings, component status,
+        active errors, and technician P-parameters with current values.
+        Useful for remote troubleshooting with Arctic support.
+        
+        CSV columns: Category, Name, P-Code, Modbus Address, Value, Unit
+        
+        Sections:
+        - System State (power, mode, connection)
+        - Temperatures (all sensor readings in °C)
+        - Setpoints (cooling, heating, hot water)
+        - System Readings (compressor freq, fan RPM, voltages, currents, pressures)
+        - Component Status (individual bits from registers 2135/2136)
+        - Raw Register Values (hex values of status/error registers)
+        - Active Errors (individual error flags from registers 2137/2138)
+        - P-Parameters (all technician settings with live values)
+      responses:
+        '200':
+          description: CSV diagnostic file
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              description: 'attachment; filename="arctic-diagnostic-YYYYMMDD-HHMMSS.csv"'
+          content:
+            text/csv:
+              schema:
+                type: string
+                description: CSV formatted diagnostic data
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /api/heatpump/errors:
     get:
       tags:

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -88,6 +88,7 @@ static esp_err_t heatpump_setpoints_put_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_get_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_clear_handler(httpd_req_t* req);
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req);
+static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req);
 static esp_err_t events_get_handler(httpd_req_t* req);
 static esp_err_t events_clear_handler(httpd_req_t* req);
 static esp_err_t display_brightness_get_handler(httpd_req_t* req);
@@ -274,7 +275,7 @@ bool api_server_start(void)
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
     config.uri_match_fn = httpd_uri_match_wildcard;
-    config.max_uri_handlers = 84;  // 43 api_server + 34 test_endpoints = 77 needed
+    config.max_uri_handlers = 86;  // 44 api_server + 34 test_endpoints = 78 needed
     config.stack_size = 16384;     // Default task stack (tree walk is iterative, not recursive)
     config.max_resp_headers = 16;  // More response headers
     config.recv_wait_timeout = 10; // 10 second receive timeout
@@ -617,6 +618,15 @@ bool api_server_start(void)
     };
     REGISTER_URI(heatpump_errors_clear_uri);
     
+    // GET /api/heatpump/diagnostic - Download diagnostic CSV dump
+    httpd_uri_t heatpump_diagnostic_uri = {
+        .uri = "/api/heatpump/diagnostic",
+        .method = HTTP_GET,
+        .handler = heatpump_diagnostic_get_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(heatpump_diagnostic_uri);
+
     // PATCH /api/heatpump/demo - Write fields in demo mode (for testing)
     httpd_uri_t heatpump_demo_uri = {
         .uri = "/api/heatpump/demo",
@@ -2338,6 +2348,190 @@ static esp_err_t heatpump_errors_clear_handler(httpd_req_t* req)
     free(json_str);
     cJSON_Delete(root);
     
+    return ESP_OK;
+}
+
+// ============================================================================
+// GET /api/heatpump/diagnostic - Download complete system diagnostic as CSV
+// ============================================================================
+static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+
+    // Get current timestamp for filename
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    char filename[128];
+    snprintf(filename, sizeof(filename), "attachment; filename=\"arctic-diagnostic-%04d%02d%02d-%02d%02d%02d.csv\"",
+             timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
+             timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+
+    httpd_resp_set_type(req, "text/csv");
+    httpd_resp_set_hdr(req, "Content-Disposition", filename);
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
+    // Line buffer for CSV rows
+    char line[256];
+
+    // UTF-8 BOM so Excel interprets the file correctly (degree signs, accents, etc.)
+    httpd_resp_send_chunk(req, "\xEF\xBB\xBF", 3);
+
+    // CSV header
+    httpd_resp_sendstr_chunk(req, "Category,Name,P-Code,Modbus Address,Value,Unit\r\n");
+
+    arctic::HeatPumpState hp = arctic::getState();
+    bool demo = arctic::isDemoMode();
+
+    // --- System State ---
+    snprintf(line, sizeof(line), "System,Connected,,,\"%s\",\r\n", hp.connected ? "Yes" : "No");
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "System,Demo Mode,,,\"%s\",\r\n", demo ? "Yes" : "No");
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "System,Unit Power,,2000,\"%s\",\r\n", hp.unit_on ? "ON" : "OFF");
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "System,Working Mode,,2001,\"%s\",\r\n", arctic::workingModeToString(hp.working_mode));
+    httpd_resp_sendstr_chunk(req, line);
+
+    // --- Temperatures (stored as tenths of °C) ---
+    #define DIAG_TEMP(name_str, field, addr) \
+        snprintf(line, sizeof(line), "Temperature,%s,,%d,%.1f,°C\r\n", name_str, addr, (field) / 10.0f); \
+        httpd_resp_sendstr_chunk(req, line);
+
+    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       2100)
+    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     2102)
+    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      2103)
+    DIAG_TEMP("Discharge",        hp.discharge_temp,        2104)
+    DIAG_TEMP("Suction",          hp.suction_temp,          2105)
+    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     2107)
+    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      2108)
+    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  2110)
+    DIAG_TEMP("IPM Module",       hp.ipm_temp,              2114)
+    #undef DIAG_TEMP
+
+    // --- Setpoints ---
+    snprintf(line, sizeof(line), "Setpoint,Cooling,,2002,%d,°C\r\n", hp.cooling_setpoint);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Setpoint,Heating,,2003,%d,°C\r\n", hp.heating_setpoint);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Setpoint,Hot Water,,2004,%d,°C\r\n", hp.hot_water_setpoint);
+    httpd_resp_sendstr_chunk(req, line);
+
+    // --- System Readings ---
+    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,2118,%u,Hz\r\n", hp.compressor_freq);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,Fan Speed,,2119,%u,RPM\r\n", hp.fan_speed);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,AC Voltage,,2120,%u,V\r\n", hp.ac_voltage);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,AC Current,,2121,%.1f,A\r\n", hp.ac_current / 10.0f);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,DC Voltage,,2122,%.1f,V\r\n", hp.getDcVoltageV());
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,DC Current,,2123,%.1f,A\r\n", hp.dc_current / 10.0f);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,2124,%u,steps\r\n", hp.primary_eev_opening);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,Secondary EEV Opening,,2125,%u,steps\r\n", hp.secondary_eev_opening);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,High Pressure,,2126,%.2f,MPa\r\n", hp.getHighPressureMPa());
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,Low Pressure,,2127,%.2f,MPa\r\n", hp.getLowPressureMPa());
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Reading,Power Consumption,,,%.0f,W\r\n", (hp.ac_voltage * hp.ac_current) / 10.0f);
+    httpd_resp_sendstr_chunk(req, line);
+
+    // --- Component Status (register 2135) ---
+    #define DIAG_STATUS1(name_str, mask) \
+        snprintf(line, sizeof(line), "Status,%s,,2135,\"%s\",\r\n", name_str, (hp.status1 & arctic::status1::mask) ? "ON" : "OFF"); \
+        httpd_resp_sendstr_chunk(req, line);
+
+    DIAG_STATUS1("Unit",            UNIT_ON)
+    DIAG_STATUS1("Compressor",      COMPRESSOR)
+    DIAG_STATUS1("Fan High",        FAN_HIGH)
+    DIAG_STATUS1("Fan Medium",      FAN_MED)
+    DIAG_STATUS1("Fan Low",         FAN_LOW)
+    DIAG_STATUS1("Water Pump",      WATER_PUMP)
+    DIAG_STATUS1("Four-Way Valve",  FOUR_WAY_VALVE)
+    DIAG_STATUS1("Backup Heater",   BACKUP_HEATER)
+    DIAG_STATUS1("Water Flow Switch", WATER_FLOW_SW)
+    DIAG_STATUS1("High Press Switch", HIGH_PRESS_SW)
+    DIAG_STATUS1("Low Press Switch",  LOW_PRESS_SW)
+    DIAG_STATUS1("Emergency Switch",  EMERGENCY_SW)
+    DIAG_STATUS1("AC Online",       AC_ONLINE)
+    DIAG_STATUS1("Mode Switch",     MODE_SWITCH)
+    DIAG_STATUS1("3-Way Valve 1",   THREE_WAY_V1)
+    DIAG_STATUS1("3-Way Valve 2",   THREE_WAY_V2)
+    #undef DIAG_STATUS1
+
+    // --- Component Status (register 2136) ---
+    #define DIAG_STATUS2(name_str, mask) \
+        snprintf(line, sizeof(line), "Status,%s,,2136,\"%s\",\r\n", name_str, (hp.status2 & arctic::status2::mask) ? "ON" : "OFF"); \
+        httpd_resp_sendstr_chunk(req, line);
+
+    DIAG_STATUS2("Solenoid Valve",    SOLENOID_VALVE)
+    DIAG_STATUS2("Unloading Valve",   UNLOADING_VALVE)
+    DIAG_STATUS2("Oil Return Valve",  OIL_RETURN_VALVE)
+    DIAG_STATUS2("Defrosting",        DEFROSTING)
+    DIAG_STATUS2("Refrigerant Recovery", REFRIG_RECOVERY)
+    DIAG_STATUS2("Oil Return",        OIL_RETURN)
+    DIAG_STATUS2("Wired Controller",  WIRED_CTRL_CONN)
+    DIAG_STATUS2("Energy Saving",     ENERGY_SAVING)
+    DIAG_STATUS2("Antifreeze Level 1", ANTIFREEZE_1)
+    DIAG_STATUS2("Antifreeze Level 2", ANTIFREEZE_2)
+    DIAG_STATUS2("Sterilization",     STERILIZATION)
+    #undef DIAG_STATUS2
+
+    // --- Raw status/error register values ---
+    snprintf(line, sizeof(line), "Register,Status 1 (raw),,2135,0x%04X,\r\n", hp.status1);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Register,Status 2 (raw),,2136,0x%04X,\r\n", hp.status2);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Register,Error 1 (raw),,2137,0x%04X,\r\n", hp.error1);
+    httpd_resp_sendstr_chunk(req, line);
+    snprintf(line, sizeof(line), "Register,Error 2 (raw),,2138,0x%04X,\r\n", hp.error2);
+    httpd_resp_sendstr_chunk(req, line);
+
+    // --- Active Errors (from ErrorDef arrays with Arctic codes) ---
+    int err_count = 0;
+    const arctic::ErrorDef* err1_defs = arctic::getError1Definitions(&err_count);
+    for (int i = 0; i < err_count; i++) {
+        if (hp.error1 & err1_defs[i].mask) {
+            snprintf(line, sizeof(line), "Error,\"%s\",%s,2137,ACTIVE,\r\n",
+                     err1_defs[i].description, err1_defs[i].code);
+            httpd_resp_sendstr_chunk(req, line);
+        }
+    }
+    err1_defs = arctic::getError2Definitions(&err_count);
+    for (int i = 0; i < err_count; i++) {
+        if (hp.error2 & err1_defs[i].mask) {
+            snprintf(line, sizeof(line), "Error,\"%s\",%s,2138,ACTIVE,\r\n",
+                     err1_defs[i].description, err1_defs[i].code);
+            httpd_resp_sendstr_chunk(req, line);
+        }
+    }
+
+    // --- P-Parameters (technician settings) ---
+    for (int i = 0; i < NUM_HEATPUMP_PARAMS; i++) {
+        const HeatPumpParam* p = &HEATPUMP_PARAMS[i];
+        bool read_ok = false;
+        int16_t value = heatpump_param_read_by_index(i, &read_ok);
+        if (read_ok) {
+            snprintf(line, sizeof(line), "Parameter,\"%s\",%s,%u,%d,%s\r\n",
+                     p->name, p->p_code, p->reg_addr, value, param_unit_to_string(p->unit_type));
+        } else {
+            snprintf(line, sizeof(line), "Parameter,\"%s\",%s,%u,READ_ERROR,%s\r\n",
+                     p->name, p->p_code, p->reg_addr, param_unit_to_string(p->unit_type));
+        }
+        httpd_resp_sendstr_chunk(req, line);
+    }
+
+    // Terminate chunked response
+    httpd_resp_sendstr_chunk(req, NULL);
     return ESP_OK;
 }
 

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -137,6 +137,11 @@
                 rebootController: 'Reboot Controller',
                 rebootConfirm: 'Reboot the device now?',
                 rebootingMsg: 'Device is rebooting. Please wait...',
+
+                // Settings - Diagnostics
+                diagnostics: 'Diagnostics',
+                diagnosticsDesc: 'Download a complete snapshot of all Modbus registers, sensor readings, and system parameters as a CSV file. Useful for troubleshooting with Arctic support.',
+                downloadDiagnostic: 'Download Diagnostic Report',
                 
                 // Language
                 language: 'Language',
@@ -390,6 +395,11 @@
                 rebootController: 'Redémarrer le contrôleur',
                 rebootConfirm: "Redémarrer l'appareil maintenant?",
                 rebootingMsg: "L'appareil redémarre. Veuillez patienter...",
+
+                // Settings - Diagnostics
+                diagnostics: 'Diagnostics',
+                diagnosticsDesc: 'Télécharger un instantané complet de tous les registres Modbus, les lectures des capteurs et les paramètres système au format CSV. Utile pour le dépannage avec le support Arctic.',
+                downloadDiagnostic: 'Télécharger le rapport de diagnostic',
                 
                 // Language
                 language: 'Langue',
@@ -643,6 +653,11 @@
                 rebootController: 'Reiniciar controlador',
                 rebootConfirm: '¿Reiniciar el dispositivo ahora?',
                 rebootingMsg: 'El dispositivo está reiniciando. Por favor espere...',
+
+                // Settings - Diagnostics
+                diagnostics: 'Diagnósticos',
+                diagnosticsDesc: 'Descargar una instantánea completa de todos los registros Modbus, lecturas de sensores y parámetros del sistema en formato CSV. Útil para resolver problemas con el soporte de Arctic.',
+                downloadDiagnostic: 'Descargar informe de diagnóstico',
                 
                 // Language
                 language: 'Idioma',
@@ -3245,6 +3260,19 @@
                                 </div>
                             </div>
                             
+                            <!-- Diagnostics -->
+                            <div class="card">
+                                <div class="card-header">
+                                    <h2 x-text="t('diagnostics')"></h2>
+                                </div>
+                                <div class="card-body">
+                                    <p style="color: var(--text-secondary); margin-bottom: 1rem;" x-text="t('diagnosticsDesc')"></p>
+                                    <a href="/api/heatpump/diagnostic" class="btn btn-secondary" style="width: 100%; text-align: center; text-decoration: none; display: block;">
+                                        📋 <span x-text="t('downloadDiagnostic')"></span>
+                                    </a>
+                                </div>
+                            </div>
+
                             <!-- Reboot Controller -->
                             <div class="card">
                                 <div class="card-header">

--- a/tests/api/test_diagnostic_api.py
+++ b/tests/api/test_diagnostic_api.py
@@ -1,0 +1,390 @@
+"""
+Functional tests for the Diagnostic CSV download endpoint.
+
+GET /api/heatpump/diagnostic returns a CSV file containing a complete
+snapshot of system state, temperatures, parameters, errors, and raw
+register values — intended for support and troubleshooting.
+
+Prerequisites:
+  - Device reachable at ARCTIC_URL (default http://arctic.local)
+  - ARCTIC_API_KEY env var set
+  - Demo mode enabled on the device
+"""
+
+import csv
+import io
+import os
+import time
+
+import pytest
+import requests
+from pathlib import Path
+
+# Load .env from repo root if present (local dev)
+_env_file = Path(__file__).resolve().parent.parent.parent / ".env"
+if _env_file.exists():
+    from dotenv import load_dotenv
+    load_dotenv(_env_file)
+
+BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
+API_KEY = os.environ.get("ARCTIC_API_KEY")
+
+# Expected CSV categories emitted by the diagnostic endpoint
+EXPECTED_CATEGORIES = [
+    "System",
+    "Temperature",
+    "Setpoint",
+    "Reading",
+    "Status",
+    "Register",
+    "Error",
+    "Parameter",
+]
+
+CSV_HEADER = ["Category", "Name", "P-Code", "Modbus Address", "Value", "Unit"]
+
+# UTF-8 BOM bytes
+UTF8_BOM = b"\xef\xbb\xbf"
+
+
+def _headers(api_key=None):
+    """Build auth headers."""
+    h = {}
+    key = api_key if api_key is not None else API_KEY
+    if key:
+        h["X-API-Key"] = key
+    return h
+
+
+def _get(path, **kwargs):
+    """Authenticated GET helper."""
+    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+
+
+def _inject_demo(fields: dict):
+    """Inject demo-mode field values."""
+    requests.post(
+        f"{BASE_URL}/api/test/set-demo-field",
+        headers=_headers(),
+        json=fields,
+        timeout=10,
+    )
+
+
+def _parse_csv(text: str) -> list[dict]:
+    """Parse CSV text into list of row dicts."""
+    reader = csv.DictReader(io.StringIO(text))
+    return list(reader)
+
+
+@pytest.fixture(autouse=True)
+def _check_prerequisites():
+    """Skip if device is unreachable or not in demo mode."""
+    try:
+        r = requests.get(
+            f"{BASE_URL}/api/heatpump/status",
+            headers=_headers(),
+            timeout=5,
+        )
+        r.raise_for_status()
+        data = r.json()
+        if not data.get("demo_mode"):
+            pytest.skip("Device not in demo mode")
+    except requests.ConnectionError:
+        pytest.skip("Device not reachable")
+
+
+# ── Response Headers & Format ─────────────────────────────────────────────
+
+
+class TestDiagnosticResponseFormat:
+    """Verify HTTP response headers and CSV format."""
+
+    def test_returns_200(self):
+        r = _get("/api/heatpump/diagnostic")
+        assert r.status_code == 200
+
+    def test_content_type_is_csv(self):
+        r = _get("/api/heatpump/diagnostic")
+        assert "text/csv" in r.headers.get("Content-Type", "")
+
+    def test_content_disposition_attachment(self):
+        """Response triggers a file download with a timestamped filename."""
+        r = _get("/api/heatpump/diagnostic")
+        cd = r.headers.get("Content-Disposition", "")
+        assert "attachment" in cd
+        assert "arctic-diagnostic-" in cd
+        assert cd.endswith('.csv"')
+
+    def test_utf8_bom_present(self):
+        """CSV starts with UTF-8 BOM for Excel compatibility."""
+        r = _get("/api/heatpump/diagnostic")
+        assert r.content.startswith(UTF8_BOM), "CSV should start with UTF-8 BOM"
+
+    def test_csv_header_row(self):
+        """First data row (after BOM) is the expected CSV header."""
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")  # strips BOM
+        lines = text.strip().splitlines()
+        assert len(lines) > 1, "CSV should have header + data rows"
+        header = lines[0].split(",")
+        assert header == CSV_HEADER
+
+    def test_csv_parseable(self):
+        """Entire response is valid CSV."""
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")
+        rows = _parse_csv(text)
+        assert len(rows) > 10, f"Expected many CSV rows, got {len(rows)}"
+
+    def test_all_rows_have_six_columns(self):
+        """Every row should have all 6 CSV columns."""
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")
+        rows = _parse_csv(text)
+        for i, row in enumerate(rows):
+            assert len(row) == 6, f"Row {i+1} has {len(row)} columns, expected 6: {row}"
+
+
+# ── Category Coverage ─────────────────────────────────────────────────────
+
+
+class TestDiagnosticCategories:
+    """Verify all expected data categories are present in the CSV."""
+
+    def _get_categories(self) -> set:
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")
+        rows = _parse_csv(text)
+        return {row["Category"] for row in rows}
+
+    def test_system_category(self):
+        assert "System" in self._get_categories()
+
+    def test_temperature_category(self):
+        assert "Temperature" in self._get_categories()
+
+    def test_setpoint_category(self):
+        assert "Setpoint" in self._get_categories()
+
+    def test_reading_category(self):
+        assert "Reading" in self._get_categories()
+
+    def test_status_category(self):
+        assert "Status" in self._get_categories()
+
+    def test_register_category(self):
+        assert "Register" in self._get_categories()
+
+    def test_parameter_category(self):
+        assert "Parameter" in self._get_categories()
+
+    def test_no_unexpected_categories(self):
+        """Only expected categories should appear."""
+        cats = self._get_categories()
+        unexpected = cats - set(EXPECTED_CATEGORIES)
+        assert not unexpected, f"Unexpected categories: {unexpected}"
+
+
+# ── Data Content ──────────────────────────────────────────────────────────
+
+
+class TestDiagnosticContent:
+    """Verify actual data content within the CSV."""
+
+    def _get_rows(self) -> list[dict]:
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")
+        return _parse_csv(text)
+
+    def _rows_by_category(self, category: str) -> list[dict]:
+        return [r for r in self._get_rows() if r["Category"] == category]
+
+    def test_system_has_demo_mode_row(self):
+        """System category should include Demo Mode status."""
+        system_rows = self._rows_by_category("System")
+        names = [r["Name"] for r in system_rows]
+        assert "Demo Mode" in names
+
+    def test_system_has_unit_power(self):
+        system_rows = self._rows_by_category("System")
+        names = [r["Name"] for r in system_rows]
+        assert "Unit Power" in names
+
+    def test_temperatures_have_units(self):
+        """All temperature rows should have °C unit."""
+        temp_rows = self._rows_by_category("Temperature")
+        assert len(temp_rows) >= 5, "Expected at least 5 temperature readings"
+        for row in temp_rows:
+            assert row["Unit"] == "°C", f"Temperature '{row['Name']}' missing °C unit"
+
+    def test_temperatures_have_modbus_addresses(self):
+        """Temperature rows should have register addresses."""
+        temp_rows = self._rows_by_category("Temperature")
+        for row in temp_rows:
+            addr = row["Modbus Address"]
+            assert addr.isdigit(), f"Temperature '{row['Name']}' has non-numeric address: {addr}"
+
+    def test_setpoints_present(self):
+        """Should have cooling, heating, and hot water setpoints."""
+        setpoint_rows = self._rows_by_category("Setpoint")
+        names = [r["Name"] for r in setpoint_rows]
+        assert len(setpoint_rows) >= 3, f"Expected at least 3 setpoints, got {len(setpoint_rows)}"
+
+    def test_readings_have_units(self):
+        """System readings should have appropriate units."""
+        reading_rows = self._rows_by_category("Reading")
+        assert len(reading_rows) >= 5, "Expected at least 5 system readings"
+        # At least some should have units
+        with_units = [r for r in reading_rows if r["Unit"]]
+        assert len(with_units) >= 3, "Most readings should have units"
+
+    def test_status_bits_have_values(self):
+        """Status rows should have On/Off values."""
+        status_rows = self._rows_by_category("Status")
+        assert len(status_rows) >= 10, "Expected at least 10 status bits"
+        for row in status_rows:
+            assert row["Value"] in ("ON", "OFF"), (
+                f"Status '{row['Name']}' has unexpected value: {row['Value']}"
+            )
+
+    def test_register_rows_have_hex_values(self):
+        """Raw register rows should contain hex values."""
+        reg_rows = self._rows_by_category("Register")
+        assert len(reg_rows) >= 2, "Expected at least 2 raw register rows"
+        for row in reg_rows:
+            val = row["Value"]
+            assert val.startswith("0x"), f"Register value should be hex: {val}"
+
+    def test_parameters_have_pcodes(self):
+        """Parameter rows should have P-codes (e.g. P29, P37)."""
+        param_rows = self._rows_by_category("Parameter")
+        assert len(param_rows) >= 10, "Expected at least 10 parameters"
+        for row in param_rows:
+            assert row["P-Code"].startswith("P"), (
+                f"Parameter '{row['Name']}' missing P-code: {row['P-Code']}"
+            )
+
+    def test_parameters_have_modbus_addresses(self):
+        param_rows = self._rows_by_category("Parameter")
+        for row in param_rows:
+            addr = row["Modbus Address"]
+            assert addr.isdigit(), f"Parameter '{row['Name']}' has non-numeric address: {addr}"
+
+
+# ── Error Injection ───────────────────────────────────────────────────────
+
+
+class TestDiagnosticErrors:
+    """Verify error reporting in the diagnostic CSV."""
+
+    def test_errors_appear_when_injected(self):
+        """Injecting error1 bit should produce Error rows in CSV."""
+        _inject_demo({"error1": 1})  # Bit 0 = E01
+        time.sleep(0.5)
+
+        try:
+            r = _get("/api/heatpump/diagnostic")
+            text = r.content.decode("utf-8-sig")
+            rows = _parse_csv(text)
+            error_rows = [r for r in rows if r["Category"] == "Error"]
+            assert len(error_rows) >= 1, "Expected at least 1 error row after injection"
+
+            # The error row should have an Arctic error code in P-Code column
+            codes = [r["P-Code"] for r in error_rows if r["P-Code"]]
+            assert len(codes) >= 1, "Error rows should have Arctic error codes"
+        finally:
+            _inject_demo({"error1": 0, "error2": 0})
+            time.sleep(0.3)
+
+    def test_no_errors_when_clear(self):
+        """With no errors injected, Error category should be absent or empty."""
+        _inject_demo({"error1": 0, "error2": 0})
+        time.sleep(0.3)
+
+        r = _get("/api/heatpump/diagnostic")
+        text = r.content.decode("utf-8-sig")
+        rows = _parse_csv(text)
+        error_rows = [r for r in rows if r["Category"] == "Error"]
+        # It's acceptable to have zero error rows when no errors active
+        assert len(error_rows) == 0, (
+            f"Expected no error rows when errors cleared, got {len(error_rows)}"
+        )
+
+
+# ── Authentication ────────────────────────────────────────────────────────
+
+
+def _enable_api_auth():
+    """Enable API auth on the device."""
+    requests.post(
+        f"{BASE_URL}/api/auth/config",
+        headers=_headers(),
+        json={"web_auth_enabled": True},
+        timeout=5,
+    )
+    time.sleep(0.5)
+
+
+def _disable_api_auth():
+    """Disable API auth on the device."""
+    requests.post(
+        f"{BASE_URL}/api/auth/config",
+        headers=_headers(),
+        json={"web_auth_enabled": False},
+        timeout=5,
+    )
+    time.sleep(0.5)
+
+
+class TestDiagnosticAuth:
+    """Diagnostic endpoint should require authentication when auth is enabled."""
+
+    def test_no_auth_returns_401(self):
+        """Request without API key should be rejected when auth is enabled."""
+        _enable_api_auth()
+        try:
+            r = requests.get(
+                f"{BASE_URL}/api/heatpump/diagnostic",
+                timeout=10,
+            )
+            assert r.status_code == 401
+        finally:
+            _disable_api_auth()
+
+    def test_bad_api_key_returns_401(self):
+        """Request with wrong API key should be rejected when auth is enabled."""
+        _enable_api_auth()
+        try:
+            r = requests.get(
+                f"{BASE_URL}/api/heatpump/diagnostic",
+                headers={"X-API-Key": "wrong-key-12345"},
+                timeout=10,
+            )
+            assert r.status_code == 401
+        finally:
+            _disable_api_auth()
+
+
+# ── Idempotency ───────────────────────────────────────────────────────────
+
+
+class TestDiagnosticIdempotency:
+    """Multiple downloads should produce consistent results."""
+
+    def test_two_downloads_same_structure(self):
+        """Two consecutive downloads should have the same categories and row count."""
+        r1 = _get("/api/heatpump/diagnostic")
+        r2 = _get("/api/heatpump/diagnostic")
+
+        rows1 = _parse_csv(r1.content.decode("utf-8-sig"))
+        rows2 = _parse_csv(r2.content.decode("utf-8-sig"))
+
+        cats1 = {r["Category"] for r in rows1}
+        cats2 = {r["Category"] for r in rows2}
+        assert cats1 == cats2, "Categories should be identical across downloads"
+
+        # Row count should be the same (values may differ slightly due to timing)
+        assert len(rows1) == len(rows2), (
+            f"Row count changed between downloads: {len(rows1)} vs {len(rows2)}"
+        )

--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -138,7 +138,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`device_client.py`](device_client.py) | Python HTTP client wrapping all 19 test endpoints + production API |
 | [`openapi-test.yaml`](openapi-test.yaml) | OpenAPI 3.0 spec for the test instrumentation API |
 
-### Test Files (243 UI tests + 9 screenshot API tests + 254 REST API tests + 53 web tests + API contract tests)
+### Test Files (243 UI tests + 9 screenshot API tests + 286 REST API tests + 55 web tests + API contract tests)
 
 | File | Tests | Description |
 |------|-------|-------------|
@@ -170,6 +170,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`../api/test_auth_api.py`](../api/test_auth_api.py) | 17 | Auth config, login/logout sessions, API key management, auth enforcement |
 | [`../api/test_session_api.py`](../api/test_session_api.py) | 23 | Session lifecycle: login/logout, concurrent (max 4), credential changes, auth toggle |
 | [`../api/test_ota_api.py`](../api/test_ota_api.py) | 41 | OTA safety: URL allowlist, bad uploads, auth enforcement, releases, error state, schema |
+| [`../api/test_diagnostic_api.py`](../api/test_diagnostic_api.py) | 32 | Diagnostic CSV download: format, BOM, headers, categories, content, error injection, auth, idempotency |
 | [`../api/test_events_and_misc_api.py`](../api/test_events_and_misc_api.py) | 50 | Events, health, status, time config (round-trip), OTA status, time sync, WiFi, info, display brightness, preferences |
 | [`../web/test_dashboard.py`](../web/test_dashboard.py) | — | Web dashboard: page load, real-time updates, temperature displays, controls |
 | [`../web/test_navigation.py`](../web/test_navigation.py) | — | Web navigation: tab switching, responsive layout, scroll behavior |

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -17,7 +17,7 @@ class TestSettingsCards:
         """All 6 settings cards are rendered."""
         _go_to_settings(dashboard_page)
         cards = dashboard_page.locator(".card")
-        assert cards.count() >= 6, f"Expected at least 6 settings cards, got {cards.count()}"
+        assert cards.count() >= 7, f"Expected at least 7 settings cards, got {cards.count()}"
 
     def test_device_info_card(self, dashboard_page: Page):
         """Device Info card shows version, platform, free heap, uptime."""
@@ -105,6 +105,22 @@ class TestFirmwareSettings:
         _go_to_settings(dashboard_page)
         file_input = dashboard_page.locator("input[type='file'][accept='.bin']")
         assert file_input.count() == 1
+
+
+class TestDiagnosticsSettings:
+    """Diagnostics card in Settings."""
+
+    def test_diagnostics_card_visible(self, dashboard_page: Page):
+        """Diagnostics card is present on Settings page."""
+        _go_to_settings(dashboard_page)
+        link = dashboard_page.locator("a[href='/api/heatpump/diagnostic']")
+        expect(link).to_be_visible()
+
+    def test_diagnostics_download_link_href(self, dashboard_page: Page):
+        """Download link points to the diagnostic CSV endpoint."""
+        _go_to_settings(dashboard_page)
+        link = dashboard_page.locator("a[href='/api/heatpump/diagnostic']")
+        assert link.get_attribute("href") == "/api/heatpump/diagnostic"
 
 
 class TestSystemSettings:


### PR DESCRIPTION
## Summary

Adds a new **Diagnostic Report** feature that downloads a complete CSV snapshot of the heat pump system state — designed for support and troubleshooting.

## Changes

### New Endpoint: \GET /api/heatpump/diagnostic\
- Streams a CSV file via chunked HTTP transfer (memory-efficient)
- Timestamped filename: \rctic-diagnostic-20250101-120000.csv\
- UTF-8 BOM prefix for proper Excel encoding (avoids \Â°C\ rendering)
- Requires API key or session cookie authentication

### CSV Sections
| Category | Content |
|----------|---------|
| **System** | Connection, demo mode, power, operating mode |
| **Temperature** | All 9 sensor readings with register addresses |
| **Setpoint** | Cooling, heating, hot water targets |
| **Reading** | Compressor freq, fan RPM, voltages, currents, pressures, EEV, power |
| **Status** | 27 component status bits (On/Off) from registers 2135-2136 |
| **Register** | Raw hex values of status and error registers |
| **Error** | Active errors with Arctic codes (E01, P19, r02, etc.) from ErrorDef arrays |
| **Parameter** | All P-parameters with P-code, register address, current value, unit |

### Web Dashboard
- New **Diagnostics** card in Settings tab with download button
- i18n strings added for EN, FR, ES
- Card placed above the Reboot card

### Documentation
- \docs/openapi.yaml\ updated with endpoint spec

### Tests (34 new)
- **32 API tests** (\	ests/api/test_diagnostic_api.py\): response format, UTF-8 BOM, Content-Disposition, CSV parsing, all 8 categories, content validation (units, addresses, P-codes, hex values, status On/Off), error injection, auth enforcement, idempotency
- **2 web tests** (\	ests/web/test_settings.py\): diagnostics card visibility, download link href

## Files Changed
- \main/api_server.cpp\ — endpoint handler + registration (+196 lines)
- \main/web/index.html\ — diagnostics card + i18n strings
- \docs/openapi.yaml\ — endpoint documentation
- \	ests/api/test_diagnostic_api.py\ — new test file (32 tests)
- \	ests/web/test_settings.py\ — 2 new tests + card count bump
- \	ests/device/README.md\ — test count update (254 → 286 API tests)