### PR TITLE
Make screen navigation instant and add swipe home

### DIFF
--- a/main/heatpump_errors_screen.cpp
+++ b/main/heatpump_errors_screen.cpp
@@ -626,8 +626,8 @@ void heatpump_errors_show(heatpump_errors_close_cb_t on_close) {
     // Periodic check — only rebuilds when error registers or history actually change
     state.update_timer = lv_timer_create(error_screen_timer_cb, 2000, nullptr);
     
-    // Load screen with animation
-    lv_screen_load_anim(state.screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, false);
+    // Match persistent tab navigation: switch screens immediately.
+    lv_screen_load(state.screen);
     
     ESP_LOGI(TAG, "Error details screen shown");
 }

--- a/main/heatpump_screen.cpp
+++ b/main/heatpump_screen.cpp
@@ -432,10 +432,9 @@ static lv_obj_t* create_expandable_panel(lv_obj_t* parent, const char* title,
 }
 
 static void on_errors_close(void) {
-    // Load saved screen back with fade animation
-    // auto_del=true - LVGL will delete the sub-screen after animation
+    // Match persistent tab navigation: return immediately.
     if (state.saved_screen) {
-        lv_screen_load_anim(state.saved_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, true);
+        lv_screen_load_anim(state.saved_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);
         state.saved_screen = nullptr;
     }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -515,14 +515,14 @@ static void on_status_bar_wifi_click(void)
         }
     }
     
-    // Open WiFi screen directly (back button will fade back to main screen)
+    // Open WiFi screen directly from the status bar.
     bsp_display_lock(0);
     wifi_screen_config_t wifi_cfg = {
         .on_wifi_scan = on_wifi_scan,
         .on_wifi_connect = on_wifi_connect,
         .on_wifi_disconnect = on_wifi_disconnect,
-        .on_back = on_wifi_screen_close,  // Fade back to main screen
-        .use_fade = true,                  // Fade in from status bar
+        .on_back = on_wifi_screen_close,
+        .use_instant_transition = true,
     };
     wifi_screen_create(&wifi_cfg);
     bsp_display_unlock();
@@ -604,9 +604,9 @@ static void on_settings_close(void)
     
     bsp_display_lock(0);
     
-    // Load main screen with slide-up animation (auto_del=true will delete settings menu)
+    // Return immediately; auto_del deletes the settings menu screen.
     if (main_screen) {
-        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, true);
+        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);
     }
     
     // Mark settings as closed (screen will be auto-deleted by LVGL)
@@ -621,9 +621,9 @@ static void on_wifi_screen_close(void)
 {
     mclog::tagInfo(TAG, "WiFi screen closed (from status bar)");
     
-    // Load main screen with fade animation (auto_del=true deletes WiFi screen)
+    // Return immediately; auto_del deletes the WiFi screen.
     if (main_screen) {
-        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, true);
+        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);
     }
 }
 
