### PR TITLE
ci: auto-update simulator & fix Node.js deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       TARGET: ${{ inputs.target || 'esp32p4' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -81,7 +81,7 @@ jobs:
           path: '.'
 
       - name: Upload firmware artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-v${{ steps.version.outputs.version }}-${{ env.TARGET }}
           path: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload firmware artifact
         if: ${{ !inputs.dry_run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-${{ steps.version.outputs.tag }}
           path: |

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -74,6 +74,7 @@ jobs:
     timeout-minutes: 120
     env:
       ARCTIC_URL: http://arctic-controller-ghr.mi
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -57,7 +57,7 @@ jobs:
           path: '.'
 
       - name: Upload firmware + flash metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware
           path: |
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download firmware
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: firmware
           path: build/
@@ -448,7 +448,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload failure screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: failure-screenshots

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -94,6 +94,74 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 
+      - name: Update simulator to latest release
+        run: |
+          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
+
+          # 1. Get current simulator version
+          CURRENT_VERSION=""
+          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
+          if [ -n "$RESP" ]; then
+            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+          fi
+          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
+
+          # 2. Get latest release tag from GitHub
+          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
+            -o /tmp/simulator_release.json
+          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
+          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
+          LATEST_VERSION="${LATEST_TAG#v}"
+          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
+
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "WARNING: Could not determine latest simulator release — skipping update"
+            echo "API response:"; cat /tmp/simulator_release.json; echo
+            exit 0
+          fi
+
+          # 3. Compare versions — skip if already up to date
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Simulator is already up to date ($CURRENT_VERSION)"
+            exit 0
+          fi
+          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
+
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          mkdir -p /tmp/simulator
+          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            if [ ! -s "/tmp/simulator/$BIN" ]; then
+              echo "ERROR: Failed to download $BIN"
+              exit 1
+            fi
+            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
+          done
+
+          # 5. Flash via USB serial
+          echo "Flashing simulator on /dev/ttyACM1..."
+          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
+            --before default_reset --after hard_reset \
+            write_flash \
+            0x0     /tmp/simulator/bootloader.bin \
+            0x8000  /tmp/simulator/partition-table.bin \
+            0x10000 /tmp/simulator/arctic-simulator.bin
+
+          # 6. Wait for simulator to come back online
+          echo "Waiting for simulator to boot..."
+          sleep 10
+          for i in $(seq 1 30); do
+            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
+              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "WARNING: Simulator did not come back online within 40s"
+
       - name: Sync API key from device (pre-OTA)
         run: |
           # Read the device's current API key before OTA so the upload can authenticate.
@@ -313,74 +381,6 @@ jobs:
         id: ui_tests
         continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
-
-      - name: Update simulator to latest release
-        run: |
-          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
-
-          # 1. Get current simulator version
-          CURRENT_VERSION=""
-          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
-          if [ -n "$RESP" ]; then
-            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
-          fi
-          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
-
-          # 2. Get latest release tag from GitHub
-          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
-            -o /tmp/simulator_release.json
-          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
-          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
-          LATEST_VERSION="${LATEST_TAG#v}"
-          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
-
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "WARNING: Could not determine latest simulator release — skipping update"
-            echo "API response:"; cat /tmp/simulator_release.json; echo
-            exit 0
-          fi
-
-          # 3. Compare versions — skip if already up to date
-          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
-            echo "Simulator is already up to date ($CURRENT_VERSION)"
-            exit 0
-          fi
-          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
-
-          # 4. Download release binaries
-          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
-          mkdir -p /tmp/simulator
-          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            echo "Downloading $BIN..."
-            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
-            if [ ! -s "/tmp/simulator/$BIN" ]; then
-              echo "ERROR: Failed to download $BIN"
-              exit 1
-            fi
-            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
-          done
-
-          # 5. Flash via USB serial
-          echo "Flashing simulator on /dev/ttyACM1..."
-          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
-            --before default_reset --after hard_reset \
-            write_flash \
-            0x0     /tmp/simulator/bootloader.bin \
-            0x8000  /tmp/simulator/partition-table.bin \
-            0x10000 /tmp/simulator/arctic-simulator.bin
-
-          # 6. Wait for simulator to come back online
-          echo "Waiting for simulator to boot..."
-          sleep 10
-          for i in $(seq 1 30); do
-            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
-              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
-              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "WARNING: Simulator did not come back online within 40s"
 
       - name: Run Modbus E2E tests
         id: modbus_tests

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -314,6 +314,71 @@ jobs:
         continue-on-error: true
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
+      - name: Update simulator to latest release
+        run: |
+          SIMULATOR_URL="http://arctic-simulator-ghr.mi"
+
+          # 1. Get current simulator version
+          CURRENT_VERSION=""
+          RESP=$(curl -s --connect-timeout 3 --max-time 5 "$SIMULATOR_URL/api/status" 2>/dev/null) || true
+          if [ -n "$RESP" ]; then
+            CURRENT_VERSION=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+          fi
+          echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
+
+          # 2. Get latest release tag from GitHub
+          RELEASE_JSON=$(curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
+          LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
+          # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
+          LATEST_VERSION="${LATEST_TAG#v}"
+          echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
+
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "WARNING: Could not determine latest simulator release — skipping update"
+            exit 0
+          fi
+
+          # 3. Compare versions — skip if already up to date
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Simulator is already up to date ($CURRENT_VERSION)"
+            exit 0
+          fi
+          echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
+
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          mkdir -p /tmp/simulator
+          for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            if [ ! -s "/tmp/simulator/$BIN" ]; then
+              echo "ERROR: Failed to download $BIN"
+              exit 1
+            fi
+          done
+
+          # 5. Flash via USB serial
+          echo "Flashing simulator on /dev/ttyACM1..."
+          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
+            --before default_reset --after hard_reset \
+            write_flash \
+            0x0     /tmp/simulator/bootloader.bin \
+            0x8000  /tmp/simulator/partition-table.bin \
+            0x10000 /tmp/simulator/arctic-simulator.bin
+
+          # 6. Wait for simulator to come back online
+          echo "Waiting for simulator to boot..."
+          sleep 10
+          for i in $(seq 1 30); do
+            if curl -s --connect-timeout 2 "$SIMULATOR_URL/api/status" > /dev/null 2>&1; then
+              NEW_VER=$(curl -s "$SIMULATOR_URL/api/status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null) || true
+              echo "Simulator online — version $NEW_VER (after $((i + 10))s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "WARNING: Simulator did not come back online within 40s"
+
       - name: Run Modbus E2E tests
         id: modbus_tests
         continue-on-error: true

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -315,8 +315,6 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
       - name: Update simulator to latest release
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           SIMULATOR_URL="http://arctic-simulator-ghr.mi"
 
@@ -328,17 +326,17 @@ jobs:
           fi
           echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
 
-          # 2. Get latest release tag from GitHub (use token for private repo access)
-          RELEASE_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
-          LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
+          # 2. Get latest release tag from GitHub
+          curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest" \
+            -o /tmp/simulator_release.json
+          LATEST_TAG=$(python3 -c "import json; print(json.load(open('/tmp/simulator_release.json')).get('tag_name',''))" 2>/dev/null) || true
           # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
           LATEST_VERSION="${LATEST_TAG#v}"
           echo "Latest release: $LATEST_TAG (version $LATEST_VERSION)"
 
           if [ -z "$LATEST_VERSION" ]; then
             echo "WARNING: Could not determine latest simulator release — skipping update"
-            echo "API response: $RELEASE_JSON"
+            echo "API response:"; cat /tmp/simulator_release.json; echo
             exit 0
           fi
 
@@ -349,29 +347,12 @@ jobs:
           fi
           echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
 
-          # 4. Download release binaries (use token for private repo assets)
+          # 4. Download release binaries
+          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
           mkdir -p /tmp/simulator
-          # Get asset download URLs from release JSON
-          python3 -c "
-          import json, sys
-          release = json.loads('''$RELEASE_JSON''')
-          for asset in release.get('assets', []):
-              print(f\"{asset['name']}|{asset['url']}\")
-          " > /tmp/simulator/assets.txt 2>/dev/null || true
-
           for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            ASSET_URL=$(grep "^${BIN}|" /tmp/simulator/assets.txt | cut -d'|' -f2) || true
-            if [ -n "$ASSET_URL" ]; then
-              echo "Downloading $BIN via API..."
-              curl -sL -H "Authorization: token $GH_TOKEN" \
-                -H "Accept: application/octet-stream" \
-                -o "/tmp/simulator/$BIN" "$ASSET_URL"
-            else
-              # Fallback to direct URL (public repos)
-              echo "Downloading $BIN via direct URL..."
-              curl -sL -o "/tmp/simulator/$BIN" \
-                "https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG/$BIN"
-            fi
+            echo "Downloading $BIN..."
+            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
             if [ ! -s "/tmp/simulator/$BIN" ]; then
               echo "ERROR: Failed to download $BIN"
               exit 1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -74,7 +74,6 @@ jobs:
     timeout-minutes: 120
     env:
       ARCTIC_URL: http://arctic-controller-ghr.mi
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -422,6 +422,7 @@ jobs:
           name: Device UI Test Results
           path: test-results.xml
           reporter: java-junit
+          use-actions-summary: 'false'
 
       - name: Publish API contract test results
         uses: dorny/test-reporter@v2
@@ -430,6 +431,7 @@ jobs:
           name: API Contract Test Results
           path: api-test-results.xml
           reporter: java-junit
+          use-actions-summary: 'false'
 
       - name: Publish Modbus E2E test results
         uses: dorny/test-reporter@v2
@@ -438,6 +440,7 @@ jobs:
           name: Modbus E2E Test Results
           path: modbus-test-results.xml
           reporter: java-junit
+          use-actions-summary: 'false'
 
       - name: Publish web test results
         uses: dorny/test-reporter@v2
@@ -446,6 +449,7 @@ jobs:
           name: Web Dashboard Test Results
           path: web-test-results.xml
           reporter: java-junit
+          use-actions-summary: 'false'
 
       - name: Upload failure screenshots
         uses: actions/upload-artifact@v7

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -416,7 +416,7 @@ jobs:
           TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
 
       - name: Publish UI test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always() && steps.ui_tests.outcome != 'skipped'
         with:
           name: Device UI Test Results
@@ -424,7 +424,7 @@ jobs:
           reporter: java-junit
 
       - name: Publish API contract test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always() && steps.api_tests.outcome != 'skipped'
         with:
           name: API Contract Test Results
@@ -432,7 +432,7 @@ jobs:
           reporter: java-junit
 
       - name: Publish Modbus E2E test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always() && steps.modbus_tests.outcome != 'skipped'
         with:
           name: Modbus E2E Test Results
@@ -440,7 +440,7 @@ jobs:
           reporter: java-junit
 
       - name: Publish web test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always() && steps.web_tests.outcome != 'skipped'
         with:
           name: Web Dashboard Test Results

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -315,6 +315,8 @@ jobs:
         run: python -m pytest tests/device/ -v --tb=short --junitxml=test-results.xml -p no:cacheprovider -m "not modbus"
 
       - name: Update simulator to latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           SIMULATOR_URL="http://arctic-simulator-ghr.mi"
 
@@ -326,8 +328,9 @@ jobs:
           fi
           echo "Simulator current version: ${CURRENT_VERSION:-unreachable}"
 
-          # 2. Get latest release tag from GitHub
-          RELEASE_JSON=$(curl -s "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
+          # 2. Get latest release tag from GitHub (use token for private repo access)
+          RELEASE_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/sslivins/arctic-simulator/releases/latest") || true
           LATEST_TAG=$(echo "$RELEASE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null) || true
           # Strip leading 'v' for comparison (release tag is "v0.8.0", firmware reports "0.8.0")
           LATEST_VERSION="${LATEST_TAG#v}"
@@ -335,6 +338,7 @@ jobs:
 
           if [ -z "$LATEST_VERSION" ]; then
             echo "WARNING: Could not determine latest simulator release — skipping update"
+            echo "API response: $RELEASE_JSON"
             exit 0
           fi
 
@@ -345,16 +349,34 @@ jobs:
           fi
           echo "Updating simulator from ${CURRENT_VERSION:-unknown} to $LATEST_VERSION..."
 
-          # 4. Download release binaries
-          DOWNLOAD_BASE="https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG"
+          # 4. Download release binaries (use token for private repo assets)
           mkdir -p /tmp/simulator
+          # Get asset download URLs from release JSON
+          python3 -c "
+          import json, sys
+          release = json.loads('''$RELEASE_JSON''')
+          for asset in release.get('assets', []):
+              print(f\"{asset['name']}|{asset['url']}\")
+          " > /tmp/simulator/assets.txt 2>/dev/null || true
+
           for BIN in bootloader.bin partition-table.bin arctic-simulator.bin; do
-            echo "Downloading $BIN..."
-            curl -sL -o "/tmp/simulator/$BIN" "$DOWNLOAD_BASE/$BIN"
+            ASSET_URL=$(grep "^${BIN}|" /tmp/simulator/assets.txt | cut -d'|' -f2) || true
+            if [ -n "$ASSET_URL" ]; then
+              echo "Downloading $BIN via API..."
+              curl -sL -H "Authorization: token $GH_TOKEN" \
+                -H "Accept: application/octet-stream" \
+                -o "/tmp/simulator/$BIN" "$ASSET_URL"
+            else
+              # Fallback to direct URL (public repos)
+              echo "Downloading $BIN via direct URL..."
+              curl -sL -o "/tmp/simulator/$BIN" \
+                "https://github.com/sslivins/arctic-simulator/releases/download/$LATEST_TAG/$BIN"
+            fi
             if [ ! -s "/tmp/simulator/$BIN" ]; then
               echo "ERROR: Failed to download $BIN"
               exit 1
             fi
+            echo "  $(wc -c < /tmp/simulator/$BIN) bytes"
           done
 
           # 5. Flash via USB serial

--- a/.github/workflows/renew-tls-cert.yml
+++ b/.github/workflows/renew-tls-cert.yml
@@ -21,7 +21,7 @@ jobs:
     name: Renew wildcard cert and deploy to device
     runs-on: vm-mi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install certbot and Cloudflare plugin
         run: |


### PR DESCRIPTION
## Summary

CI improvements for the device-tests workflow: auto-update the Modbus simulator before tests and fix Node.js 16 deprecation warnings.

## Changes

### Simulator auto-update
- Automatically check the latest `arctic-simulator` GitHub release before Modbus E2E tests
- Flash the simulator via USB serial if a newer version is available
- Skip update if already running the latest version

### Fix Node.js deprecation warnings
- Update `dorny/test-reporter` from v1 (Node.js 16) to v2 (Node.js 20)
- Affects all 4 test result publishers: UI, API, Modbus, and Web

## Notes
- No firmware changes — CI-only
- The simulator update step runs early in the pipeline so any flash + reboot time is absorbed before tests start