### PR TITLE
Dim display after five minutes of inactivity

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -44,6 +44,7 @@ idf_component_register(
         "ota_manager.cpp"
         "auth_manager.cpp"
         "app_preferences.cpp"
+        "display_idle.cpp"
         "advanced_params.cpp"
         "heatpump_errors.cpp"
         "event_log.cpp"

--- a/main/display_idle.cpp
+++ b/main/display_idle.cpp
@@ -1,0 +1,93 @@
+#include "display_idle.h"
+
+#include "settings/settings_display_screen.h"
+#include <bsp/display.h>
+#include <esp_log.h>
+#include <lvgl.h>
+
+static const char* TAG = "display_idle";
+
+static constexpr uint32_t IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+static constexpr int IDLE_BRIGHTNESS = 10;
+static constexpr uint32_t CHECK_INTERVAL_MS = 1000;
+
+static bool s_initialized = false;
+static bool s_dimmed = false;
+static uint32_t s_last_activity_ms = 0;
+
+static void restore_saved_brightness()
+{
+    const int brightness = display_screen_get_brightness();
+    esp_err_t err = bsp_display_brightness_set(brightness);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to restore brightness: %s", esp_err_to_name(err));
+    }
+}
+
+void display_idle_force_dim(void)
+{
+    if (display_screen_get_brightness() <= IDLE_BRIGHTNESS) {
+        s_last_activity_ms = lv_tick_get();
+        s_dimmed = false;
+        return;
+    }
+
+    esp_err_t err = bsp_display_brightness_set(IDLE_BRIGHTNESS);
+    if (err == ESP_OK) {
+        s_dimmed = true;
+        ESP_LOGI(TAG, "Display dimmed to %d%%", IDLE_BRIGHTNESS);
+    } else {
+        ESP_LOGE(TAG, "Failed to dim display: %s", esp_err_to_name(err));
+    }
+}
+
+bool display_idle_handle_activity(void)
+{
+    s_last_activity_ms = lv_tick_get();
+    if (!s_dimmed) return false;
+
+    restore_saved_brightness();
+    s_dimmed = false;
+    ESP_LOGI(TAG, "Display restored after user activity");
+    return true;
+}
+
+bool display_idle_is_dimmed(void)
+{
+    return s_dimmed;
+}
+
+static void input_event_cb(lv_event_t* event)
+{
+    if (!display_idle_handle_activity()) return;
+
+    lv_indev_t* indev = static_cast<lv_indev_t*>(lv_event_get_current_target(event));
+    if (indev) {
+        lv_indev_stop_processing(indev);
+        lv_indev_wait_release(indev);
+    }
+}
+
+static void idle_timer_cb(lv_timer_t*)
+{
+    if (!s_dimmed && lv_tick_elaps(s_last_activity_ms) >= IDLE_TIMEOUT_MS) {
+        display_idle_force_dim();
+    }
+}
+
+void display_idle_init(void)
+{
+    if (s_initialized) return;
+
+    s_last_activity_ms = lv_tick_get();
+    for (lv_indev_t* indev = lv_indev_get_next(nullptr);
+         indev != nullptr;
+         indev = lv_indev_get_next(indev)) {
+        if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER) {
+            lv_indev_add_event_cb(indev, input_event_cb, LV_EVENT_PRESSED, nullptr);
+        }
+    }
+    lv_timer_create(idle_timer_cb, CHECK_INTERVAL_MS, nullptr);
+    s_initialized = true;
+    ESP_LOGI(TAG, "Idle dimming enabled after %lu ms", (unsigned long)IDLE_TIMEOUT_MS);
+}

