### PR TITLE
ci: USB serial flashing with WiFi provisioning for device tests

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -282,21 +282,18 @@ jobs:
       # - name: Run device UI tests
       #   id: ui_tests
       #   run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
-      #   env:
-      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
 
       # - name: Run Modbus E2E tests
       #   id: modbus_tests
       #   run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
       #   env:
-      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
       #     SIMULATOR_URL: http://arctic-simulator-ghr.mi
 
       - name: Run API contract tests
         id: api_tests
         run: python -m pytest tests/api/ -v --tb=short --junitxml=api-test-results.xml -p no:cacheprovider
         env:
-          ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
+          # ARCTIC_API_KEY is set via $GITHUB_ENV by the "Sync API key" step
           ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
           ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
           HYPOTHESIS_PROFILE: ci
@@ -312,7 +309,6 @@ jobs:
       #   id: web_tests
       #   run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
       #   env:
-      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
       #     ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
       #     ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
       #     TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -226,18 +226,19 @@ jobs:
             echo "Device does not support HTTPS — keeping $ARCTIC_URL"
           fi
 
-      - name: Run device UI tests
-        id: ui_tests
-        run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
-        env:
-          ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
+      # TEMPORARILY DISABLED — UI tests pass (268/268), skip to speed up API fix iteration
+      # - name: Run device UI tests
+      #   id: ui_tests
+      #   run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
+      #   env:
+      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
 
-      - name: Run Modbus E2E tests
-        id: modbus_tests
-        run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
-        env:
-          ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
-          SIMULATOR_URL: http://arctic-simulator-ghr.mi
+      # - name: Run Modbus E2E tests
+      #   id: modbus_tests
+      #   run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
+      #   env:
+      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
+      #     SIMULATOR_URL: http://arctic-simulator-ghr.mi
 
       - name: Run API contract tests
         id: api_tests
@@ -249,20 +250,21 @@ jobs:
           HYPOTHESIS_PROFILE: ci
           PYTHONDONTWRITEBYTECODE: '1'
 
-      - name: Install Playwright for web tests
-        run: |
-          pip install -r tests/web/requirements.txt
-          playwright install chromium
+      # TEMPORARILY DISABLED — skip web tests to speed up API fix iteration
+      # - name: Install Playwright for web tests
+      #   run: |
+      #     pip install -r tests/web/requirements.txt
+      #     playwright install chromium
 
-      - name: Run web dashboard tests
-        id: web_tests
-        run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
-        env:
-          ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
-          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
-          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
-          TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}
-          TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
+      # - name: Run web dashboard tests
+      #   id: web_tests
+      #   run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
+      #   env:
+      #     ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
+      #     ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
+      #     ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
+      #     TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}
+      #     TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
 
       - name: Publish UI test results
         uses: dorny/test-reporter@v1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -225,18 +225,25 @@ jobs:
           # The device may have a randomly-generated API key (fresh flash without
           # NVS provisioning, or pre-existing device).  Read the actual key from
           # the device and override the env var so tests use the correct value.
+          #
+          # We disable errexit inside the probe functions because curl/python
+          # will fail for unreachable URLs (e.g. HTTPS when TLS isn't active).
           get_key() {
-            curl -sk --connect-timeout 3 --max-time 5 "$1/api/auth/key" 2>/dev/null \
-              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null
+            local RESULT
+            RESULT=$(curl -sk --connect-timeout 3 --max-time 5 "$1/api/auth/key" 2>/dev/null \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+            echo "$RESULT"
           }
           get_key_via_session() {
             local URL=$1
-            local JAR=$(mktemp)
+            local JAR
+            JAR=$(mktemp)
             curl -sk -c "$JAR" -X POST "$URL/login" \
               -H "Content-Type: application/json" \
-              -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1
-            local KEY=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null \
-              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null)
+              -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
+            local KEY
+            KEY=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
             rm -f "$JAR"
             echo "$KEY"
           }
@@ -244,9 +251,9 @@ jobs:
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           DEVICE_KEY=""
           for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
-            DEVICE_KEY=$(get_key "$URL")
+            DEVICE_KEY=$(get_key "$URL") || true
             if [ -z "$DEVICE_KEY" ]; then
-              DEVICE_KEY=$(get_key_via_session "$URL")
+              DEVICE_KEY=$(get_key_via_session "$URL") || true
             fi
             if [ -n "$DEVICE_KEY" ]; then
               break

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -172,13 +172,17 @@ jobs:
         run: |
           echo "OTA failed, falling back to USB serial flash..."
 
