### PR TITLE
fix(ci): make TLS cert renewal workflow operational

### DIFF
--- a/.github/workflows/renew-tls-cert.yml
+++ b/.github/workflows/renew-tls-cert.yml
@@ -155,7 +155,7 @@ jobs:
               -H "X-API-Key: ${ARCTIC_API_KEY}" \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "$URL/api/tls/certificates") || true
+              "$URL/api/tls/certificate") || true
             HTTP_CODE=$(echo "$RESPONSE" | tail -1)
             BODY=$(echo "$RESPONSE" | sed '$d')
             echo "$URL → HTTP $HTTP_CODE"

--- a/.github/workflows/renew-tls-cert.yml
+++ b/.github/workflows/renew-tls-cert.yml
@@ -20,6 +20,8 @@ jobs:
   renew:
     name: Renew wildcard cert and deploy to device
     runs-on: vm-mi
+    env:
+      ARCTIC_URL: http://arctic-controller-ghr.mi
     steps:
       - uses: actions/checkout@v6
 
@@ -86,57 +88,108 @@ jobs:
             echo "KEY_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Sync API key from device
+        if: steps.certbot.outputs.renewed == 'true'
+        run: |
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          DEVICE_KEY=""
+
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
+            DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+
+            if [ -z "$DEVICE_KEY" ]; then
+              JAR=$(mktemp)
+              curl -sk -c "$JAR" -X POST "$URL/login" \
+                -H "Content-Type: application/json" \
+                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
+              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
+              DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+              rm -f "$JAR"
+            fi
+
+            if [ -n "$DEVICE_KEY" ]; then
+              break
+            fi
+          done
+
+          if [ -n "$DEVICE_KEY" ]; then
+            echo "ARCTIC_API_KEY=$DEVICE_KEY" >> $GITHUB_ENV
+            echo "Synced API key from device"
+          else
+            echo "::warning::Could not read device API key — using secret"
+          fi
+        env:
+          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
+          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
+
       - name: Enable both auth methods on device
         if: steps.certbot.outputs.renewed == 'true'
         run: |
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           # Ensure both web auth and API auth are enabled (required for cert upload)
           curl -sf --max-time 10 \
-            -H "X-API-Key: ${{ secrets.ARCTIC_API_KEY }}" \
+            -H "X-API-Key: ${ARCTIC_API_KEY}" \
             -H "Content-Type: application/json" \
             -d '{"web_auth_enabled": true, "api_auth_enabled": true}' \
-            "${{ vars.ARCTIC_URL || 'http://arctic.local' }}/api/auth/config" \
+            "$ARCTIC_URL/api/auth/config" \
+            || curl -skf --max-time 10 \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d '{"web_auth_enabled": true, "api_auth_enabled": true}' \
+              "$ARCTIC_URL_HTTPS/api/auth/config" \
             || echo "Warning: Could not configure auth (may already be set)"
 
       - name: Upload certificate to device
         if: steps.certbot.outputs.renewed == 'true'
         run: |
           # Upload new cert + key via the TLS provisioning API
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           PAYLOAD=$(jq -n \
             --arg cert "${{ steps.read_certs.outputs.fullchain }}" \
             --arg key "${{ steps.read_certs.outputs.privkey }}" \
             '{cert: $cert, key: $key}')
 
