### PR TITLE
ci: add monthly keep-alive workflow

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,25 @@
+name: Keep-Alive
+
+# Resets GitHub's 60-day scheduled-workflow inactivity timer by pushing an
+# empty commit on the 1st of each month. Without this, Device Tests and
+# Renew TLS Certificate get auto-disabled and silently stop running.
+
+on:
+  schedule:
+    - cron: '0 12 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  poke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push empty commit
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore: keep-alive [skip ci]"
+          git push


### PR DESCRIPTION
GitHub auto-disables scheduled workflows after 60 days of repo inactivity (which just bit us — Device Tests and Renew TLS Certificate were both silently disabled).

This adds a tiny workflow that runs on the 1st of each month, pushes an empty commit, and thereby resets the inactivity timer for all scheduled workflows in the repo.

Also runnable on-demand via workflow_dispatch.