### PR TITLE
fix(ci): auto-detect serial ports instead of hardcoding ttyACM0/ttyACM1

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -94,6 +94,31 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 
+      - name: Detect serial ports
+        run: |
+          # USB serial port assignments (/dev/ttyACM0, /dev/ttyACM1) can swap
+          # after a reboot. Probe each port to find the ESP32-P4 (controller)
+          # and ESP32-S3 (simulator) reliably.
+          CONTROLLER_PORT=""
+          SIMULATOR_PORT=""
+          for PORT in /dev/ttyACM*; do
+            [ -e "$PORT" ] || continue
+            CHIP=$(esptool.py --port "$PORT" chip_id 2>&1 | grep -oP 'Chip is \K[^ ]+' || true)
+            echo "$PORT -> $CHIP"
+            case "$CHIP" in
+              ESP32-P4) CONTROLLER_PORT="$PORT" ;;
+              ESP32-S3*) SIMULATOR_PORT="$PORT" ;;
+            esac
+          done
+          echo "Controller port: ${CONTROLLER_PORT:-not found}"
+          echo "Simulator port: ${SIMULATOR_PORT:-not found}"
+          if [ -n "$CONTROLLER_PORT" ]; then
+            echo "CONTROLLER_PORT=$CONTROLLER_PORT" >> $GITHUB_ENV
+          fi
+          if [ -n "$SIMULATOR_PORT" ]; then
+            echo "SIMULATOR_PORT=$SIMULATOR_PORT" >> $GITHUB_ENV
+          fi
+
       - name: Update simulator to latest release
         run: |
           SIMULATOR_URL="http://arctic-simulator-ghr.mi"
@@ -141,8 +166,12 @@ jobs:
           done
 
           # 5. Flash via USB serial
-          echo "Flashing simulator on /dev/ttyACM1..."
-          esptool.py --port /dev/ttyACM1 --baud 921600 --chip esp32s3 \
+          if [ -z "$SIMULATOR_PORT" ]; then
+            echo "ERROR: No ESP32-S3 simulator detected on any serial port"
+            exit 1
+          fi
+          echo "Flashing simulator on $SIMULATOR_PORT..."
+          esptool.py --port "$SIMULATOR_PORT" --baud 921600 --chip esp32s3 \
             --before default_reset --after hard_reset \
             write_flash \
             0x0     /tmp/simulator/bootloader.bin \
@@ -295,7 +324,11 @@ jobs:
           python3 -m esp_idf_nvs_partition_gen generate \
             /tmp/nvs_wifi_resolved.csv /tmp/nvs_wifi.bin 0x6000
 
-          esptool.py --port /dev/ttyACM0 --baud 921600 --chip esp32p4 \
+          if [ -z "$CONTROLLER_PORT" ]; then
+            echo "ERROR: No ESP32-P4 controller detected on any serial port"
+            exit 1
+          fi
+          esptool.py --port "$CONTROLLER_PORT" --baud 921600 --chip esp32p4 \
             --before default_reset --after hard_reset \
             write_flash --flash_mode dio --flash_size 16MB --flash_freq 80m \
             0x2000  build/bootloader/bootloader.bin \


### PR DESCRIPTION
## Problem

The device tests have been failing daily since March 23. The Update simulator to latest release step tries to flash the ESP32-S3 simulator on \/dev/ttyACM1\, but finds the ESP32-P4 controller there instead:

\\\
A fatal error occurred: This chip is ESP32-P4, not ESP32-S3. Wrong chip argument?
\\\

The USB serial port assignments (\/dev/ttyACM0\, \/dev/ttyACM1\) swapped after a VM reboot or USB re-enumeration. The workflow had these ports hardcoded, making it fragile to any port reassignment.

The last passing run (March 22) succeeded only because the simulator was already at v0.8.0, so the flash step was skipped entirely.

## Fix

Add a **Detect serial ports** step that probes each \/dev/ttyACM*\ device using \esptool.py chip_id\ to determine which chip is on which port. It exports \CONTROLLER_PORT\ (ESP32-P4) and \SIMULATOR_PORT\ (ESP32-S3) as environment variables, which are then used by the simulator flash and controller USB flash steps instead of hardcoded paths.

## Changes

- Added \Detect serial ports\ step in the \device-tests\ job (after dependency install, before simulator update)
- Replaced hardcoded \/dev/ttyACM1\ in simulator flash with \\\
- Replaced hardcoded \/dev/ttyACM0\ in controller flash with \\\
- Added guard checks that fail fast with a clear error if the expected chip isn't found on any port