-          # Generate NVS partition with WiFi credentials so the device can auto-connect
-          echo "Generating NVS partition with WiFi credentials..."
+          # Generate NVS partition with WiFi credentials + API key so the device can auto-connect
+          # and tests can authenticate.  The "auth" namespace pre-seeds the API key so
+          # auth_mgr_init() uses it instead of generating a random one.
+          echo "Generating NVS partition with WiFi credentials and API key..."
           cat > /tmp/nvs_wifi.csv << 'CSVHEADER'
           key,type,encoding,value
           wifi_creds,namespace,,
           ssid,data,string,${WIFI_SSID}
           password,data,string,${WIFI_PASSWORD}
+          auth,namespace,,
+          api_key,data,string,${ARCTIC_API_KEY}
           CSVHEADER
           # Strip leading whitespace from heredoc
           sed -i 's/^[[:space:]]*//' /tmp/nvs_wifi.csv
@@ -198,6 +202,7 @@ jobs:
         env:
           WIFI_SSID: ${{ secrets.MI_WIFI_SSID }}
           WIFI_PASSWORD: ${{ secrets.MI_WIFI_PASSWORD }}
+          ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
 
       - name: Wait for device boot (USB)
         if: steps.ota_flash.outcome == 'failure'
@@ -214,6 +219,53 @@ jobs:
           done
           echo "Device did not come back online within 60s"
           exit 1
+
+      - name: Sync API key from device
+        run: |
+          # The device may have a randomly-generated API key (fresh flash without
+          # NVS provisioning, or pre-existing device).  Read the actual key from
+          # the device and override the env var so tests use the correct value.
+          get_key() {
+            curl -sk --connect-timeout 3 --max-time 5 "$1/api/auth/key" 2>/dev/null \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null
+          }
+          get_key_via_session() {
+            local URL=$1
+            local JAR=$(mktemp)
+            curl -sk -c "$JAR" -X POST "$URL/login" \
+              -H "Content-Type: application/json" \
+              -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1
+            local KEY=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null)
+            rm -f "$JAR"
+            echo "$KEY"
+          }
+
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          DEVICE_KEY=""
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            DEVICE_KEY=$(get_key "$URL")
+            if [ -z "$DEVICE_KEY" ]; then
+              DEVICE_KEY=$(get_key_via_session "$URL")
+            fi
+            if [ -n "$DEVICE_KEY" ]; then
+              break
+            fi
+          done
+
+          if [ -n "$DEVICE_KEY" ]; then
+            echo "ARCTIC_API_KEY=$DEVICE_KEY" >> $GITHUB_ENV
+            if [ "$DEVICE_KEY" = "$ARCTIC_API_KEY" ]; then
+              echo "Device API key matches secret — no override needed"
+            else
+              echo "Device API key differs from secret — overriding ARCTIC_API_KEY"
+            fi
+          else
+            echo "WARNING: Could not read device API key — tests may fail"
+          fi
+        env:
+          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
+          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
 
       - name: Detect HTTPS support
         run: |

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -116,16 +116,30 @@ jobs:
             exit 1
           fi
 
-          # Try HTTP first, fall back to HTTPS (device may only serve HTTPS when TLS certs are installed)
+          # Quick connectivity check — bail fast if device isn't actually responding
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          DEVICE_REACHABLE=false
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            if curl -sk --connect-timeout 3 --max-time 5 "$URL/api/health" > /dev/null 2>&1; then
+              DEVICE_REACHABLE=true
+              echo "Device responding at $URL"
+              break
+            fi
+          done
+          if [ "$DEVICE_REACHABLE" = "false" ]; then
+            echo "ERROR: Device resolved but not responding on HTTP or HTTPS"
+            exit 1
+          fi
+
+          # Try HTTP first, fall back to HTTPS (device may only serve HTTPS when TLS certs are installed)
           for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
             echo "Trying $URL/api/ota/upload ..."
             HTTP_CODE=$(curl -skL -o /tmp/ota_response.txt -w "%{http_code}" \
               -X POST \
               -H "Content-Type: application/octet-stream" \
               -H "X-API-Key: ${{ secrets.ARCTIC_API_KEY }}" \
-              --connect-timeout 10 \
-              --max-time 120 \
+              --connect-timeout 5 \
+              --max-time 30 \
               --data-binary @build/arctic_controller.bin \
               "$URL/api/ota/upload") || true
             echo "Response ($URL): HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt)"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -157,28 +157,48 @@ jobs:
         if: steps.ota_flash.outcome == 'failure'
         run: |
           echo "OTA failed, falling back to USB serial flash..."
