### PR TITLE
ci: auto-update simulator to latest GitHub release before Modbus tests

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -94,6 +94,74 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 
+      - name: Update simulator to latest release
+        run: |
+          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
+
+          # 1. Get current simulator version
+          CURRENT_VERSION=""
+          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
+          if [ -n "$RESP" ]; then
+            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+          fi
+          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
+
+          # 2. Get latest release tag from GitHub
+          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
+            -o /tmp/simulator_release.json
+          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
+          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
+          LATEST_VERSION="${LATEST_TAG#v}"
+          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
+
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "WARNING: Could not determine latest simulator release — skipping update"
+            echo "API response:"; cat /tmp/simulator_release.json; echo
+            exit 0
+          fi
+
+          # 3. Compare versions — skip if already up to date
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Simulator is already up to date ($CURRENT_VERSION)"
+            exit 0
+          fi
+          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
+
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          mkdir -p /tmp/simulator
+          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            if [ ! -s "/tmp/simulator/$BIN" ]; then
+              echo "ERROR: Failed to download $BIN"
+              exit 1
+            fi
+            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
+          done
+
+          # 5. Flash via USB serial
+          echo "Flashing simulator on /dev/ttyACM1..."
+          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
+            --before default_reset --after hard_reset \
+            write_flash \
+            0x0     /tmp/simulator/bootloader.bin \
+            0x8000  /tmp/simulator/partition-table.bin \
+            0x10000 /tmp/simulator/arctic-simulator.bin
+
+          # 6. Wait for simulator to come back online
+          echo "Waiting for simulator to boot..."
+          sleep 10
+          for i in $(seq 1 30); do
+            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
+              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "WARNING: Simulator did not come back online within 40s"
+
       - name: Sync API key from device (pre-OTA)
         run: |
           # Read the device's current API key before OTA so the upload can authenticate.
@@ -313,74 +381,6 @@ jobs:
         id: ui_tests
         continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
-
-      - name: Update simulator to latest release
-        run: |
-          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
-
-          # 1. Get current simulator version
-          CURRENT_VERSION=""
-          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
-          if [ -n "$RESP" ]; then
-            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
-          fi
-          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
-
-          # 2. Get latest release tag from GitHub
-          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
-            -o /tmp/simulator_release.json
-          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
-          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
-          LATEST_VERSION="${LATEST_TAG#v}"
-          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
-
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "WARNING: Could not determine latest simulator release — skipping update"
-            echo "API response:"; cat /tmp/simulator_release.json; echo
-            exit 0
-          fi
-
-          # 3. Compare versions — skip if already up to date
-          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
-            echo "Simulator is already up to date ($CURRENT_VERSION)"
-            exit 0
-          fi
-          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
-
-          # 4. Download release binaries
-          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
-          mkdir -p /tmp/simulator
-          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            echo "Downloading $BIN..."
-            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
-            if [ ! -s "/tmp/simulator/$BIN" ]; then
-              echo "ERROR: Failed to download $BIN"
-              exit 1
-            fi
-            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
-          done
-
-          # 5. Flash via USB serial
-          echo "Flashing simulator on /dev/ttyACM1..."
-          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
-            --before default_reset --after hard_reset \
-            write_flash \
-            0x0     /tmp/simulator/bootloader.bin \
-            0x8000  /tmp/simulator/partition-table.bin \
-            0x10000 /tmp/simulator/arctic-simulator.bin
-
-          # 6. Wait for simulator to come back online
-          echo "Waiting for simulator to boot..."
-          sleep 10
-          for i in $(seq 1 30); do
-            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
-              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
-              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "WARNING: Simulator did not come back online within 40s"
 
       - name: Run Modbus E2E tests
         id: modbus_tests

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -314,6 +314,71 @@ jobs:
         continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