--- a/main/display_idle.h
+++ b/main/display_idle.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize display inactivity tracking and pointer input interception.
+ * Must be called after the LVGL display and input devices are created.
+ */
+void display_idle_init(void);
+
+/**
+ * Record user activity.
+ * @return true when this activity woke a dimmed display and must be consumed.
+ */
+bool display_idle_handle_activity(void);
+
+/**
+ * Dim immediately using the normal idle behavior.
+ * Intended for test instrumentation.
+ */
+void display_idle_force_dim(void);
+
+/**
+ * @return true while the display is idle-dimmed.
+ */
+bool display_idle_is_dimmed(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -20,6 +20,7 @@
 #include "settings/settings_firmware_screen.h"
 #include "settings/settings_time_screen.h"
 #include "settings/settings_display_screen.h"
+#include "display_idle.h"
 #include "i18n/i18n.h"
 #include "auth_manager.h"
 #include "tls_manager.h"
@@ -187,6 +188,7 @@ extern "C" void app_main(void)
 
     // Start the startup animation
     bsp_display_lock(0);
+    display_idle_init();
     startup_anim_init(on_startup_complete);
     bsp_display_unlock();
 

--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -36,6 +36,7 @@
 #include "event_log_screen.h"
 #include "tab_shell.h"
 #include "status_bar.h"
+#include "display_idle.h"
 #include <esp_timer.h>
 #include "png_encoder.h"
 
@@ -646,6 +647,20 @@ static esp_err_t click_post_handler(httpd_req_t* req)
         target = found;
     }
 
+    // Test clicks emulate physical touch activity, including wake-only behavior.
+    const bool consumed = display_idle_handle_activity();
+    if (consumed) {
+        bsp_display_unlock();
+        cJSON* resp = cJSON_CreateObject();
+        cJSON_AddBoolToObject(resp, "success", true);
+        cJSON_AddBoolToObject(resp, "consumed", true);
+        char* json = cJSON_PrintUnformatted(resp);
+        httpd_resp_sendstr(req, json);
+        free(json);
+        cJSON_Delete(resp);
+        return ESP_OK;
+    }
+
     // Fire the click event (measure render time for performance profiling)
     int64_t t0 = esp_timer_get_time();
     lv_obj_send_event(target, LV_EVENT_CLICKED, NULL);
@@ -660,6 +675,7 @@ static esp_err_t click_post_handler(httpd_req_t* req)
     // Send success response
     cJSON* resp = cJSON_CreateObject();
     cJSON_AddBoolToObject(resp, "success", true);
+    cJSON_AddBoolToObject(resp, "consumed", false);
     cJSON_AddStringToObject(resp, "clicked_type", clicked_type);
     if (clicked_text) {
         cJSON_AddStringToObject(resp, "clicked_text", clicked_text);
@@ -758,6 +774,73 @@ static esp_err_t set_slider_post_handler(httpd_req_t* req)
     free(json);
     cJSON_Delete(resp);
 
+    return ESP_OK;
+}
+
+// ============================================================================
+// POST /api/test/display-idle
+// Body: {"action": "dim" | "wake" | "status"}
+// ============================================================================
+
+static esp_err_t display_idle_post_handler(httpd_req_t* req)
+{
+    CHECK_SESSION_LOCK(req);
+    set_json_content_type(req);
+
+    if (req->content_len <= 0 || req->content_len >= 128) {
+        send_json_error(req, "400 Bad Request", "Invalid body");
+        return ESP_OK;
+    }
+
+    char buf[128];
+    int received = httpd_req_recv(req, buf, req->content_len);
+    if (received <= 0) {
+        send_json_error(req, "400 Bad Request", "Failed to read body");
+        return ESP_OK;
+    }
+    buf[received] = '\0';
+
+    cJSON* body = cJSON_Parse(buf);
+    cJSON* action = body ? cJSON_GetObjectItem(body, "action") : nullptr;
+    if (!cJSON_IsString(action)) {
+        cJSON_Delete(body);
+        send_json_error(req, "400 Bad Request", "Action must be dim, wake, or status");
+        return ESP_OK;
+    }
+
+    const bool should_dim = strcmp(action->valuestring, "dim") == 0;
+    const bool should_wake = strcmp(action->valuestring, "wake") == 0;
+    const bool should_report = strcmp(action->valuestring, "status") == 0;
+    if (!should_dim && !should_wake && !should_report) {
+        cJSON_Delete(body);
+        send_json_error(req, "400 Bad Request", "Action must be dim, wake, or status");
+        return ESP_OK;
+    }
+    cJSON_Delete(body);
+
+    if (!bsp_display_lock(1000)) {
+        send_json_error(req, "503 Service Unavailable", "Could not acquire display lock");
+        return ESP_OK;
+    }
+    bool consumed = false;
+    if (should_dim) {
+        display_idle_force_dim();
+    } else if (should_wake) {
+        consumed = display_idle_handle_activity();
+    }
+    const bool dimmed = display_idle_is_dimmed();
+    const int saved_brightness = display_screen_get_brightness();
+    bsp_display_unlock();
+
+    cJSON* resp = cJSON_CreateObject();
+    cJSON_AddBoolToObject(resp, "success", true);
+    cJSON_AddBoolToObject(resp, "dimmed", dimmed);
+    cJSON_AddBoolToObject(resp, "consumed", consumed);
+    cJSON_AddNumberToObject(resp, "saved_brightness", saved_brightness);
+    char* json = cJSON_PrintUnformatted(resp);
+    httpd_resp_sendstr(req, json);
+    free(json);
+    cJSON_Delete(resp);
     return ESP_OK;
 }
 