-          esptool.py --port /dev/ttyUSB0 --baud 921600 --chip esp32p4 \
+
+          # Generate NVS partition with WiFi credentials so the device can auto-connect
+          echo "Generating NVS partition with WiFi credentials..."
+          cat > /tmp/nvs_wifi.csv << 'CSVHEADER'
+          key,type,encoding,value
+          wifi_creds,namespace,,
+          ssid,data,string,${WIFI_SSID}
+          password,data,string,${WIFI_PASSWORD}
+          CSVHEADER
+          # Strip leading whitespace from heredoc
+          sed -i 's/^[[:space:]]*//' /tmp/nvs_wifi.csv
+          # Substitute env vars
+          envsubst < /tmp/nvs_wifi.csv > /tmp/nvs_wifi_resolved.csv
+          python3 -m esp_idf_nvs_partition_gen generate \
+            /tmp/nvs_wifi_resolved.csv /tmp/nvs_wifi.bin 0x6000
+
+          esptool.py --port /dev/ttyACM0 --baud 921600 --chip esp32p4 \
             --before default_reset --after hard_reset \
             write_flash --flash_mode dio --flash_size 16MB --flash_freq 80m \
             0x2000  build/bootloader/bootloader.bin \
             0x8000  build/partition_table/partition-table.bin \
+            0x9000  /tmp/nvs_wifi.bin \
             0xf000  build/ota_data_initial.bin \
             0x20000 build/arctic_controller.bin
+        env:
+          WIFI_SSID: ${{ secrets.MI_WIFI_SSID }}
+          WIFI_PASSWORD: ${{ secrets.MI_WIFI_PASSWORD }}
 
       - name: Wait for device boot (USB)
         if: steps.ota_flash.outcome == 'failure'
         run: |
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           sleep 15
-          for i in $(seq 1 30); do
+          for i in $(seq 1 45); do
             if curl -skL --connect-timeout 2 "$ARCTIC_URL/api/heatpump/status" > /dev/null 2>&1 || \
                curl -skL --connect-timeout 2 "$ARCTIC_URL_HTTPS/api/heatpump/status" > /dev/null 2>&1; then
-              echo "Device is back online"
+              echo "Device is back online after $((i + 15))s"
               exit 0
             fi
             sleep 1
           done
-          echo "Device did not come back online within 45s"
+          echo "Device did not come back online within 60s"
           exit 1
 
       - name: Detect HTTPS support

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -230,20 +230,15 @@ jobs:
           DEVICE_KEY=""
 
           for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
-            echo "Trying $URL/api/auth/apikey (unauthenticated)..."
             RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
-            echo "  Response: $RESP"
             DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
 
             if [ -z "$DEVICE_KEY" ]; then
-              echo "  Unauthenticated attempt failed, trying session login..."
               JAR=$(mktemp)
-              LOGIN_RESP=$(curl -sk -c "$JAR" -X POST "$URL/login" \
+              curl -sk -c "$JAR" -X POST "$URL/login" \
                 -H "Content-Type: application/json" \
-                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" 2>/dev/null) || true
-              echo "  Login response: $LOGIN_RESP"
+                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
               RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
-              echo "  Key response (with session): $RESP"
               DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
               rm -f "$JAR"
             fi
@@ -278,16 +273,15 @@ jobs:
             echo "Device does not support HTTPS — keeping $ARCTIC_URL"
           fi
 
-      # TEMPORARILY DISABLED — UI tests pass (268/268), skip to speed up API fix iteration
-      # - name: Run device UI tests
-      #   id: ui_tests
-      #   run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
+      - name: Run device UI tests
+        id: ui_tests
+        run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
-      # - name: Run Modbus E2E tests
-      #   id: modbus_tests
-      #   run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
-      #   env:
-      #     SIMULATOR_URL: http://arctic-simulator-ghr.mi
+      - name: Run Modbus E2E tests
+        id: modbus_tests
+        run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
+        env:
+          SIMULATOR_URL: http://arctic-simulator-ghr.mi
 
       - name: Run API contract tests
         id: api_tests
@@ -299,20 +293,19 @@ jobs:
           HYPOTHESIS_PROFILE: ci
           PYTHONDONTWRITEBYTECODE: '1'
 
-      # TEMPORARILY DISABLED — skip web tests to speed up API fix iteration
-      # - name: Install Playwright for web tests
-      #   run: |
-      #     pip install -r tests/web/requirements.txt
-      #     playwright install chromium
+      - name: Install Playwright for web tests
+        run: |
+          pip install -r tests/web/requirements.txt
+          playwright install chromium
 
-      # - name: Run web dashboard tests
-      #   id: web_tests
-      #   run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
-      #   env:
-      #     ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
-      #     ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
-      #     TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}
-      #     TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
+      - name: Run web dashboard tests
+        id: web_tests
+        run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
+        env:
+          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
+          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
+          TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}
+          TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
 
       - name: Publish UI test results
         uses: dorny/test-reporter@v1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -237,7 +237,7 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
         env:
           ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
-          SIMULATOR_URL: http://arctic-sim.local
+          SIMULATOR_URL: http://arctic-simulator.mi
 
       - name: Run API contract tests
         id: api_tests

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -230,8 +230,8 @@ jobs:
           DEVICE_KEY=""
 
           for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