+      - name: Update simulator to latest release
+        run: |
+          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
+
+          # 1. Get current simulator version
+          CURRENT_VERSION=""
+          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
+          if [ -n "$RESP" ]; then
+            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+          fi
+          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
+
+          # 2. Get latest release tag from GitHub
+          RELEASE_JSON=$(curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
+          LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
+          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
+          LATEST_VERSION="${LATEST_TAG#v}"
+          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
+
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "WARNING: Could not determine latest simulator release — skipping update"
+            exit 0
+          fi
+
+          # 3. Compare versions — skip if already up to date
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Simulator is already up to date ($CURRENT_VERSION)"
+            exit 0
+          fi
+          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
+
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          mkdir -p /tmp/simulator
+          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            if [ ! -s "/tmp/simulator/$BIN" ]; then
+              echo "ERROR: Failed to download $BIN"
+              exit 1
+            fi
+          done
+
+          # 5. Flash via USB serial
+          echo "Flashing simulator on /dev/ttyACM1..."
+          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
+            --before default_reset --after hard_reset \
+            write_flash \
+            0x0     /tmp/simulator/bootloader.bin \
+            0x8000  /tmp/simulator/partition-table.bin \
+            0x10000 /tmp/simulator/arctic-simulator.bin
+
+          # 6. Wait for simulator to come back online
+          echo "Waiting for simulator to boot..."
+          sleep 10
+          for i in $(seq 1 30); do
+            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
+              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "WARNING: Simulator did not come back online within 40s"
+
       - name: Run Modbus E2E tests
         id: modbus_tests
         continue-on-error: true

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -315,8 +315,6 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
       - name: Update simulator to latest release
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           SIMULATOR_URL="http://arctic-simulator-ghr.mi"
 
@@ -328,17 +326,17 @@ jobs:
           fi
           echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
 
-          # 2. Get latest release tag from GitHub (use token for private repo access)
-          RELEASE_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
-          LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
+          # 2. Get latest release tag from GitHub
+          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
+            -o /tmp/simulator_release.json
+          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
           # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
           LATEST_VERSION="${LATEST_TAG#v}"
           echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
 
           if [ -z "$LATEST_VERSION" ]; then
             echo "WARNING: Could not determine latest simulator release — skipping update"
-            echo "API response: $RELEASE_JSON"
+            echo "API response:"; cat /tmp/simulator_release.json; echo
             exit 0
           fi
 
@@ -349,29 +347,12 @@ jobs:
           fi
           echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
 
-          # 4. Download release binaries (use token for private repo assets)
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
           mkdir -p /tmp/simulator
-          # Get asset download URLs from release JSON
-          python3 -c "
-          import json, sys
-          release = json.loads('''$RELEASE_JSON''')
-          for asset in release.get('assets', []):
-              print(f\"{asset['name']}|{asset['url']}\")
-          " > /tmp/simulator/assets.txt 2>/dev/null || true
-
           for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            ASSET_URL=$(grep "^${BIN}|" /tmp/simulator/assets.txt | cut -d'|' -f2) || true
-            if [ -n "$ASSET_URL" ]; then
-              echo "Downloading $BIN via API..."
-              curl -sL -H "Authorization: token $GH_TOKEN" \
-                -H "Accept: application/octet-stream" \
-                -o "/tmp/simulator/$BIN" "$ASSET_URL"
-            else
-              # Fallback to direct URL (public repos)
-              echo "Downloading $BIN via direct URL..."
-              curl -sL -o "/tmp/simulator/$BIN" \
-                "https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG/$BIN"
-            fi
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
             if [ ! -s "/tmp/simulator/$BIN" ]; then
               echo "ERROR: Failed to download $BIN"
               exit 1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -315,6 +315,8 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
       - name: Update simulator to latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           SIMULATOR_URL="http://arctic-simulator-ghr.mi"
 
@@ -326,8 +328,9 @@ jobs:
           fi
           echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
 
-          # 2. Get latest release tag from GitHub
-          RELEASE_JSON=$(curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
+          # 2. Get latest release tag from GitHub (use token for private repo access)
+          RELEASE_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
           LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
           # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
           LATEST_VERSION="${LATEST_TAG#v}"
@@ -335,6 +338,7 @@ jobs:
 
           if [ -z "$LATEST_VERSION" ]; then
             echo "WARNING: Could not determine latest simulator release — skipping update"
+            echo "API response: $RELEASE_JSON"
             exit 0
           fi
 
@@ -345,16 +349,34 @@ jobs:
           fi
           echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
 
-          # 4. Download release binaries
-          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          # 4. Download release binaries (use token for private repo assets)
           mkdir -p /tmp/simulator
+          # Get asset download URLs from release JSON
+          python3 -c "
+          import json, sys
+          release = json.loads('''$RELEASE_JSON''')
+          for asset in release.get('assets', []):
+              print(f\"{asset['name']}|{asset['url']}\")
+          " > /tmp/simulator/assets.txt 2>/dev/null || true
+
           for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            echo "Downloading $BIN..."
-            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            ASSET_URL=$(grep "^${BIN}|" /tmp/simulator/assets.txt | cut -d'|' -f2) || true
+            if [ -n "$ASSET_URL" ]; then
+              echo "Downloading $BIN via API..."
+              curl -sL -H "Authorization: token $GH_TOKEN" \
+                -H "Accept: application/octet-stream" \
+                -o "/tmp/simulator/$BIN" "$ASSET_URL"
+            else
+              # Fallback to direct URL (public repos)
+              echo "Downloading $BIN via direct URL..."
+              curl -sL -o "/tmp/simulator/$BIN" \
+                "https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG/$BIN"
+            fi
             if [ ! -s "/tmp/simulator/$BIN" ]; then
               echo "ERROR: Failed to download $BIN"
               exit 1
             fi
+            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
           done
 
           # 5. Flash via USB serial


### PR DESCRIPTION
## Summary

Automatically updates the arctic-simulator to the latest GitHub release before running Modbus E2E tests.

## How it works

1. Queries `GET /api/status` on `arctic-simulator-ghr.mi` to get the current firmware version
2. Queries the GitHub Releases API for the latest tag on `sslivins/arctic-simulator`
3. Compares versions — **skips** if already up to date (no unnecessary flash cycles)
4. If outdated or unreachable:
   - Downloads the 3 release binaries (bootloader, partition-table, firmware)
   - Flashes via `esptool.py --chip esp32s3` on `/dev/ttyACM1`
   - Waits up to 40s for the simulator to come back online

## Details

- Serial port: `/dev/ttyACM1` (simulator is ESP32-S3 Atom S3, controller is on `/dev/ttyACM0`)
- Flash addresses: `0x0` bootloader, `0x8000` partition-table, `0x10000` firmware (matches simulator's `esptool` args)
- Version comparison strips the `v` prefix from the release tag (tag `v0.8.0` → compare against `0.8.0`)
- Step is non-blocking — if GitHub API is unreachable or version can't be determined, it logs a warning and continues