### PR TITLE
fix(ci): use sysfs USB speed to detect serial ports instead of esptool

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -98,17 +98,34 @@ jobs:
         run: |
           # USB serial port assignments (/dev/ttyACM0, /dev/ttyACM1) can swap
           # after a reboot. Probe each port to find the ESP32-P4 (controller)
-          # and ESP32-S3 (simulator) reliably.
+          # and ESP32-S3 (simulator) by reading USB device attributes from sysfs.
           CONTROLLER_PORT=""
           SIMULATOR_PORT=""
           for PORT in /dev/ttyACM*; do
             [ -e "$PORT" ] || continue
-            CHIP=$(esptool.py --port "$PORT" chip_id 2>&1 | grep -oP 'Chip is \K[^ ]+' || true)
-            echo "$PORT -> $CHIP"
-            case "$CHIP" in
-              ESP32-P4) CONTROLLER_PORT="$PORT" ;;
-              ESP32-S3*) SIMULATOR_PORT="$PORT" ;;
-            esac
+            BASENAME=$(basename "$PORT")
+            # Walk sysfs to find the USB device backing this tty
+            SYSDEV=$(readlink -f "/sys/class/tty/$BASENAME/device")
+            USB_INTF="$SYSDEV/.."
+            USB_DEV="$USB_INTF/.."
+            VID=$(cat "$USB_DEV/idVendor" 2>/dev/null || echo "?")
+            PID=$(cat "$USB_DEV/idProduct" 2>/dev/null || echo "?")
+            PRODUCT=$(cat "$USB_DEV/product" 2>/dev/null || echo "?")
+            SERIAL=$(cat "$USB_DEV/serial" 2>/dev/null || echo "?")
+            SPEED=$(cat "$USB_DEV/speed" 2>/dev/null || echo "?")
+            echo "$PORT: VID=$VID PID=$PID product='$PRODUCT' serial=$SERIAL speed=${SPEED}Mbps"
+
+            # ESP32-P4 uses USB 2.0 High-Speed (480 Mbps)
+            # ESP32-S3 uses USB 1.1 Full-Speed (12 Mbps)
+            if [ "$VID" = "303a" ]; then
+              if [ "$SPEED" = "480" ]; then
+                CONTROLLER_PORT="$PORT"
+                echo "  -> ESP32-P4 controller (high-speed USB)"
+              elif [ "$SPEED" = "12" ]; then
+                SIMULATOR_PORT="$PORT"
+                echo "  -> ESP32-S3 simulator (full-speed USB)"
+              fi
+            fi
           done
           echo "Controller port: ${CONTROLLER_PORT:-not found}"
           echo "Simulator port: ${SIMULATOR_PORT:-not found}"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -103,19 +103,20 @@ jobs:
           SIMULATOR_PORT=""
           for PORT in /dev/ttyACM*; do
             [ -e "$PORT" ] || continue
-            BASENAME=$(basename "$PORT")
-            SYSDEV=$(readlink -f "/sys/class/tty/$BASENAME/device")
-            USB_DEV="$SYSDEV/../.."
-            SERIAL=$(cat "$USB_DEV/serial" 2>/dev/null || echo "")
-            VID=$(cat "$USB_DEV/idVendor" 2>/dev/null || echo "?")
-            PID=$(cat "$USB_DEV/idProduct" 2>/dev/null || echo "?")
-            echo "$PORT: VID=$VID PID=$PID serial=$SERIAL"
-            if [ "$SERIAL" = "$CONTROLLER_USB_SERIAL" ]; then
-              CONTROLLER_PORT="$PORT"
-              echo "  -> matched controller"
-            elif [ "$SERIAL" = "$SIMULATOR_USB_SERIAL" ]; then
-              SIMULATOR_PORT="$PORT"
-              echo "  -> matched simulator"
+            # udevadm reliably finds the USB device attributes regardless of hub depth
+            SERIAL=$(udevadm info -q property --name="$PORT" | grep -oP '^ID_SERIAL_SHORT=\K.*' || echo "")
+            VID=$(udevadm info -q property --name="$PORT" | grep -oP '^ID_VENDOR_ID=\K.*' || echo "?")
+            PID=$(udevadm info -q property --name="$PORT" | grep -oP '^ID_MODEL_ID=\K.*' || echo "?")
+            MODEL=$(udevadm info -q property --name="$PORT" | grep -oP '^ID_MODEL=\K.*' || echo "?")
+            echo "$PORT: VID=$VID PID=$PID model=$MODEL serial=$SERIAL"
+            if [ -n "$SERIAL" ]; then
+              if [ "$SERIAL" = "$CONTROLLER_USB_SERIAL" ]; then
+                CONTROLLER_PORT="$PORT"
+                echo "  -> matched controller"
+              elif [ "$SERIAL" = "$SIMULATOR_USB_SERIAL" ]; then
+                SIMULATOR_PORT="$PORT"
+                echo "  -> matched simulator"
+              fi
             fi
           done
           echo "Controller port: ${CONTROLLER_PORT:-not found}"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -97,34 +97,25 @@ jobs:
       - name: Detect serial ports
         run: |
           # USB serial port assignments (/dev/ttyACM0, /dev/ttyACM1) can swap
