### PR TITLE
fix(test): stop retrying 502 in OTA API tests

### DIFF
--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -34,7 +34,7 @@ API_KEY = os.environ.get("ARCTIC_API_KEY")
 # Retry-enabled session for all API calls
 _session = requests.Session()
 _retry = Retry(total=3, backoff_factor=1, allowed_methods=None,
-               status_forcelist=[502, 503, 504])
+               status_forcelist=[503, 504])
 _session.mount("http://", HTTPAdapter(max_retries=_retry))
 _session.mount("https://", HTTPAdapter(max_retries=_retry))
 


### PR DESCRIPTION
## Problem

`GET /api/ota/releases` returns 502 when the device can't reach GitHub. The tests handle this correctly with `pytest.skip()`:

```python
if r.status_code == 502:
    pytest.skip("Device cannot reach GitHub")
```

But the test session's HTTP client is configured with `status_forcelist=[502, 503, 504]`, which auto-retries 502 responses. After 3 retries, urllib3 raises `MaxRetryError` instead of returning the 502 response. The test never gets to check `r.status_code` because `r` is never assigned.

## Fix

Remove 502 from `status_forcelist`. The device only returns 502 for this one case (upstream GitHub unreachable), and retrying won't help — the condition is persistent, not transient. 503/504 remain for genuine transient errors.
