### PR TITLE
fix: limit firmware update checks

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -62,7 +62,7 @@ static volatile bool wifi_init_complete = false;
 
 // Periodic update check timer
 static lv_timer_t* update_check_timer = NULL;
-#define UPDATE_CHECK_INTERVAL_MS (60 * 1000)  // 1 minute for testing (change to 60*60*1000 for hourly)
+#define UPDATE_CHECK_INTERVAL_MS (60 * 60 * 1000)  // 1 hour
 
 // WiFi stability tracking
 #define WIFI_UNSTABLE_THRESHOLD 3       // Number of disconnects to trigger "unstable" notification

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -890,7 +890,7 @@
     async function mutate(url, options, success) {
       state.busy = true;
       try { const data = await api(url, options); if (success) toast(success, "good"); return data; }
-      catch (error) { toast(error.message, "bad"); throw error; }
+      catch (error) { toast(error.message, "bad"); error.toastShown = true; throw error; }
       finally { state.busy = false; }
     }
     function jsonOptions(method, body) {
@@ -1024,14 +1024,18 @@
       if (settings) { event.preventDefault(); await navigate("settings", settings.dataset.settings); return; }
       const action = event.target.closest("[data-action]");
       if (action && action.dataset.action !== "power-hold") {
-        event.preventDefault(); handleAction(action.dataset.action, action).catch(error => toast(error.message, "bad"));
+        event.preventDefault(); handleAction(action.dataset.action, action).catch(error => {
+          if (!error.toastShown) toast(error.message, "bad");
+        });
       }
     });
     document.addEventListener("submit", event => {
       const form = event.target.closest("[data-form]");
       if (!form) return;
       event.preventDefault();
-      handleForm(form).catch(error => toast(error.message, "bad"));
+      handleForm(form).catch(error => {
+        if (!error.toastShown) toast(error.message, "bad");
+      });
     });
     document.addEventListener("pointerdown", event => {
       const button = event.target.closest('[data-action="power-hold"]');

--- a/tests/api/test_update_check_rate_limit.py
+++ b/tests/api/test_update_check_rate_limit.py
@@ -1,0 +1,31 @@
+"""Guard update-check behavior against exhausting GitHub's public API quota."""
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = ROOT / "main" / "main.cpp"
+WEB = ROOT / "main" / "web" / "index.html"
+
+
+def test_periodic_update_check_is_at_least_hourly():
+    source = MAIN.read_text(encoding="utf-8")
+    match = re.search(
+        r"#define\s+UPDATE_CHECK_INTERVAL_MS\s+\(([^)]+)\)",
+        source,
+    )
+    assert match, "UPDATE_CHECK_INTERVAL_MS definition not found"
+
+    factors = [int(value) for value in re.findall(r"\d+", match.group(1))]
+    interval_ms = 1
+    for factor in factors:
+        interval_ms *= factor
+
+    assert interval_ms >= 60 * 60 * 1000
+
+
+def test_mutation_errors_are_not_toasted_twice():
+    source = WEB.read_text(encoding="utf-8")
+    assert "error.toastShown = true" in source
+    assert source.count("if (!error.toastShown) toast(error.message, \"bad\");") == 2


### PR DESCRIPTION
## Summary
- reduce automatic GitHub release checks from every minute to hourly
- prevent mutation failures from producing duplicate Web UI toasts
- add regression coverage for both behaviors

## Testing
- `python -m pytest tests/api/test_update_check_rate_limit.py tests/api/test_openapi_coverage.py -q -p no:cacheprovider`
- full ESP-IDF firmware build