### PR TITLE
fix(test): add retry-enabled sessions to all API test helpers

### DIFF
--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -16,6 +16,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -28,6 +30,13 @@ API_KEY = os.environ.get("ARCTIC_API_KEY")
 USERNAME = os.environ.get("ARCTIC_USERNAME", "arctic")
 PASSWORD = os.environ.get("ARCTIC_PASSWORD", "arctic")
 
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
 
 def _headers(api_key=None):
     h = {}
@@ -38,12 +47,12 @@ def _headers(api_key=None):
 
 
 def _get(path, **kwargs):
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _post(path, json=None, headers=None, **kwargs):
     h = headers if headers is not None else _headers()
-    return requests.post(f"{BASE_URL}{path}", headers=h, json=json, timeout=10, **kwargs)
+    return _session.post(f"{BASE_URL}{path}", headers=h, json=json, timeout=10, **kwargs)
 
 
 def _enable_web_auth():

--- a/tests/api/test_diagnostic_api.py
+++ b/tests/api/test_diagnostic_api.py
@@ -19,6 +19,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -28,6 +30,13 @@ if _env_file.exists():
 
 BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
 API_KEY = os.environ.get("ARCTIC_API_KEY")
+
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
 
 # Expected CSV categories emitted by the diagnostic endpoint
 EXPECTED_CATEGORIES = [
@@ -58,7 +67,7 @@ def _headers(api_key=None):
 
 def _get(path, **kwargs):
     """Authenticated GET helper."""
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _inject_demo(fields: dict):

--- a/tests/api/test_events_and_misc_api.py
+++ b/tests/api/test_events_and_misc_api.py
@@ -22,6 +22,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -32,6 +34,13 @@ if _env_file.exists():
 BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
 API_KEY = os.environ.get("ARCTIC_API_KEY")
 
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
 
 def _headers():
     h = {}
@@ -41,15 +50,15 @@ def _headers():
 
 
 def _get(path, **kwargs):
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _post(path, json=None, **kwargs):
-    return requests.post(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
+    return _session.post(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
 
 
 def _delete(path):
-    return requests.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10)
+    return _session.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -20,6 +20,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -31,6 +33,13 @@ BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
 API_KEY = os.environ.get("ARCTIC_API_KEY")
 
 VALID_MODES = ["cooling", "floor_heating", "fan_coil_heating", "hot_water", "auto"]
+
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
 
 
 def _headers(api_key=None):
@@ -44,29 +53,29 @@ def _headers(api_key=None):
 
 def _get(path, **kwargs):
     """Authenticated GET helper."""
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _put(path, json=None, data=None, **kwargs):
     """Authenticated PUT helper."""
-    return requests.put(
+    return _session.put(
         f"{BASE_URL}{path}", headers=_headers(), json=json, data=data, timeout=10, **kwargs
     )
 
 
 def _patch(path, json=None, **kwargs):
     """Authenticated PATCH helper."""
-    return requests.patch(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
+    return _session.patch(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
 
 
 def _post(path, json=None, **kwargs):
     """Authenticated POST helper."""
-    return requests.post(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
+    return _session.post(f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs)
 
 
 def _delete(path, **kwargs):
     """Authenticated DELETE helper."""
-    return requests.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _inject_demo(fields: dict):

--- a/tests/api/test_logs_api.py
+++ b/tests/api/test_logs_api.py
@@ -15,6 +15,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -25,6 +27,13 @@ if _env_file.exists():
 BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
 API_KEY = os.environ.get("ARCTIC_API_KEY")
 
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
 
 def _headers():
     h = {}
@@ -34,11 +43,11 @@ def _headers():
 
 
 def _get(path, **kwargs):
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _delete(path):
-    return requests.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10)
+    return _session.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -19,6 +19,8 @@ import time
 import pytest
 import requests
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Load .env from repo root if present (local dev)
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -29,6 +31,13 @@ if _env_file.exists():
 BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
 API_KEY = os.environ.get("ARCTIC_API_KEY")
 
+# Retry-enabled session for all API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
 
 def _headers():
     h = {}
@@ -38,11 +47,11 @@ def _headers():
 
 
 def _get(path, **kwargs):
-    return requests.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
+    return _session.get(f"{BASE_URL}{path}", headers=_headers(), timeout=10, **kwargs)
 
 
 def _post(path, json=None, **kwargs):
-    return requests.post(
+    return _session.post(
         f"{BASE_URL}{path}", headers=_headers(), json=json, timeout=10, **kwargs
     )
 
@@ -51,7 +60,7 @@ def _post_raw(path, data=None, content_type="application/octet-stream", **kwargs
     """POST with raw binary data (for firmware upload tests)."""
     h = _headers()
     h["Content-Type"] = content_type
-    return requests.post(
+    return _session.post(
         f"{BASE_URL}{path}", headers=h, data=data, timeout=30, **kwargs
     )
 

--- a/tests/device/test_screenshot_api.py
+++ b/tests/device/test_screenshot_api.py
@@ -16,6 +16,8 @@ import time
 
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Device URL and API key from environment
 ARCTIC_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
@@ -26,6 +28,13 @@ EXPECTED_WIDTH = 720
 EXPECTED_HEIGHT = 1280
 
 # PNG magic bytes
+# Retry-enabled session for API calls
+_session = requests.Session()
+_retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
+               status_forcelist=[502, 503, 504])
+_session.mount("http://", HTTPAdapter(max_retries=_retry))
+_session.mount("https://", HTTPAdapter(max_retries=_retry))
+
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -39,7 +48,7 @@ def _api_headers(api_key: str = API_KEY) -> dict:
 
 def _get_screenshot(api_key: str = API_KEY) -> requests.Response:
     """Fetch a screenshot from the production endpoint."""
-    return requests.get(
+    return _session.get(
         f"{ARCTIC_URL}/api/screenshot",
         headers=_api_headers(api_key),
         timeout=30.0,


### PR DESCRIPTION
API test helpers used bare requests calls with no retry. Transient ConnectTimeout errors in test bodies caused CI failures (test_fan_speed_medium, test_idle_state_values).

Adds a module-level requests.Session with urllib3 Retry adapter (3 retries, exponential backoff) to each API test file, matching the pattern already used in DeviceClient.

Files changed: 7 API/device test files.