-            echo "Trying $URL/api/auth/key (unauthenticated)..."
-            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/key" 2>/dev/null) || true
+            echo "Trying $URL/api/auth/apikey (unauthenticated)..."
+            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
             echo "  Response: $RESP"
             DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
 
@@ -242,7 +242,7 @@ jobs:
                 -H "Content-Type: application/json" \
                 -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" 2>/dev/null) || true
               echo "  Login response: $LOGIN_RESP"
-              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null) || true
+              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
               echo "  Key response (with session): $RESP"
               DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
               rm -f "$JAR"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: [self-hosted, vm-mi]
     timeout-minutes: 120
     env:
-      ARCTIC_URL: http://arctic.local
+      ARCTIC_URL: http://arctic-controller-ghr.mi
 
     steps:
       - name: Checkout code
@@ -237,7 +237,7 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
         env:
           ARCTIC_API_KEY: ${{ secrets.ARCTIC_API_KEY }}
-          SIMULATOR_URL: http://arctic-simulator.mi
+          SIMULATOR_URL: http://arctic-simulator-ghr.mi
 
       - name: Run API contract tests
         id: api_tests

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -94,6 +94,42 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 
+      - name: Sync API key from device (pre-OTA)
+        run: |
+          # Read the device's current API key before OTA so the upload can authenticate.
+          # The device may have a randomly-generated key or one from a previous NVS flash.
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          DEVICE_KEY=""
+
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
+            DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+
+            if [ -z "$DEVICE_KEY" ]; then
+              JAR=$(mktemp)
+              curl -sk -c "$JAR" -X POST "$URL/login" \
+                -H "Content-Type: application/json" \
+                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
+              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
+              DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+              rm -f "$JAR"
+            fi
+
+            if [ -n "$DEVICE_KEY" ]; then
+              break
+            fi
+          done
+
+          if [ -n "$DEVICE_KEY" ]; then
+            echo "ARCTIC_API_KEY=$DEVICE_KEY" >> $GITHUB_ENV
+            echo "Synced API key from device"
+          else
+            echo "Could not read device API key — OTA will use secret"
+          fi
+        env:
+          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
+          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
+
       - name: Flash device via OTA
         id: ota_flash
         continue-on-error: true