-          RESPONSE=$(curl -sf --max-time 30 \
-            -H "X-API-Key: ${{ secrets.ARCTIC_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            "${{ vars.ARCTIC_URL || 'http://arctic.local' }}/api/tls/certificates")
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            RESPONSE=$(curl -sk --max-time 30 -w '\n%{http_code}' \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "$URL/api/tls/certificates") || true
+            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+            BODY=$(echo "$RESPONSE" | sed '$d')
+            echo "$URL → HTTP $HTTP_CODE"
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Device response: $BODY"
+              echo "Certificate uploaded successfully."
+              exit 0
+            fi
+          done
 
-          echo "Device response: $RESPONSE"
-
-          if echo "$RESPONSE" | jq -e '.success == true' > /dev/null 2>&1; then
-            echo "Certificate uploaded successfully."
-          else
-            echo "::error::Certificate upload failed: $RESPONSE"
-            exit 1
-          fi
+          echo "::error::Certificate upload failed on both HTTP and HTTPS"
+          exit 1
 
       - name: Reboot device to activate new cert
         if: steps.certbot.outputs.renewed == 'true'
         run: |
-          curl -sf --max-time 10 \
-            -H "X-API-Key: ${{ secrets.ARCTIC_API_KEY }}" \
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          curl -skf --max-time 10 \
+            -H "X-API-Key: ${ARCTIC_API_KEY}" \
             -X POST \
-            "${{ vars.ARCTIC_URL || 'http://arctic.local' }}/api/system/reboot" \
+            "$ARCTIC_URL/api/system/reboot" \
+            || curl -skf --max-time 10 \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              -X POST \
+              "$ARCTIC_URL_HTTPS/api/system/reboot" \
             || true
 
           echo "Reboot triggered. Waiting for device to come back..."
           sleep 10
 
           for i in $(seq 1 30); do
-            if curl -sk --connect-timeout 2 \
-              "${{ vars.ARCTIC_URL || 'http://arctic.local' }}/api/heatpump/status" > /dev/null 2>&1; then
-              echo "Device is back online after ${i}s."
+            if curl -sk --connect-timeout 2 "$ARCTIC_URL/api/heatpump/status" > /dev/null 2>&1 || \
+               curl -sk --connect-timeout 2 "$ARCTIC_URL_HTTPS/api/heatpump/status" > /dev/null 2>&1; then
+              echo "Device is back online after $((i + 10))s."
               exit 0
             fi
             sleep 1

--- a/.github/workflows/renew-tls-cert.yml
+++ b/.github/workflows/renew-tls-cert.yml
@@ -21,7 +21,7 @@ jobs:
     name: Renew wildcard cert and deploy to device
     runs-on: vm-mi
     env:
-      ARCTIC_URL: http://arctic-controller-ghr.mi
+      ARCTIC_URL: http://arctic-01b0.mennlabs.com
     steps:
       - uses: actions/checkout@v6
 
@@ -140,6 +140,18 @@ jobs:
               "$ARCTIC_URL_HTTPS/api/auth/config" \
             || echo "Warning: Could not configure auth (may already be set)"
 
+      - name: Clear existing certs on device
+        if: steps.certbot.outputs.renewed == 'true'
+        run: |
+          # Delete any existing certs to avoid the deadlock where certs exist
+          # in NVS but HTTPS failed to start (blocks HTTP cert uploads).
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+            curl -sk --max-time 10 -X DELETE \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              "$URL/api/tls/certificate" 2>/dev/null && break || true
+          done
+
       - name: Upload certificate to device
         if: steps.certbot.outputs.renewed == 'true'
         run: |
@@ -187,8 +199,8 @@ jobs:
           sleep 10
 
           for i in $(seq 1 30); do
-            if curl -sk --connect-timeout 2 "$ARCTIC_URL/api/heatpump/status" > /dev/null 2>&1 || \
-               curl -sk --connect-timeout 2 "$ARCTIC_URL_HTTPS/api/heatpump/status" > /dev/null 2>&1; then
+            if curl -sk --connect-timeout 2 "$ARCTIC_URL/api/health" > /dev/null 2>&1 || \
+               curl -sk --connect-timeout 2 "$ARCTIC_URL_HTTPS/api/health" > /dev/null 2>&1; then
               echo "Device is back online after $((i + 10))s."
               exit 0
             fi

--- a/.github/workflows/renew-tls-cert.yml
+++ b/.github/workflows/renew-tls-cert.yml
@@ -188,11 +188,11 @@ jobs:
           curl -skf --max-time 10 \
             -H "X-API-Key: ${ARCTIC_API_KEY}" \
             -X POST \
-            "$ARCTIC_URL/api/system/reboot" \
+            "$ARCTIC_URL/api/ota/reboot" \
             || curl -skf --max-time 10 \
               -H "X-API-Key: ${ARCTIC_API_KEY}" \
               -X POST \
-              "$ARCTIC_URL_HTTPS/api/system/reboot" \
+              "$ARCTIC_URL_HTTPS/api/ota/reboot" \
             || true
 
           echo "Reboot triggered. Waiting for device to come back..."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.10.0")
+set(PROJECT_VER "2.11.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.11.0")
+set(PROJECT_VER "2.10.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS

--- a/fetch_repos.py
+++ b/fetch_repos.py
@@ -4,10 +4,8 @@ import json
 
 
 def clone_or_update_repo(repo_url, path, branch):
-    command = []
-    command.append('git')
-    command.append('clone')
-    
+    command = ['git', 'clone', '--depth', '1']
+
     if branch:
         command.append('-b')
         command.append(branch)

--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -139,7 +139,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`simulator_client.py`](simulator_client.py) | HTTP client for the [arctic-simulator](https://github.com/sslivins/arctic-simulator) REST API (register access, presets, error injection) |
 | [`openapi-test.yaml`](openapi-test.yaml) | OpenAPI 3.0 spec for the test instrumentation API |
 
-### Test Files (266 UI tests + 9 screenshot API tests + 286 REST API tests + 55 web tests + 10 Modbus e2e tests + API contract tests)
+### Test Files (266 UI tests + 9 screenshot API tests + 10 HTTPS tests + 286 REST API tests + 55 web tests + 10 Modbus e2e tests + API contract tests)
 
 | File | Tests | Description |
 |------|-------|-------------|
@@ -167,6 +167,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`test_error_history_duration.py`](test_error_history_duration.py) | 1 | Error history duration format ("3s") |
 | [`test_modbus_e2e.py`](test_modbus_e2e.py) | 10 | End-to-end Modbus: connection, power on/off, mode change, temps, errors, setpoints |
 | [`test_screenshot_api.py`](test_screenshot_api.py) | 9 | Production screenshot endpoint: PNG validity, dimensions, auth |
+| [`test_https.py`](test_https.py) | 10 | HTTPS lifecycle: self-signed cert upload, reboot, HTTPS verification, cleanup |
 | [`../api/test_api_schema.py`](../api/test_api_schema.py) | 8+ | API contract validation via Schemathesis + targeted smoke tests |
 | [`../api/test_heatpump_api.py`](../api/test_heatpump_api.py) | 65 | Heat pump status, demo injection, status1 bits, power/mode/setpoint control, params, errors |
 | [`../api/test_logs_api.py`](../api/test_logs_api.py) | 17 | Log buffer retrieval, filtering (since/level/limit), incremental polling, clear |

--- a/tests/device/test_https.py
+++ b/tests/device/test_https.py
@@ -1,0 +1,316 @@
+"""
+Test: HTTPS / TLS Certificate Lifecycle
+
+Verifies the full TLS certificate lifecycle on the device:
+  1. Upload a self-signed certificate
+  2. Reboot to activate HTTPS
+  3. Confirm HTTPS is serving on port 443
+  4. Verify API endpoints work over HTTPS
+  5. Delete certificate and reboot back to HTTP-only
+  6. Confirm HTTPS is no longer active
+
+These tests require both web auth and API key auth to be enabled
+(firmware prerequisite for cert upload). The fixture handles enabling
+auth before tests and restoring the original state afterwards.
+
+The test generates a self-signed EC certificate at runtime — no external
+cert files or DNS records are needed. DeviceClient uses verify=False,
+so hostname mismatch is not an issue.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+
+import pytest
+import requests
+import urllib3
+
+from device_client import DeviceClient
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+ARCTIC_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
+API_KEY = os.environ.get("ARCTIC_API_KEY", "")
+
+
+def _api_headers() -> dict:
+    headers = {}
+    if API_KEY:
+        headers["X-API-Key"] = API_KEY
+    return headers
+
+
+def _api_get(path: str, **kwargs) -> requests.Response:
+    return requests.get(
+        f"{ARCTIC_URL}{path}", headers=_api_headers(), verify=False, timeout=10, **kwargs
+    )
+
+
+def _api_post(path: str, **kwargs) -> requests.Response:
+    return requests.post(
+        f"{ARCTIC_URL}{path}", headers=_api_headers(), verify=False, timeout=10, **kwargs
+    )
+
+
+def _api_delete(path: str, **kwargs) -> requests.Response:
+    return requests.delete(
+        f"{ARCTIC_URL}{path}", headers=_api_headers(), verify=False, timeout=10, **kwargs
+    )
+
+
+def _https_url() -> str:
+    """Derive HTTPS URL from the HTTP ARCTIC_URL."""
+    return ARCTIC_URL.replace("http://", "https://")
+
+
+def _tls_status() -> dict:
+    return _api_get("/api/tls/status").json()
+
+
+def _generate_self_signed_cert() -> tuple[str, str]:
+    """Generate a self-signed EC P-256 certificate and private key.
+
+    Returns (cert_pem, key_pem) as strings.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = f"{tmpdir}/key.pem"
+        cert_path = f"{tmpdir}/cert.pem"
+
+        # Generate EC private key
+        subprocess.run(
+            ["openssl", "ecparam", "-genkey", "-name", "prime256v1",
+             "-noout", "-out", key_path],
+            check=True, capture_output=True,
+        )
+
+        # Generate self-signed certificate (valid 1 day)
+        subprocess.run(
+            ["openssl", "req", "-new", "-x509", "-key", key_path,
+             "-out", cert_path, "-days", "1",
+             "-subj", "/CN=arctic-test"],
+            check=True, capture_output=True,
+        )
+
+        with open(cert_path) as f:
+            cert_pem = f.read()
+        with open(key_path) as f:
+            key_pem = f.read()
+
+    return cert_pem, key_pem
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def self_signed_cert() -> tuple[str, str]:
+    """Generate a self-signed cert once for the module."""
+    return _generate_self_signed_cert()
+
+
+@pytest.fixture(scope="module")
+def auth_enabled(device: DeviceClient):
+    """Ensure both web and API auth are enabled (required for cert upload).
+
+    Restores previous auth config after the module completes.
+    """
+    # Read current config
+    r = _api_get("/api/auth/config")
+    original = r.json()
+
+    # Enable both if not already
+    if not original.get("web_auth_enabled") or not original.get("api_auth_enabled"):
+        _api_post(
+            "/api/auth/config",
+            json={"web_auth_enabled": True, "api_auth_enabled": True},
+        )
+
+    yield
+
+    # Restore original auth config
+    _api_post(
+        "/api/auth/config",
+        json={
+            "web_auth_enabled": original.get("web_auth_enabled", True),
+            "api_auth_enabled": original.get("api_auth_enabled", True),
+        },
+    )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def clean_tls_state(device: DeviceClient, auth_enabled):
+    """Ensure no leftover certs before tests and clean up after."""
+    status = _tls_status()
+    if status.get("has_certs"):
+        _api_delete("/api/tls/certificate")
+        device.reboot()
+        assert device.wait_for_device(timeout=30.0), "Device did not come back after clearing certs"
+
+    yield
+
+    # Clean up: delete any certs left by tests
+    try:
+        status = _tls_status()
+        if status.get("has_certs"):
+            _api_delete("/api/tls/certificate")
+            device.reboot()
+            device.wait_for_device(timeout=30.0)
+    except Exception:
+        pass  # best effort cleanup
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestTlsStatus:
+    """Verify /api/tls/status reports correct state."""
+
+    def test_no_certs_initially(self, device: DeviceClient, auth_enabled):
+        """With no certs provisioned, status should reflect that."""
+        status = _tls_status()
+        assert status["has_certs"] is False
+        assert status["https_active"] is False
+
+    def test_status_requires_auth(self):
+        """TLS status endpoint requires API key authentication."""
+        r = requests.get(f"{ARCTIC_URL}/api/tls/status", verify=False, timeout=10)
+        assert r.status_code == 401
+
+
+class TestCertUpload:
+    """Verify certificate upload validation."""
+
+    def test_upload_requires_auth(self, self_signed_cert):
+        """Cert upload without API key returns 401."""
+        cert_pem, key_pem = self_signed_cert
+        r = requests.post(
+            f"{ARCTIC_URL}/api/tls/certificate",
+            json={"cert": cert_pem, "key": key_pem},
+            verify=False, timeout=10,
+        )
+        assert r.status_code == 401
+
+    def test_upload_rejects_invalid_cert(self, auth_enabled):
+        """Non-PEM cert is rejected with 400."""
+        r = _api_post(
+            "/api/tls/certificate",
+            json={"cert": "not a valid cert", "key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----"},
+        )
+        assert r.status_code == 400
+        assert "PEM" in r.json().get("error", "")
+
+    def test_upload_rejects_invalid_key(self, self_signed_cert, auth_enabled):
+        """Non-PEM key is rejected with 400."""
+        cert_pem, _ = self_signed_cert
+        r = _api_post(
+            "/api/tls/certificate",
+            json={"cert": cert_pem, "key": "not a valid key"},
+        )
+        assert r.status_code == 400
+        assert "PEM" in r.json().get("error", "")
+
+    def test_upload_rejects_missing_fields(self, auth_enabled):
+        """Missing cert or key field returns 400."""
+        r = _api_post("/api/tls/certificate", json={"cert": "something"})
+        assert r.status_code == 400
+
+
+class TestHttpsLifecycle:
+    """Full lifecycle: upload → reboot → HTTPS active → delete → reboot → HTTP only."""
+
+    def test_upload_cert(self, device: DeviceClient, self_signed_cert, auth_enabled):
+        """Upload self-signed cert succeeds and sets has_certs."""
+        cert_pem, key_pem = self_signed_cert
+        r = _api_post(
+            "/api/tls/certificate",
+            json={"cert": cert_pem, "key": key_pem},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["success"] is True
+
+        # Certs stored but HTTPS not active until reboot
+        status = _tls_status()
+        assert status["has_certs"] is True
+        assert status["https_active"] is False
+
+    def test_reboot_activates_https(self, device: DeviceClient, self_signed_cert, auth_enabled):
+        """After uploading cert and rebooting, HTTPS should be active on port 443."""
+        # Ensure cert is uploaded
+        cert_pem, key_pem = self_signed_cert
+        status = _tls_status()
+        if not status.get("has_certs"):
+            r = _api_post(
+                "/api/tls/certificate",
+                json={"cert": cert_pem, "key": key_pem},
+            )
+            assert r.status_code == 200
+
+        device.reboot()
+        assert device.wait_for_device(timeout=30.0), "Device did not come back after reboot"
+        time.sleep(2)  # give HTTPS server time to start
+
+        # HTTPS should now be active
+        https_url = _https_url()
+        r = requests.get(f"{https_url}/api/health", verify=False, timeout=10)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+
+    def test_api_works_over_https(self, device: DeviceClient, self_signed_cert, auth_enabled):
+        """Production API endpoints work over HTTPS."""
+        # Ensure HTTPS is active (cert uploaded + rebooted from previous test)
+        https_url = _https_url()
+        try:
+            r = requests.get(f"{https_url}/api/health", verify=False, timeout=10)
+            if r.status_code != 200:
+                pytest.skip("HTTPS not active — previous test may have failed")
+        except Exception:
+            pytest.skip("HTTPS not reachable")
+
+        # Test authenticated endpoint over HTTPS
+        r = requests.get(
+            f"{https_url}/api/tls/status",
+            headers=_api_headers(), verify=False, timeout=10,
+        )
+        assert r.status_code == 200
+        status = r.json()
+        assert status["has_certs"] is True
+        assert status["https_active"] is True
+
+    def test_delete_cert_and_revert_to_http(self, device: DeviceClient, auth_enabled):
+        """Deleting cert and rebooting reverts to HTTP-only."""
+        https_url = _https_url()
+
+        # Delete cert (try HTTPS first since that's where routes are registered
+        # when HTTPS is active, fall back to HTTP)
+        deleted = False
+        for url in [https_url, ARCTIC_URL]:
+            try:
+                r = requests.delete(
+                    f"{url}/api/tls/certificate",
+                    headers=_api_headers(), verify=False, timeout=10,
+                )
+                if r.status_code == 200:
+                    deleted = True
+                    break
+            except Exception:
+                continue
+
+        assert deleted, "Failed to delete certificate on both HTTP and HTTPS"
+
+        device.reboot()
+        assert device.wait_for_device(timeout=30.0), "Device did not come back after reboot"
+
+        # HTTPS should no longer be active
+        status = _tls_status()
+        assert status["has_certs"] is False
+        assert status["https_active"] is False
+
+        # Port 443 should refuse connections
+        with pytest.raises(Exception):
+            requests.get(f"{https_url}/api/health", verify=False, timeout=3)


### PR DESCRIPTION
## Summary

The TLS certificate renewal workflow (`renew-tls-cert.yml`) was non-functional — every run since its creation failed. This PR fixes all the issues to make it fully operational.

## Changes

### API key sync from device
- Added a "Sync API key from device" step (matching the pattern in `device-tests.yml`) that reads the device's actual API key via unauthenticated access or cookie-based login fallback
- Replaced hardcoded `${{ secrets.ARCTIC_API_KEY }}` references with the synced `${ARCTIC_API_KEY}` env var
- Added "Enable both auth methods" step to ensure auth is configured before cert upload

### Hostname and URL fixes
- Switched `ARCTIC_URL` from `arctic-controller-ghr.mi` to `arctic-01b0.mennlabs.com` — a Cloudflare DNS record pointing to the device's IP, matching the `*.mennlabs.com` wildcard certificate
- Removed the `${{ vars.ARCTIC_URL }}` fallback pattern (no repo variables were configured)

### Deadlock prevention
- Added "Clear existing certs on device" step before upload — if certs exist in NVS but HTTPS failed to start (e.g. after a corrupted upload), the firmware returns 403 on HTTP cert uploads, creating an unrecoverable deadlock. Clearing first makes the workflow idempotent.

### Endpoint fixes
- Fixed cert upload endpoint from `/api/tls/certificates` (plural) to `/api/tls/certificate` (singular)
- Fixed reboot endpoint from `/api/system/reboot` to `/api/ota/reboot`
- Changed reboot health check from `/api/heatpump/status` (requires auth) to `/api/health` (registered as essential, works without auth)

### HTTP/HTTPS fallback
- All device API calls now try HTTP first, then fall back to HTTPS (with `-sk` for self-signed tolerance), so the workflow works whether or not HTTPS is currently active

## Testing

Ran 6 iterations of the workflow on this branch:
- Runs 1–3: identified and fixed endpoint, auth, and deadlock issues incrementally
- Run 5: first fully green run (all steps pass), but device didn't actually reboot (wrong endpoint)
- **Run 6: fully green, device rebooted, HTTPS active on port 443 with valid Let's Encrypt cert, GitHub secrets updated** ✅

Verified from the runner:
```
$ curl -s http://arctic-01b0.mennlabs.com/api/health
{"status":"ok","uptime_ms":153326}

$ curl -sk https://arctic-01b0.mennlabs.com/api/health
{"status":"ok","uptime_ms":153326}
# TLSv1.2 / ECDHE-ECDSA-AES256-GCM-SHA384
# subject: CN=*.mennlabs.com
# valid: Mar 18 – Jun 16, 2026 (Let's Encrypt E8)
```
