### PR TITLE
fix(ci): prevent 409 Conflict on badge gist updates

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -269,6 +269,7 @@ jobs:
           label: Device UI Tests
           message: ${{ steps.test_results.outputs.ui_msg }}
           color: ${{ steps.test_results.outputs.ui_color }}
+          forceUpdate: true
 
       - name: Update API Contract Tests badge
         if: always() && steps.test_results.outputs.has_results == 'true'
@@ -280,6 +281,7 @@ jobs:
           label: API Contract Tests
           message: ${{ steps.test_results.outputs.api_msg }}
           color: ${{ steps.test_results.outputs.api_color }}
+          forceUpdate: true
 
       - name: Update Web Dashboard Tests badge
         if: always() && steps.test_results.outputs.has_results == 'true'
@@ -291,3 +293,4 @@ jobs:
           label: Web Dashboard Tests
           message: ${{ steps.test_results.outputs.web_msg }}
           color: ${{ steps.test_results.outputs.web_color }}
+          forceUpdate: true


### PR DESCRIPTION
## Problem

The three badge update steps at the end of the device tests workflow write to the same gist. They run near-simultaneously, and the second/third updates fail with `409 Conflict` because the gist version was bumped by the prior update.

## Fix

Add `forceUpdate: true` to all three `schneegans/dynamic-badges-action` steps. This skips the version check and overwrites regardless, eliminating the race condition.
