### PR TITLE
fix(modbus): derive unit_on from STATUS_1 register instead of command register

### DIFF
--- a/main/modbus/arctic_heatpump.cpp
+++ b/main/modbus/arctic_heatpump.cpp
@@ -73,6 +73,12 @@ static esp_err_t writeSingleReg(uint16_t address, uint16_t value) {
     if (s_demo_mode) {
         uint16_t offset = address - DEMO_REG_BASE;
         s_demo_regs[offset] = value;
+        // Simulate heat pump acking power command via STATUS_1 bit 0
+        if (address == reg::UNIT_ON_OFF) {
+            uint16_t& st1 = s_demo_regs[reg::STATUS_1 - DEMO_REG_BASE];
+            if (value) st1 |= status1::UNIT_ON;
+            else       st1 &= ~status1::UNIT_ON;
+        }
         return ESP_OK;
     }
     return modbus::writeSingleRegister(SLAVE_ADDRESS, address, value);
@@ -88,7 +94,7 @@ static bool pollHoldingRegisters() {
     }
     
     xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-    s_state.unit_on = (data[0] != 0);
+    // unit_on is derived from STATUS_1 bit 0 in pollStatus(), not from the command register
     s_state.working_mode = static_cast<WorkingMode>(data[1]);
     s_state.cooling_setpoint = static_cast<int16_t>(data[2]);
     s_state.heating_setpoint = static_cast<int16_t>(data[3]);
@@ -166,6 +172,7 @@ static bool pollStatus() {
     s_state.status2 = data[1];  // 2136
     s_state.error1 = data[2];   // 2137
     s_state.error2 = data[3];   // 2138
+    s_state.unit_on = (s_state.status1 & status1::UNIT_ON) != 0;
     xSemaphoreGive(s_state_mutex);
     
     return true;
@@ -469,9 +476,7 @@ bool isConnected() {
 bool setUnitPower(bool on) {
     esp_err_t err = writeSingleReg(reg::UNIT_ON_OFF, on ? 1 : 0);
     if (err == ESP_OK) {
-        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-        s_state.unit_on = on;
-        xSemaphoreGive(s_state_mutex);
+        // unit_on will update from STATUS_1 on next pollStatus() cycle
         ESP_LOGI(TAG, "Unit power set to %s", on ? "ON" : "OFF");
         return true;
     }

--- a/main/modbus/arctic_heatpump.cpp
+++ b/main/modbus/arctic_heatpump.cpp
@@ -692,6 +692,14 @@ bool setDemoField(const char* field, int32_t value) {
     else return false;
     
     s_demo_regs[addr - DEMO_REG_BASE] = (uint16_t)value;
+    
+    // Mirror UNIT_ON_OFF to STATUS_1 bit 0 (same as writeSingleReg)
+    if (addr == reg::UNIT_ON_OFF) {
+        uint16_t& st1 = s_demo_regs[reg::STATUS_1 - DEMO_REG_BASE];
+        if (value) st1 |= status1::UNIT_ON;
+        else       st1 &= ~status1::UNIT_ON;
+    }
+    
     ESP_LOGI(TAG, "[DEMO] Field '%s' (reg %d) set to %ld", field, addr, (long)value);
     return true;
 }

--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -120,8 +120,14 @@ def device() -> DeviceClient:
             client.toggle("demo_mode_switch")
             time.sleep(0.3)
             _return_to_main(client)
-    except Exception:
-        pass  # Best effort — tests will fail with clear errors if demo mode is off
+        # Verify demo mode is actually on
+        prefs = client.get_preferences()
+        if not prefs.get("demo_mode"):
+            pytest.exit("Demo mode could not be enabled — aborting session", returncode=1)
+    except SystemExit:
+        raise  # Let pytest.exit() propagate
+    except Exception as e:
+        pytest.exit(f"Failed to enable demo mode: {e}", returncode=1)
 
     yield client
 


### PR DESCRIPTION
## Problem

The controller determined whether the heat pump was running by reading back holding register 2000 (`UNIT_ON_OFF`) — the command it itself wrote. This masked real-world scenarios:

- **Startup delay**: The heat pump may perform self-checks before confirming it's on
- **Command rejection**: Error lockout could prevent startup, but register 2000 would still show 1
- **State mismatch**: The UI showed the *commanded* state, not the *actual* state

## Fix

Derive `s_state.unit_on` from `STATUS_1` (input register 2135) bit 0 (`UNIT_ON`), which is the heat pump's actual running confirmation.

### Changes in `arctic_heatpump.cpp`:

| Location | Before | After |
|---|---|---|
| `pollHoldingRegisters()` | Set `unit_on` from register 2000 | Skipped — comment explains why |
| `pollStatus()` | Only stored `status1` raw value | Also derives `unit_on` from `status1 & UNIT_ON` |
| `setUnitPower()` | Optimistic update of `unit_on` | Removed — state updates on next `pollStatus()` cycle (~500ms) |
| `writeSingleReg()` (demo) | Wrote register value only | Also mirrors `UNIT_ON_OFF` into `STATUS_1` bit 0 |

## Testing

- Demo mode: power toggle still works (STATUS_1 bit mirroring)
- Real hardware: `unit_on` reflects actual HP state with natural poll latency