@@ -1782,6 +1865,22 @@ void test_endpoints_register(httpd_handle_t server)
         .user_ctx = NULL
     };
     httpd_register_uri_handler(server, &set_slider_options_uri);
+
+    httpd_uri_t display_idle_uri = {
+        .uri = "/api/test/display-idle",
+        .method = HTTP_POST,
+        .handler = display_idle_post_handler,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &display_idle_uri);
+
+    httpd_uri_t display_idle_options_uri = {
+        .uri = "/api/test/display-idle",
+        .method = HTTP_OPTIONS,
+        .handler = test_options_handler,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &display_idle_options_uri);
 
     httpd_uri_t scroll_uri = {
         .uri = "/api/test/scroll",

--- a/tests/device/device_client.py
+++ b/tests/device/device_client.py
@@ -222,6 +222,16 @@ class DeviceClient:
         r.raise_for_status()
         return r.json()["brightness"]
 
+    def set_display_idle(self, action: str) -> dict:
+        """Force or inspect display idle state through test instrumentation."""
+        r = self.session.post(
+            f"{self.base_url}/api/test/display-idle",
+            json={"action": action},
+            timeout=self.timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
     def get_preferences(self) -> dict:
         """GET /api/preferences — returns {demo_mode, temp_unit, brightness, language}."""
         r = self.session.get(

--- a/tests/device/test_display_idle.py
+++ b/tests/device/test_display_idle.py
@@ -1,0 +1,23 @@
+from device_client import DeviceClient
+
+
+def test_dimmed_display_consumes_first_touch(device: DeviceClient):
+    """The first touch wakes the display without activating its target."""
+    device.wait_for_screen("main", timeout=5.0)
+
+    dimmed = device.set_display_idle("dim")
+    assert dimmed["dimmed"] is True
+    assert dimmed["saved_brightness"] > 10
+
+    wake = device.click(tag="settings")
+    assert wake["consumed"] is True
+    assert device.get_ui_state()["screen"] == "main"
+
+    status = device.set_display_idle("status")
+    assert status["dimmed"] is False
+
+    opened = device.click(tag="settings")
+    assert opened["consumed"] is False
+    device.wait_for_screen("settings", timeout=5.0)
+    device.click(tag="settings_close")
+    device.wait_for_screen("main", timeout=5.0)


### PR DESCRIPTION
## Summary

- dim the Tab5 backlight to 10% after five minutes without touch activity
- restore the brightness saved in Settings when the user returns
- consume the first wake touch so it cannot accidentally activate a control
- add device-test instrumentation and coverage for dim, wake, and second-touch activation

## Testing

- ESP-IDF firmware build
- physical-device five-minute inactivity threshold
- physical-device dim/wake/consume behavior
- existing display brightness tests
