### PR TITLE
feat: plumb per-param msg_ids through API/web; fix web gzip staleness

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2014,8 +2014,27 @@ components:
           example: 13
         name:
           type: string
-          description: Human-readable name
+          description: Human-readable English name (fallback when name_msg_id is untranslated)
           example: Defrost Cycle
+        detail:
+          type: string
+          description: >-
+            Human-readable English detail/help text (fallback when detail_msg_id
+            is untranslated). May contain `{T:<celsius>}` temperature tokens the
+            UI substitutes with a converted, unit-labelled value.
+          example: Time between defrost cycles.
+        name_msg_id:
+          type: string
+          description: >-
+            Stable translation key for `name` (e.g. `ap.max_hw_setpoint.name`).
+            UIs translate by this key and fall back to `name` when untranslated.
+          example: ap.max_hw_setpoint.name
+        detail_msg_id:
+          type: string
+          description: >-
+            Stable translation key for `detail` (e.g. `ap.max_hw_setpoint.detail`).
+            UIs translate by this key and fall back to `detail` when untranslated.
+          example: ap.max_hw_setpoint.detail
         unit:
           type: string
           description: Unit of measurement

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,31 +1,35 @@
 # Web UI gzip compression
-# Generate gzipped web file at configure time if source is newer
+# The embedded dashboard is stored gzipped in flash. Two rules keep the .gz in
+# sync with the source HTML:
+#   1. execute_process (configure time) guarantees the .gz exists so the initial
+#      EMBED_FILES resolution below succeeds on a clean tree.
+#   2. add_custom_command (build time) re-gzips whenever web/index.html or the
+#      gzip script changes, so a plain `idf.py build` always re-embeds the latest
+#      markup WITHOUT needing an explicit `idf.py reconfigure`.
 set(WEB_SRC "${CMAKE_CURRENT_SOURCE_DIR}/web/index.html")
 set(WEB_GZ "${CMAKE_CURRENT_SOURCE_DIR}/web/index.html.gz")
 set(GZIP_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/web/gzip_html.py")
 
-# Check if we need to regenerate the gzip file
-if(EXISTS "${WEB_SRC}")
-    if(NOT EXISTS "${WEB_GZ}" OR "${WEB_SRC}" IS_NEWER_THAN "${WEB_GZ}")
-        message(STATUS "Compressing web/index.html -> index.html.gz")
-        # Find Python - prefer IDF's Python, then system Python
-        # Use Python3::Interpreter if available (set by ESP-IDF), otherwise find it
-        if(Python3_EXECUTABLE)
-            set(PYTHON_CMD "${Python3_EXECUTABLE}")
-        else()
-            find_program(PYTHON_CMD NAMES python3 python)
-        endif()
-        if(NOT PYTHON_CMD)
-            message(FATAL_ERROR "Python not found - required for gzip compression")
-        endif()
-        execute_process(
-            COMMAND "${PYTHON_CMD}" "${GZIP_SCRIPT}" "${WEB_SRC}" "${WEB_GZ}"
-            RESULT_VARIABLE GZIP_RESULT
-            ERROR_VARIABLE GZIP_ERROR
-        )
-        if(NOT GZIP_RESULT EQUAL 0)
-            message(FATAL_ERROR "Failed to gzip web/index.html (exit code: ${GZIP_RESULT}, error: ${GZIP_ERROR})")
-        endif()
+# Find Python once - prefer IDF's Python, then system Python.
+if(Python3_EXECUTABLE)
+    set(PYTHON_CMD "${Python3_EXECUTABLE}")
+else()
+    find_program(PYTHON_CMD NAMES python3 python)
+endif()
+if(NOT PYTHON_CMD)
+    message(FATAL_ERROR "Python not found - required for gzip compression")
+endif()
+
+# Configure-time: ensure the .gz exists for the initial EMBED_FILES resolution.
+if(EXISTS "${WEB_SRC}" AND (NOT EXISTS "${WEB_GZ}" OR "${WEB_SRC}" IS_NEWER_THAN "${WEB_GZ}"))
+    message(STATUS "Compressing web/index.html -> index.html.gz")
+    execute_process(
+        COMMAND "${PYTHON_CMD}" "${GZIP_SCRIPT}" "${WEB_SRC}" "${WEB_GZ}"
+        RESULT_VARIABLE GZIP_RESULT
+        ERROR_VARIABLE GZIP_ERROR
+    )
+    if(NOT GZIP_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to gzip web/index.html (exit code: ${GZIP_RESULT}, error: ${GZIP_ERROR})")
     endif()
 endif()
 
@@ -104,3 +108,15 @@ idf_component_register(
         mbedtls
         arctic-macon
 )
+
+# Build-time: re-gzip whenever the source HTML or the gzip script changes, so
+# `idf.py build` alone re-embeds the latest dashboard (no reconfigure needed).
+add_custom_command(
+    OUTPUT "${WEB_GZ}"
+    COMMAND "${PYTHON_CMD}" "${GZIP_SCRIPT}" "${WEB_SRC}" "${WEB_GZ}"
+    DEPENDS "${WEB_SRC}" "${GZIP_SCRIPT}"
+    COMMENT "Gzipping web/index.html"
+    VERBATIM
+)
+add_custom_target(web_assets DEPENDS "${WEB_GZ}")
+add_dependencies(${COMPONENT_LIB} web_assets)

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -2288,6 +2288,8 @@ static void add_ap_to_json(cJSON* parent, const arctic::AdvancedParam* p, bool r
     cJSON_AddNumberToObject(obj, "ap", p->ap);
     cJSON_AddStringToObject(obj, "name", p->name ? p->name : "");
     cJSON_AddStringToObject(obj, "detail", p->detail ? p->detail : "");
+    cJSON_AddStringToObject(obj, "name_msg_id", p->name_msg_id ? p->name_msg_id : "");
+    cJSON_AddStringToObject(obj, "detail_msg_id", p->detail_msg_id ? p->detail_msg_id : "");
     if (read_ok) {
         cJSON_AddNumberToObject(obj, "value", value);
     } else {
@@ -2392,7 +2394,8 @@ static esp_err_t heatpump_advanced_single_get_handler(httpd_req_t* req)
     cJSON_AddStringToObject(root, "key", key);
     cJSON_AddStringToObject(root, "name", p->name ? p->name : "");
     cJSON_AddStringToObject(root, "detail", p->detail ? p->detail : "");
-    cJSON_AddStringToObject(root, "unit", p->unit ? p->unit : "");
+    cJSON_AddStringToObject(root, "name_msg_id", p->name_msg_id ? p->name_msg_id : "");
+    cJSON_AddStringToObject(root, "detail_msg_id", p->detail_msg_id ? p->detail_msg_id : "");
     cJSON_AddStringToObject(root, "category", p->category ? p->category : "");
     cJSON_AddNumberToObject(root, "min", p->min_val);
     cJSON_AddNumberToObject(root, "max", p->max_val);

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -4442,7 +4442,15 @@
                     let full = (p && p.detail) ? p.detail : (extra ? extra.full : null);
                     const remarks = extra ? extra.remarks : undefined;
                     if (!full && !remarks) return null;
-                    return { full: full || '', remarks };
+                    return { full: this.substTemps(full || ''), remarks };
+                },
+
+                // Substitute {T:<celsius>} tokens in a library detail string with a
+                // displayable temperature. The web always presents native °C
+                // (there is no C/F toggle), matching the firmware's no-space
+                // format (e.g. "-9°C"), so the token value is emitted verbatim.
+                substTemps(text) {
+                    return text.replace(/\{T:(-?\d+)\}/g, (_, c) => c + '\u00b0C');
                 },
 
                 // The enum option matching a param's current wire value, or null.


### PR DESCRIPTION
## Summary

Phase 3 of the advanced-param localization work: extend the `msg_id` plumbing (already used for the K-ratio block) to **all** advanced parameters, and fix a long-standing web-gzip staleness footgun.

### Library (via arctic-macon #12, submodule bump)
- All 34 advanced params now carry `name_msg_id` / `detail_msg_id` stable keys.

### API (`api_server.cpp` + `docs/openapi.yaml`)
- Serialize `name_msg_id` / `detail_msg_id` in the advanced-param **list** and **single-get** responses.
- Document `detail`, `name_msg_id`, `detail_msg_id` on the `AdvancedParam` schema.

### Web (`main/web/index.html`)
- Substitute `{T:<celsius>}` temperature tokens in param detail text (web always presents native °C), so tokens no longer render raw.

### Build fix (`main/CMakeLists.txt`)
- Re-gzip `web/index.html` at **build time** via a custom command (previously only at configure time). A plain `idf.py build` now always re-embeds the latest dashboard — **no more `idf.py reconfigure` needed** after editing the HTML. (Ported from the heatlink project's fix.)

## Testing
- Native library test asserts all 34 params have both msg_ids — passes.
- Firmware built and OTA-flashed to device 192.168.1.201:
  - Single-get + list responses include `name_msg_id` / `detail_msg_id` on all 34 params.
  - K-ratio detail still returns `{T:}` tokens + options.
  - Verified a plain `idf.py build` re-gzips (`[1/11] Gzipping web/index.html`) and the served 240 KB page contains the new `substTemps` logic.

## Notes
- FR/ES **translations** for the 27 newly-keyed params are a deliberate future pass; this PR is plumbing + English-verifiable only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>