@@ -137,7 +173,7 @@ jobs:
             HTTP_CODE=$(curl -skL -o /tmp/ota_response.txt -w "%{http_code}" \
               -X POST \
               -H "Content-Type: application/octet-stream" \
-              -H "X-API-Key: ${{ secrets.ARCTIC_API_KEY }}" \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
               --connect-timeout 5 \
               --max-time 30 \
               --data-binary @build/arctic_controller.bin \
@@ -275,16 +311,19 @@ jobs:
 
       - name: Run device UI tests
         id: ui_tests
+        continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
       - name: Run Modbus E2E tests
         id: modbus_tests
+        continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=modbus-test-results.xml -p no:cacheprovider -m modbus
         env:
           SIMULATOR_URL: http://arctic-simulator-ghr.mi
 
       - name: Run API contract tests
         id: api_tests
+        continue-on-error: true
         run: python -m pytest tests/api/ -v --tb=short --junitxml=api-test-results.xml -p no:cacheprovider
         env:
           # ARCTIC_API_KEY is set via $GITHUB_ENV by the "Sync API key" step
@@ -300,6 +339,7 @@ jobs:
 
       - name: Run web dashboard tests
         id: web_tests
+        continue-on-error: true
         run: python -m pytest tests/web/ -v --tb=short --junitxml=web-test-results.xml
         env:
           ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
@@ -441,3 +481,19 @@ jobs:
           resp = urllib.request.urlopen(req)
           print(f'Gist updated: {resp.status}')
           "
+
+      - name: Fail job if any tests failed
+        if: always()
+        run: |
+          # With continue-on-error on test steps, we need to explicitly fail the job
+          FAILED=false
+          for step_outcome in "${{ steps.ui_tests.outcome }}" "${{ steps.modbus_tests.outcome }}" "${{ steps.api_tests.outcome }}" "${{ steps.web_tests.outcome }}"; do
+            if [ "$step_outcome" = "failure" ]; then
+              FAILED=true
+            fi
+          done
+          if [ "$FAILED" = "true" ]; then
+            echo "One or more test suites failed — see individual results above"
+            exit 1
+          fi
+          echo "All test suites passed"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -225,36 +225,29 @@ jobs:
           # The device may have a randomly-generated API key (fresh flash without
           # NVS provisioning, or pre-existing device).  Read the actual key from
           # the device and override the env var so tests use the correct value.
-          #
-          # We disable errexit inside the probe functions because curl/python
-          # will fail for unreachable URLs (e.g. HTTPS when TLS isn't active).
-          get_key() {
-            local RESULT
-            RESULT=$(curl -sk --connect-timeout 3 --max-time 5 "$1/api/auth/key" 2>/dev/null \
-              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
-            echo "$RESULT"
-          }
-          get_key_via_session() {
-            local URL=$1
-            local JAR
-            JAR=$(mktemp)
-            curl -sk -c "$JAR" -X POST "$URL/login" \
-              -H "Content-Type: application/json" \
-              -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
-            local KEY
-            KEY=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null \
-              | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
-            rm -f "$JAR"
-            echo "$KEY"
-          }
 
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           DEVICE_KEY=""
+
           for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
-            DEVICE_KEY=$(get_key "$URL") || true
+            echo "Trying $URL/api/auth/key (unauthenticated)..."
+            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/key" 2>/dev/null) || true
+            echo "  Response: $RESP"
+            DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+
             if [ -z "$DEVICE_KEY" ]; then
-              DEVICE_KEY=$(get_key_via_session "$URL") || true
+              echo "  Unauthenticated attempt failed, trying session login..."
+              JAR=$(mktemp)
+              LOGIN_RESP=$(curl -sk -c "$JAR" -X POST "$URL/login" \
+                -H "Content-Type: application/json" \
+                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" 2>/dev/null) || true
+              echo "  Login response: $LOGIN_RESP"
+              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/key" 2>/dev/null) || true
+              echo "  Key response (with session): $RESP"
+              DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+              rm -f "$JAR"
             fi
+
             if [ -n "$DEVICE_KEY" ]; then
               break
             fi

--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -59,36 +59,36 @@ def _post(path, json=None, headers=None, **kwargs):
     return _session.post(f"{BASE_URL}{path}", headers=h, json=json, timeout=10, **kwargs)
 
 
-def _enable_web_auth():
+def _auth_config_post(payload: dict):
+    """POST /api/auth/config, falling back to a session login on 401."""
     for attempt in range(3):
         try:
-            requests.post(
+            r = requests.post(
                 f"{BASE_URL}/api/auth/config",
-                json={"web_auth_enabled": True},
+                json=payload,
                 headers=_headers(),
                 timeout=5,
             )
+            if r.status_code == 401:
+                s = requests.Session()
+                s.verify = False
+                s.post(f"{BASE_URL}/login",
+                       json={"username": USERNAME, "password": PASSWORD},
+                       timeout=5)
+                s.post(f"{BASE_URL}/api/auth/config", json=payload, timeout=5)
             return
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             if attempt == 2:
                 raise
             time.sleep(2)
+
+
+def _enable_web_auth():
+    _auth_config_post({"web_auth_enabled": True, "api_auth_enabled": True})
 
 
 def _disable_web_auth():
-    for attempt in range(3):
-        try:
-            requests.post(
-                f"{BASE_URL}/api/auth/config",
-                json={"web_auth_enabled": False},
-                headers=_headers(),
-                timeout=5,
-            )
-            return
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            if attempt == 2:
-                raise
-            time.sleep(2)
+    _auth_config_post({"web_auth_enabled": False, "api_auth_enabled": False})
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/api/test_diagnostic_api.py
+++ b/tests/api/test_diagnostic_api.py
@@ -350,40 +350,38 @@ class TestDiagnosticErrors:
 # ── Authentication ────────────────────────────────────────────────────────
 
 
-def _enable_api_auth():
-    """Enable API auth on the device."""
+def _auth_config_post(payload: dict):
+    """POST /api/auth/config, falling back to a session login on 401."""
     for attempt in range(3):
         try:
-            requests.post(
+            r = requests.post(
                 f"{BASE_URL}/api/auth/config",
                 headers=_headers(),
-                json={"web_auth_enabled": True},
+                json=payload,
                 timeout=5,
             )
+            if r.status_code == 401:
+                s = requests.Session()
+                s.post(f"{BASE_URL}/login",
+                       json={"username": "arctic", "password": "arctic"},
+                       timeout=5)
+                s.post(f"{BASE_URL}/api/auth/config", json=payload, timeout=5)
             time.sleep(0.5)
             return
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             if attempt == 2:
                 raise
             time.sleep(2)
+
+
+def _enable_api_auth():
+    """Enable API auth on the device."""
+    _auth_config_post({"web_auth_enabled": True, "api_auth_enabled": True})
 
 
 def _disable_api_auth():
     """Disable API auth on the device."""
-    for attempt in range(3):
-        try:
-            requests.post(
-                f"{BASE_URL}/api/auth/config",
-                headers=_headers(),
-                json={"web_auth_enabled": False},
-                timeout=5,
-            )
-            time.sleep(0.5)
-            return
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            if attempt == 2:
-                raise
-            time.sleep(2)
+    _auth_config_post({"web_auth_enabled": False, "api_auth_enabled": False})
 
 
 class TestDiagnosticAuth:

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -91,6 +91,29 @@ def _post_raw_no_auth(path, data=None, content_type="application/octet-stream", 
     return requests.post(f"{BASE_URL}{path}", headers=h, data=data, timeout=30, **kwargs)
 
 
+def _auth_config_post(payload: dict):
+    """POST /api/auth/config, falling back to a session login on 401."""
+    for attempt in range(3):
+        try:
+            r = requests.post(
+                f"{BASE_URL}/api/auth/config",
+                json=payload,
+                headers=_headers(),
+                timeout=5,
+            )
+            if r.status_code == 401:
+                s = requests.Session()
+                s.post(f"{BASE_URL}/login",
+                       json={"username": "arctic", "password": "arctic"},
+                       timeout=5)
+                s.post(f"{BASE_URL}/api/auth/config", json=payload, timeout=5)
+            return
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            if attempt == 2:
+                raise
+            time.sleep(2)
+
+
 def _get_with_bad_key(path, **kwargs):
     """GET with an invalid API key."""
     h = {"X-API-Key": "invalid_key_000000000000000000"}
@@ -466,15 +489,18 @@ class TestOtaGithubUpdate:
 class TestOtaAuthEnforcement:
     """Verify OTA endpoints reject invalid API keys.
 
-    Note: check_api_auth allows unauthenticated requests through when
-    web_auth is disabled (local web UI fallback). To reliably test auth
-    enforcement, we send requests with an INVALID API key, which forces
-    the key-validation path regardless of web_auth state.
-
-    The reboot endpoint is tested with extra caution: we verify the
-    invalid-key request is rejected BEFORE asserting the device is
-    still responding.
+    Both ``api_auth_enabled`` and ``web_auth_enabled`` must be true for
+    ``check_api_auth`` to validate API keys.  On a fresh device both
+    default to false, so the setup fixture enables them and teardown
+    restores them.
     """
+
+    @pytest.fixture(autouse=True)
+    def _ensure_api_auth(self):
+        """Enable API + web auth before each test, restore after."""
+        _auth_config_post({"web_auth_enabled": True, "api_auth_enabled": True})
+        yield
+        _auth_config_post({"web_auth_enabled": False, "api_auth_enabled": False})
 
     def test_status_rejects_bad_key(self):
         """GET /api/ota/status with invalid API key → 401."""

--- a/tests/api/test_session_api.py
+++ b/tests/api/test_session_api.py
@@ -96,48 +96,21 @@ def _admin_session(username=None, password=None):
     return s
 
 
-def _enable_web_auth():
-    """Enable web auth.  Only called when web auth is currently OFF,
-    so API-key auth (check_api_auth bypass) is sufficient."""
+def _auth_config_post(payload: dict):
+    """POST /api/auth/config, falling back to a session login on 401."""
     for attempt in range(3):
         try:
-            requests.post(
-                f"{BASE_URL}/api/auth/config",
-                json={"web_auth_enabled": True},
-                headers=_api_headers(),
-                timeout=5,
-            )
-            return
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            if attempt == 2:
-                raise
-            time.sleep(2)
-
-
-def _disable_web_auth():
-    """Disable web auth.  When it is currently ON, admin endpoints require
-    a session cookie — so we log in first.
-    Returns False if blocked (e.g. TLS certs prevent disabling auth)."""
-    for attempt in range(3):
-        try:
-            # Try API-key first (works when web auth is already off)
             r = requests.post(
                 f"{BASE_URL}/api/auth/config",
-                json={"web_auth_enabled": False},
+                json=payload,
                 headers=_api_headers(),
                 timeout=5,
             )
             if r.status_code == 403:
-                # TLS certs provisioned — auth cannot be disabled
                 return False
             if r.status_code == 401:
-                # Web auth is on — use a session
                 s = _admin_session()
-                r2 = s.post(
-                    f"{BASE_URL}/api/auth/config",
-                    json={"web_auth_enabled": False},
-                    timeout=5,
-                )
+                r2 = s.post(f"{BASE_URL}/api/auth/config", json=payload, timeout=5)
                 if r2.status_code == 403:
                     return False
             return True
@@ -145,6 +118,16 @@ def _disable_web_auth():
             if attempt == 2:
                 raise
             time.sleep(2)
+
+
+def _enable_web_auth():
+    """Enable web + API auth so that check_api_auth enforces key validation."""
+    _auth_config_post({"web_auth_enabled": True, "api_auth_enabled": True})
+
+
+def _disable_web_auth():
+    """Disable web + API auth.  Returns False if blocked (e.g. TLS certs)."""
+    return _auth_config_post({"web_auth_enabled": False, "api_auth_enabled": False})
 
 
 def _restore_credentials():

--- a/tests/device/test_screenshot_api.py
+++ b/tests/device/test_screenshot_api.py
@@ -65,6 +65,41 @@ def _get_screenshot(api_key: str = API_KEY) -> requests.Response:
     )
 
 
+def _auth_config_post(payload: dict):
+    """POST /api/auth/config, handling the case where web auth is already on.
+
+    When ``web_auth_enabled`` is already true, the endpoint requires a
+    session cookie (``check_web_auth``), not just an API key.  We try
+    with the API key first; on 401 we log in with default creds and retry.
+    """
+    for attempt in range(3):
+        try:
+            r = requests.post(
+                f"{ARCTIC_URL}/api/auth/config",
+                json=payload,
+                headers=_api_headers(),
+                timeout=5,
+            )
+            if r.status_code == 401:
+                # Web auth is on — need a session cookie
+                s = requests.Session()
+                s.post(
+                    f"{ARCTIC_URL}/login",
+                    json={"username": "arctic", "password": "arctic"},
+                    timeout=5,
+                )
+                s.post(
+                    f"{ARCTIC_URL}/api/auth/config",
+                    json=payload,
+                    timeout=5,
+                )
+            return
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            if attempt == 2:
+                raise
+            time.sleep(2)
+
+
 def _enable_web_auth():
     """Enable web + API auth so that API key enforcement kicks in.
 
@@ -73,36 +108,12 @@ def _enable_web_auth():
     when false), and ``web_auth_enabled`` prevents the "allow local web UI"
     fallback.  On a fresh device both default to false, so we must set both.
     """
-    for attempt in range(3):
-        try:
-            requests.post(
-                f"{ARCTIC_URL}/api/auth/config",
-                json={"web_auth_enabled": True, "api_auth_enabled": True},
-                headers=_api_headers(),
-                timeout=5,
-            )
-            return
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            if attempt == 2:
-                raise
-            time.sleep(2)
+    _auth_config_post({"web_auth_enabled": True, "api_auth_enabled": True})
 
 
 def _disable_web_auth():
     """Disable web + API auth (restore normal test state)."""
-    for attempt in range(3):
-        try:
-            requests.post(
-                f"{ARCTIC_URL}/api/auth/config",
-                json={"web_auth_enabled": False, "api_auth_enabled": False},
-                headers=_api_headers(),
-                timeout=5,
-            )
-            return
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            if attempt == 2:
-                raise
-            time.sleep(2)
+    _auth_config_post({"web_auth_enabled": False, "api_auth_enabled": False})
 
 
 def _parse_png_ihdr(data: bytes) -> dict:

--- a/tests/device/test_screenshot_api.py
+++ b/tests/device/test_screenshot_api.py
@@ -66,12 +66,18 @@ def _get_screenshot(api_key: str = API_KEY) -> requests.Response:
 
 
 def _enable_web_auth():
-    """Enable web auth so that API key enforcement kicks in."""
+    """Enable web + API auth so that API key enforcement kicks in.
+
+    Both flags must be true for ``check_api_auth`` to reject requests:
+    ``api_auth_enabled`` gates the entire check (short-circuits to *allow*
+    when false), and ``web_auth_enabled`` prevents the "allow local web UI"
+    fallback.  On a fresh device both default to false, so we must set both.
+    """
     for attempt in range(3):
         try:
             requests.post(
                 f"{ARCTIC_URL}/api/auth/config",
-                json={"web_auth_enabled": True},
+                json={"web_auth_enabled": True, "api_auth_enabled": True},
                 headers=_api_headers(),
                 timeout=5,
             )
@@ -83,12 +89,12 @@ def _enable_web_auth():
 
 
 def _disable_web_auth():
-    """Disable web auth (restore normal test state)."""
+    """Disable web + API auth (restore normal test state)."""
     for attempt in range(3):
         try:
             requests.post(
                 f"{ARCTIC_URL}/api/auth/config",
-                json={"web_auth_enabled": False},
+                json={"web_auth_enabled": False, "api_auth_enabled": False},
                 headers=_api_headers(),
                 timeout=5,
             )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,5 @@ requests>=2.28
 schemathesis>=3.0
 pyyaml>=6.0
 esptool>=4.0
+esp-idf-nvs-partition-gen>=0.1
 python-dotenv>=1.0

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -1,7 +1,14 @@
 """Tests for the web dashboard Settings page."""
 
+import os
 import pytest
+import requests
 from playwright.sync_api import Page, expect
+
+# Credentials from env
+_USERNAME = os.environ.get("ARCTIC_USERNAME", "arctic")
+_PASSWORD = os.environ.get("ARCTIC_PASSWORD", "arctic")
+_API_KEY = os.environ.get("ARCTIC_API_KEY")
 
 
 def _go_to_settings(page: Page):
@@ -24,6 +31,39 @@ def _ensure_api_auth_enabled(page: Page):
     if not api_toggle.is_checked():
         api_toggle.click()
         page.wait_for_timeout(500)
+
+
+def _disable_api_auth(base_url: str):
+    """Disable API auth via the REST API so it doesn't affect subsequent runs."""
+    headers = {}
+    if _API_KEY:
+        headers["X-API-Key"] = _API_KEY
+    try:
+        # Try with API key first
+        r = requests.post(
+            f"{base_url}/api/auth/config",
+            json={"api_auth_enabled": False, "web_auth_enabled": False},
+            headers=headers,
+            timeout=5,
+            verify=False,
+        )
+        if r.status_code == 200:
+            return
+        # Fall back to session login
+        session = requests.Session()
+        session.verify = False
+        session.post(
+            f"{base_url}/login",
+            json={"username": _USERNAME, "password": _PASSWORD},
+            timeout=5,
+        )
+        session.post(
+            f"{base_url}/api/auth/config",
+            json={"api_auth_enabled": False, "web_auth_enabled": False},
+            timeout=5,
+        )
+    except Exception:
+        pass
 
 
 class TestSettingsCards:
@@ -78,6 +118,12 @@ class TestTimeSettings:
 
 class TestSecuritySettings:
     """Security card interactions (on Security tab)."""
+
+    @pytest.fixture(autouse=True)
+    def _cleanup_api_auth(self, base_url: str):
+        """Disable API auth after each test so it doesn't persist across runs."""
+        yield
+        _disable_api_auth(base_url)
 
     def test_web_auth_toggle_visible(self, dashboard_page: Page):
         """Web Auth toggle is present in Authentication card."""

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -16,6 +16,16 @@ def _go_to_security(page: Page):
     page.wait_for_timeout(500)
 
 
+def _ensure_api_auth_enabled(page: Page):
+    """Enable the API Auth toggle if it's not already on, so the API key section renders."""
+    toggles = page.locator(".toggle input[type='checkbox']")
+    # The API Auth toggle is the second one on the Security page
+    api_toggle = toggles.nth(1)
+    if not api_toggle.is_checked():
+        api_toggle.click()
+        page.wait_for_timeout(500)
+
+
 class TestSettingsCards:
     """Settings page layout and card visibility."""
 
@@ -77,14 +87,16 @@ class TestSecuritySettings:
         assert toggles.count() >= 2, f"Expected at least 2 toggles, got {toggles.count()}"
 
     def test_api_key_display_visible(self, dashboard_page: Page):
-        """API key display area is present."""
+        """API key display area is present when API auth is enabled."""
         _go_to_security(dashboard_page)
+        _ensure_api_auth_enabled(dashboard_page)
         api_key = dashboard_page.locator(".api-key-display")
         expect(api_key).to_be_visible()
 
     def test_api_key_copy_button(self, dashboard_page: Page):
         """Copy API key button is clickable."""
         _go_to_security(dashboard_page)
+        _ensure_api_auth_enabled(dashboard_page)
         copy_btn = dashboard_page.locator(".api-key-display .btn-group button").nth(1)
         expect(copy_btn).to_be_visible()
         expect(copy_btn).to_be_enabled()

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -29,7 +29,8 @@ def _ensure_api_auth_enabled(page: Page):
     # The API Auth toggle is the second one on the Security page
     api_toggle = toggles.nth(1)
     if not api_toggle.is_checked():
-        api_toggle.click()
+        # Click the parent label (styled switch) — the checkbox itself has zero size
+        page.locator(".toggle").nth(1).click()
         page.wait_for_timeout(500)
 
 

--- a/tests/web/test_tls.py
+++ b/tests/web/test_tls.py
@@ -125,9 +125,9 @@ def _browser_login(page: Page):
 def _restore_auth():
     """Ensure auth toggles are restored after each test."""
     yield
-    # Disable web auth, keep API auth enabled (test suite default).
-    # Ignore failure — the conftest dashboard_page fixture handles login fallback.
-    _set_auth(web=False, api=True)
+    # Disable both auth methods so subsequent CI runs aren't affected.
+    # This prevents OTA uploads from failing with 401 on the next run.
+    _set_auth(web=False, api=False)
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds USB serial flashing support via the new USB hub on the self-hosted runner, with automatic WiFi provisioning so fresh/factory-reset devices can connect and run tests.

## Changes

- **USB port**: Updated fallback serial port from \/dev/ttyUSB0\ to \/dev/ttyACM0\
- **WiFi provisioning**: When OTA fails (e.g. brand-new device with no WiFi), the USB flash step now generates an NVS partition containing WiFi credentials (\MI_WIFI_SSID\/\MI_WIFI_PASSWORD\ secrets) and flashes it to \