### PR TITLE
Allow cooling setpoints down to 4C

### DIFF
--- a/main/web/index.html
+++ b/main/web/index.html
@@ -3516,7 +3516,7 @@
                     aux_heater: false,
                     temperatures: { tank: 0, outlet: 0, inlet: 0, outdoor: 0, discharge: 0, suction: 0, outdoor_coil: 0, indoor_coil: 0, ipm: 0 },
                     setpoints: { cooling: 0, heating: 0, hot_water: 0 },
-                    setpoint_limits: { cooling: { min: 10, max: 30 }, heating: { min: 20, max: 60 }, hot_water: { min: 30, max: 60 } },
+                    setpoint_limits: { cooling: { min: 4, max: 30 }, heating: { min: 20, max: 60 }, hot_water: { min: 30, max: 60 } },
                     readings: { compressor_freq: 0, fan_rpm: 0, ac_voltage: 0, ac_current: 0, primary_eev: 0, secondary_eev: 0, power_consumption: 0 },
                     error: null 
                 },
@@ -3948,7 +3948,7 @@
                             aux_heater: data.aux_heater || false,
                             temperatures: data.temperatures || { tank: 0, outlet: 0, inlet: 0, outdoor: 0, discharge: 0, suction: 0, outdoor_coil: 0, indoor_coil: 0, ipm: 0 },
                             setpoints: data.setpoints || { cooling: 0, heating: 0, hot_water: 0 },
-                            setpoint_limits: data.setpoint_limits || { cooling: { min: 10, max: 30 }, heating: { min: 20, max: 60 }, hot_water: { min: 30, max: 60 } },
+                            setpoint_limits: data.setpoint_limits || { cooling: { min: 4, max: 30 }, heating: { min: 20, max: 60 }, hot_water: { min: 30, max: 60 } },
                             readings: data.readings || { compressor_freq: 0, fan_rpm: 0, ac_voltage: 0, ac_current: 0, primary_eev: 0, secondary_eev: 0, power_consumption: 0 },
                             has_error: data.has_error || false,
                             error: data.error || null

--- a/tests/device/test_control_screen.py
+++ b/tests/device/test_control_screen.py
@@ -208,7 +208,7 @@ class TestSetpoints:
         try:
             slider = device.find_widget(tag="edit_slider")
             assert slider is not None, "Setpoint slider not found"
-            assert slider.min < slider.max
+            assert (slider.min, slider.max) == (4, 30)
             assert not _has_text_containing(device, "Range:"), \
                 "Slider editor should not repeat its enforced range as text"
         finally:


### PR DESCRIPTION
## Summary

- consume the Macon-owned 4°C cooling setpoint minimum
- update web dashboard fallback limits
- verify the physical setpoint slider exposes 4–30°C

## Dependency

- sslivins/arctic-macon#15

## Testing

- ESP-IDF firmware build
- physical-device cooling setpoint slider test
