### PR TITLE
feat: 3-bar fan speed indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.8.0")
+set(PROJECT_VER "2.9.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/main/heatpump_screen.cpp
+++ b/main/heatpump_screen.cpp
@@ -120,7 +120,7 @@ static struct {
     // Component dots row (Comp | Fan | Pump | Aux)
     lv_obj_t* comp_dot = nullptr;
     lv_obj_t* comp_dot_label = nullptr;
-    lv_obj_t* fan_dot = nullptr;
+    lv_obj_t* fan_bars[3] = {nullptr, nullptr, nullptr};  // 3-bar speed indicator
     lv_obj_t* fan_dot_label = nullptr;
     lv_obj_t* pump_dot = nullptr;
     lv_obj_t* pump_dot_label = nullptr;
@@ -651,8 +651,47 @@ void heatpump_screen_create(lv_obj_t* parent, int y_offset) {
     
     make_dot(dots_row, i18n_get(STR_HP_COMPRESSOR), &state.comp_dot, &state.comp_dot_label);
     lv_obj_set_user_data(state.comp_dot, (void*)"comp_dot");
-    make_dot(dots_row, i18n_get(STR_HP_FAN), &state.fan_dot, &state.fan_dot_label);
-    lv_obj_set_user_data(state.fan_dot, (void*)"fan_dot");
+    // Fan speed bars (3 ascending bars like signal strength)
+    {
+        lv_obj_t* fan_col = lv_obj_create(dots_row);
+        lv_obj_set_size(fan_col, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        lv_obj_set_style_bg_opa(fan_col, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_border_width(fan_col, 0, LV_PART_MAIN);
+        lv_obj_set_style_pad_all(fan_col, 4, LV_PART_MAIN);
+        lv_obj_clear_flag(fan_col, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_set_flex_flow(fan_col, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_style_pad_row(fan_col, 6, LV_PART_MAIN);
+        lv_obj_set_flex_align(fan_col, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_user_data(fan_col, (void*)"fan_speed");
+
+        // Row of 3 bars, bottom-aligned, increasing height
+        lv_obj_t* bar_row = lv_obj_create(fan_col);
+        lv_obj_set_size(bar_row, 24, 18);
+        lv_obj_set_style_bg_opa(bar_row, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_border_width(bar_row, 0, LV_PART_MAIN);
+        lv_obj_set_style_pad_all(bar_row, 0, LV_PART_MAIN);
+        lv_obj_clear_flag(bar_row, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_set_flex_flow(bar_row, LV_FLEX_FLOW_ROW);
+        lv_obj_set_style_pad_column(bar_row, 2, LV_PART_MAIN);
+        lv_obj_set_flex_align(bar_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER);
+
+        static const int bar_heights[] = {8, 13, 18};
+        static const char* bar_tags[] = {"fan_bar_1", "fan_bar_2", "fan_bar_3"};
+        for (int i = 0; i < 3; i++) {
+            state.fan_bars[i] = lv_obj_create(bar_row);
+            lv_obj_set_size(state.fan_bars[i], 6, bar_heights[i]);
+            lv_obj_set_style_radius(state.fan_bars[i], 1, LV_PART_MAIN);
+            lv_obj_set_style_bg_color(state.fan_bars[i], COLOR_INACTIVE, LV_PART_MAIN);
+            lv_obj_set_style_border_width(state.fan_bars[i], 0, LV_PART_MAIN);
+            lv_obj_clear_flag(state.fan_bars[i], LV_OBJ_FLAG_SCROLLABLE);
+            lv_obj_set_user_data(state.fan_bars[i], (void*)bar_tags[i]);
+        }
+
+        state.fan_dot_label = lv_label_create(fan_col);
+        lv_label_set_text(state.fan_dot_label, i18n_get(STR_HP_FAN));
+        lv_obj_set_style_text_font(state.fan_dot_label, UI_FONT_BODY, LV_PART_MAIN);
+        lv_obj_set_style_text_color(state.fan_dot_label, COLOR_TEXT_DIM, LV_PART_MAIN);
+    }
     make_dot(dots_row, i18n_get(STR_HP_PUMP), &state.pump_dot, &state.pump_dot_label);
     lv_obj_set_user_data(state.pump_dot, (void*)"pump_dot");
     make_dot(dots_row, i18n_get(STR_HP_AUX_HEAT), &state.heater_dot, &state.heater_dot_label);
@@ -1002,7 +1041,14 @@ void heatpump_screen_update(void) {
     // COMPONENT DOTS ROW
     // =====================================================================
     set_indicator_active(state.comp_dot, hp.connected && hp.isCompressorRunning(), COLOR_SUCCESS);
-    set_indicator_active(state.fan_dot, hp.connected && hp.isFanRunning(), COLOR_SUCCESS);
+    // Fan speed bars: light up 1/2/3 bars based on speed level
+    {
+        int fan_level = (hp.connected) ? hp.getFanSpeedLevel() : 0;
+        for (int i = 0; i < 3; i++) {
+            lv_color_t c = (i < fan_level) ? COLOR_SUCCESS : COLOR_INACTIVE;
+            lv_obj_set_style_bg_color(state.fan_bars[i], c, LV_PART_MAIN);
+        }
+    }
     set_indicator_active(state.pump_dot, hp.connected && hp.isWaterPumpRunning(), COLOR_ACCENT);
     set_indicator_active(state.heater_dot, hp.connected && hp.isBackupHeaterOn(), COLOR_WARNING);
     

--- a/tests/device/test_main_screen.py
+++ b/tests/device/test_main_screen.py
@@ -180,26 +180,61 @@ class TestComponentDots:
         assert dot.bg_color == COLOR_INACTIVE, \
             f"Compressor dot should be inactive, got bg_color={dot.bg_color}"
 
-    def test_fan_dot_on(self, device: DeviceClient):
-        """Fan running should light the fan dot."""
+    def test_fan_speed_bars_medium(self, device: DeviceClient):
+        """Default demo has FAN_MED — bars 1 and 2 should be green, bar 3 gray."""
         device.set_demo_fields(error1=0, error2=0)
         _wait_for_update()
-        dot = device.find_widget(tag="fan_dot")
-        assert dot is not None, "fan_dot not found"
-        assert dot.bg_color != COLOR_INACTIVE, \
-            f"Fan dot should be active, got bg_color={dot.bg_color}"
+        bar1 = device.find_widget(tag="fan_bar_1")
+        bar2 = device.find_widget(tag="fan_bar_2")
+        bar3 = device.find_widget(tag="fan_bar_3")
+        assert bar1 is not None, "fan_bar_1 not found"
+        assert bar2 is not None, "fan_bar_2 not found"
+        assert bar3 is not None, "fan_bar_3 not found"
+        assert bar1.bg_color != COLOR_INACTIVE, "Bar 1 should be active (med)"
+        assert bar2.bg_color != COLOR_INACTIVE, "Bar 2 should be active (med)"
+        assert bar3.bg_color == COLOR_INACTIVE, "Bar 3 should be inactive (med)"
 
-    def test_fan_dot_off(self, device: DeviceClient):
-        """Fan stopped should grey out the fan dot."""
+    def test_fan_speed_bars_high(self, device: DeviceClient):
+        """FAN_HIGH — all 3 bars should be green."""
+        device.set_demo_fields(
+            error1=0, error2=0,
+            status1=UNIT_ON | COMPRESSOR | FAN_HIGH | WATER_PUMP,
+        )
+        _wait_for_update()
+        bar1 = device.find_widget(tag="fan_bar_1")
+        bar2 = device.find_widget(tag="fan_bar_2")
+        bar3 = device.find_widget(tag="fan_bar_3")
+        assert bar1.bg_color != COLOR_INACTIVE, "Bar 1 should be active (high)"
+        assert bar2.bg_color != COLOR_INACTIVE, "Bar 2 should be active (high)"
+        assert bar3.bg_color != COLOR_INACTIVE, "Bar 3 should be active (high)"
+
+    def test_fan_speed_bars_low(self, device: DeviceClient):
+        """FAN_LOW — only bar 1 should be green."""
+        device.set_demo_fields(
+            error1=0, error2=0,
+            status1=UNIT_ON | COMPRESSOR | FAN_LOW | WATER_PUMP,
+        )
+        _wait_for_update()
+        bar1 = device.find_widget(tag="fan_bar_1")
+        bar2 = device.find_widget(tag="fan_bar_2")
+        bar3 = device.find_widget(tag="fan_bar_3")
+        assert bar1.bg_color != COLOR_INACTIVE, "Bar 1 should be active (low)"
+        assert bar2.bg_color == COLOR_INACTIVE, "Bar 2 should be inactive (low)"
+        assert bar3.bg_color == COLOR_INACTIVE, "Bar 3 should be inactive (low)"
+
+    def test_fan_speed_bars_off(self, device: DeviceClient):
+        """No FAN bits — all 3 bars should be gray."""
         device.set_demo_fields(
             error1=0, error2=0,
             status1=UNIT_ON | COMPRESSOR | WATER_PUMP,  # no FAN bits
         )
         _wait_for_update()
-        dot = device.find_widget(tag="fan_dot")
-        assert dot is not None
-        assert dot.bg_color == COLOR_INACTIVE, \
-            f"Fan dot should be inactive, got bg_color={dot.bg_color}"
+        bar1 = device.find_widget(tag="fan_bar_1")
+        bar2 = device.find_widget(tag="fan_bar_2")
+        bar3 = device.find_widget(tag="fan_bar_3")
+        assert bar1.bg_color == COLOR_INACTIVE, "Bar 1 should be inactive (off)"
+        assert bar2.bg_color == COLOR_INACTIVE, "Bar 2 should be inactive (off)"
+        assert bar3.bg_color == COLOR_INACTIVE, "Bar 3 should be inactive (off)"
 
     def test_pump_dot_on(self, device: DeviceClient):
         """Water pump running should light the pump dot."""


### PR DESCRIPTION
## Fan Speed Indicator

Replace the simple on/off fan dot with a 3-bar signal-strength style indicator that shows the current fan speed level at a glance.

### Visual

| Speed | Bars lit |
|-------|---------|
| Off | all gray |
| Low | 1 green |
| Medium | 2 green |
| High | 3 green |

Three ascending vertical bars (8/13/18px tall), bottom-aligned, using green for active and gray for off.

### Changes

- **main/heatpump_screen.cpp** - Replace fan_dot with fan_bars[3] in state, creation, and update logic
- **tests/device/test_main_screen.py** - Replace 2 on/off dot tests with 4 speed-level tests (off/low/med/high)
- **CMakeLists.txt** - Bump version to 2.9.0

### Widget tags
- fan_speed - container
- fan_bar_1, fan_bar_2, fan_bar_3 - individual bars

### Notes
- No API changes, OpenAPI specs unchanged
- Versioned at 2.9.0