-          # after a reboot. Probe each port to find the ESP32-P4 (controller)
-          # and ESP32-S3 (simulator) by reading USB device attributes from sysfs.
+          # after a reboot. Match each port's USB serial number (burned into
+          # eFuse, globally unique per chip) to find the controller and simulator.
           CONTROLLER_PORT=""
           SIMULATOR_PORT=""
           for PORT in /dev/ttyACM*; do
             [ -e "$PORT" ] || continue
             BASENAME=$(basename "$PORT")
-            # Walk sysfs to find the USB device backing this tty
             SYSDEV=$(readlink -f "/sys/class/tty/$BASENAME/device")
-            USB_INTF="$SYSDEV/.."
-            USB_DEV="$USB_INTF/.."
+            USB_DEV="$SYSDEV/../.."
+            SERIAL=$(cat "$USB_DEV/serial" 2>/dev/null || echo "")
             VID=$(cat "$USB_DEV/idVendor" 2>/dev/null || echo "?")
             PID=$(cat "$USB_DEV/idProduct" 2>/dev/null || echo "?")
-            PRODUCT=$(cat "$USB_DEV/product" 2>/dev/null || echo "?")
-            SERIAL=$(cat "$USB_DEV/serial" 2>/dev/null || echo "?")
-            SPEED=$(cat "$USB_DEV/speed" 2>/dev/null || echo "?")
-            echo "$PORT: VID=$VID PID=$PID product='$PRODUCT' serial=$SERIAL speed=${SPEED}Mbps"
-
-            # ESP32-P4 uses USB 2.0 High-Speed (480 Mbps)
-            # ESP32-S3 uses USB 1.1 Full-Speed (12 Mbps)
-            if [ "$VID" = "303a" ]; then
-              if [ "$SPEED" = "480" ]; then
-                CONTROLLER_PORT="$PORT"
-                echo "  -> ESP32-P4 controller (high-speed USB)"
-              elif [ "$SPEED" = "12" ]; then
-                SIMULATOR_PORT="$PORT"
-                echo "  -> ESP32-S3 simulator (full-speed USB)"
-              fi
+            echo "$PORT: VID=$VID PID=$PID serial=$SERIAL"
+            if [ "$SERIAL" = "$CONTROLLER_USB_SERIAL" ]; then
+              CONTROLLER_PORT="$PORT"
+              echo "  -> matched controller"
+            elif [ "$SERIAL" = "$SIMULATOR_USB_SERIAL" ]; then
+              SIMULATOR_PORT="$PORT"
+              echo "  -> matched simulator"
             fi
           done
           echo "Controller port: ${CONTROLLER_PORT:-not found}"
@@ -135,6 +126,9 @@ jobs:
           if [ -n "$SIMULATOR_PORT" ]; then
             echo "SIMULATOR_PORT=$SIMULATOR_PORT" >> $GITHUB_ENV
           fi
+        env:
+          CONTROLLER_USB_SERIAL: ${{ secrets.CONTROLLER_USB_SERIAL }}
+          SIMULATOR_USB_SERIAL: ${{ secrets.SIMULATOR_USB_SERIAL }}
 
       - name: Update simulator to latest release
         run: |


### PR DESCRIPTION
Fixes the detection step from #60 which used esptool chip_id — that failed because the chips are running firmware (not in download mode) so esptool can't connect.

Replaces with sysfs-based detection that reads USB device attributes to distinguish the two devices:
- **ESP32-P4** (controller): USB 2.0 High-Speed (480 Mbps)
- **ESP32-S3** (simulator): USB 1.1 Full-Speed (12 Mbps)

This is instant, needs no serial communication, and works regardless of firmware state. Also logs VID/PID/product/serial for each port for future debugging.