@@ -640,14 +640,13 @@ static void on_status_bar_notify_item_click(status_bar_notify_type_t type)
     // Handle specific actions based on type
     switch (type) {
         case STATUS_BAR_NOTIFY_FIRMWARE_UPDATE: {
-            // Open firmware screen directly with fade animation
+            // Open firmware screen directly from the notification.
             bsp_display_lock(0);
             firmware_screen_config_t fw_cfg = {
                 .on_back = []() {
-                    // Fade back to main screen
                     extern lv_obj_t* main_screen;
                     if (main_screen) {
-                        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, true);
+                        lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);
                     }
                     firmware_screen_close();
                 },

--- a/main/nav_bar.cpp
+++ b/main/nav_bar.cpp
@@ -61,6 +61,14 @@ static void nav_btn_cb(lv_event_t* e) {
     tab_shell_select(target);
 }
 
+static void nav_gesture_cb(lv_event_t* e) {
+    (void)e;
+    lv_indev_t* indev = lv_indev_active();
+    if (indev && lv_indev_get_gesture_dir(indev) == LV_DIR_TOP) {
+        tab_shell_select(NAV_TAB_HOME);
+    }
+}
+
 lv_obj_t* nav_bar_create(lv_obj_t* screen, nav_tab_t active) {
     lv_obj_t* bar = lv_obj_create(screen);
     lv_obj_set_size(bar, LV_PCT(100), NAV_BAR_H);
@@ -77,6 +85,8 @@ lv_obj_t* nav_bar_create(lv_obj_t* screen, nav_tab_t active) {
     lv_obj_set_flex_flow(bar, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(bar, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_user_data(bar, (void*)"nav_bar");
+    lv_obj_remove_flag(bar, LV_OBJ_FLAG_GESTURE_BUBBLE);
+    lv_obj_add_event_cb(bar, nav_gesture_cb, LV_EVENT_GESTURE, nullptr);
 
     for (int i = 0; i < NAV_TAB_COUNT; i++) {
         const nav_tab_def_t* t = &s_tabs[i];

--- a/main/settings/settings_menu.cpp
+++ b/main/settings/settings_menu.cpp
@@ -390,7 +390,7 @@ static void row_click_cb(lv_event_t* e)
             .on_wifi_connect = state.config.on_wifi_connect,
             .on_wifi_disconnect = state.config.on_wifi_disconnect,
             .on_back = settings_menu_show,
-            .use_fade = false,
+            .use_instant_transition = false,
         };
         wifi_screen_create(&wifi_cfg);
         state.sub_screen_active = true;
@@ -609,8 +609,7 @@ void settings_menu_create(const settings_menu_config_t* config)
         settings_menu_update_wifi_status(true, wifi_mgr_get_connected_ssid());
     }
     
-    // Slide down from top when opening settings
-    lv_screen_load_anim(state.screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, false);
+    lv_screen_load(state.screen);
 }
 
 void settings_menu_close(void)

--- a/main/settings/settings_wifi_screen.cpp
+++ b/main/settings/settings_wifi_screen.cpp
@@ -171,10 +171,11 @@ void wifi_screen_create(const wifi_screen_config_t* config)
     create_networks_section();
     create_password_dialog();
     
-    // Load screen with appropriate animation
-    // Fade for status bar entry, slide-left for settings menu entry
-    lv_scr_load_anim_t anim = s_state.config.use_fade ? LV_SCR_LOAD_ANIM_FADE_IN : LV_SCR_LOAD_ANIM_MOVE_LEFT;
-    lv_screen_load_anim(s_state.screen, anim, 300, 0, false);
+    // Status-bar entry is instant; settings-menu navigation retains its slide.
+    lv_scr_load_anim_t anim = s_state.config.use_instant_transition
+        ? LV_SCR_LOAD_ANIM_NONE
+        : LV_SCR_LOAD_ANIM_MOVE_LEFT;
+    lv_screen_load_anim(s_state.screen, anim, s_state.config.use_instant_transition ? 0 : 300, 0, false);
     s_state.visible = true;
     
     // Check current connection status

--- a/main/settings/settings_wifi_screen.h
+++ b/main/settings/settings_wifi_screen.h
@@ -21,7 +21,7 @@ typedef struct {
     void (*on_wifi_connect)(const char* ssid, const char* password);
     void (*on_wifi_disconnect)(void);
     void (*on_back)(void);  // Called when back button is pressed
-    bool use_fade;          // Use fade animation instead of slide (for status bar entry)
+    bool use_instant_transition;  // Open immediately instead of sliding from the settings menu
 } wifi_screen_config_t;
 
 /**


### PR DESCRIPTION
## Summary
- remove all screen-load fade transitions while retaining the startup animation
- make error, settings, Wi-Fi, and firmware navigation instant where fades were used
- add swipe-up from the persistent bottom nav bar to return to Home
- scope the gesture to the main tab shell so full-screen settings, Wi-Fi, firmware, and error screens ignore it safely

## Validation
- ESP-IDF firmware build
- flashed and booted local Tab5