### PR TITLE
fix(test): abort session early if demo mode cannot be enabled

### DIFF
--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -120,8 +120,14 @@ def device() -> DeviceClient:
             client.toggle("demo_mode_switch")
             time.sleep(0.3)
             _return_to_main(client)
-    except Exception:
-        pass  # Best effort — tests will fail with clear errors if demo mode is off
+        # Verify demo mode is actually on
+        prefs = client.get_preferences()
+        if not prefs.get("demo_mode"):
+            pytest.exit("Demo mode could not be enabled — aborting session", returncode=1)
+    except SystemExit:
+        raise  # Let pytest.exit() propagate
+    except Exception as e:
+        pytest.exit(f"Failed to enable demo mode: {e}", returncode=1)
 
     yield client
 


### PR DESCRIPTION
## Problem

The conftest `device` fixture tries to enable demo mode at session start, but wraps the entire attempt in a bare `except: pass`. If the toggle fails for any reason (unexpected screen state, widget not found, timeout), the failure is silently swallowed and the session continues.

This causes **every test that calls `set_demo_fields()`** to fail with a cryptic `403 Demo mode is not enabled` error — 28+ failures/errors that obscure the real root cause.

## Fix

- After toggling, **verify** that `demo_mode` is actually `True` via the preferences API
- If demo mode isn't on, `pytest.exit()` immediately with a clear message
- If an exception occurs during the enable attempt, `pytest.exit()` instead of `pass`
- `SystemExit` (from `pytest.exit()`) is re-raised so it propagates correctly

This turns a cascade of 28 confusing 403 errors into a single, actionable failure message at session start.
