### PR TITLE
ci: release from exact-SHA post-merge attestation, not a re-run

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,32 +8,123 @@ on:
         required: false
         default: false
         type: boolean
+      target_sha:
+        description: 'Full commit SHA on main to release (defaults to current main HEAD)'
+        required: false
+        default: ''
+        type: string
 
-# Device serialization is handled by the device-tests.yml reusable workflow's
-# own concurrency group — no need to duplicate it here.
+# This workflow no longer runs the physical device suite. It consumes the
+# attestation produced by the authoritative post-merge device-tests.yml run
+# for the exact target SHA, so releases never re-run the ~40-minute hardware
+# suite and there is no device to serialize here.
 
 permissions:
   contents: write
   checks: write
+  actions: read
 
 jobs:
-  device-tests:
-    uses: ./.github/workflows/device-tests.yml
-    secrets: inherit
+  verify-validation:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve and require a full target SHA
+        id: resolve
+        env:
+          INPUT_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          MAIN_SHA=$(git rev-parse origin/main)
+          if [ -n "$INPUT_SHA" ]; then
+            # Expand to a full SHA and require it to be an ancestor-or-equal of main.
+            TARGET_SHA=$(git rev-parse "$INPUT_SHA^{commit}")
+          else
+            TARGET_SHA="$MAIN_SHA"
+          fi
+          if [ "$TARGET_SHA" != "$MAIN_SHA" ]; then
+            echo "::error::Target SHA $TARGET_SHA is not the current main HEAD ($MAIN_SHA). Releases must target main's tip."
+            exit 1
+          fi
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "✅ Release target SHA: $TARGET_SHA"
+
+      - name: Require a successful post-merge device validation for this SHA
+        id: run
+        env:
+          TARGET_SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          RUNS=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/device-tests.yml/runs?head_sha=$TARGET_SHA&event=push&status=completed&per_page=100")
+          RUN_ID=$(echo "$RUNS" | jq -r \
+            '[.workflow_runs[] | select(.conclusion=="success")] | sort_by(.run_started_at) | last | .id // empty')
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No successful push-to-main device-tests run found for $TARGET_SHA. The exact commit must pass the physical device suite before it can be released."
+            exit 1
+          fi
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "✅ Found validated run $RUN_ID for $TARGET_SHA"
+
+      - name: Download and verify the validation attestation
+        env:
+          TARGET_SHA: ${{ steps.resolve.outputs.sha }}
+          RUN_ID: ${{ steps.run.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          gh run download "$RUN_ID" -R "${{ github.repository }}" \
+            -n "release-attestation-$TARGET_SHA" -D attestation
+          FILE=attestation/release-attestation.json
+          if [ ! -f "$FILE" ]; then
+            echo "::error::Validation run $RUN_ID did not publish a release attestation."
+            exit 1
+          fi
+          echo "Attestation contents:"; cat "$FILE"
+          TREE_SHA=$(git rev-parse "$TARGET_SHA^{tree}")
+          jq -e --arg sha "$TARGET_SHA" '.commit_sha == $sha' "$FILE" > /dev/null \
+            || { echo "::error::Attestation commit_sha does not match $TARGET_SHA"; exit 1; }
+          jq -e --arg t "$TREE_SHA" '.tree_sha == $t' "$FILE" > /dev/null \
+            || { echo "::error::Attestation tree_sha does not match $TREE_SHA"; exit 1; }
+          jq -e '.suites.ui == "success" and .suites.api == "success" and .suites.web == "success"' "$FILE" > /dev/null \
+            || { echo "::error::Attestation records a non-passing suite"; exit 1; }
+          echo "✅ Attestation verified for $TARGET_SHA (run $RUN_ID)"
 
   build-and-release:
-    needs: device-tests
+    needs: verify-validation
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - name: Checkout code
+      - name: Checkout validated commit
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.verify-validation.outputs.sha }}
           fetch-depth: 0
           submodules: 'recursive'
           token: ${{ secrets.ARCTIC_RELEASE_TOKEN }}
+
+      - name: Verify main still points to the validated SHA
+        env:
+          TARGET_SHA: ${{ needs.verify-validation.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$MAIN_SHA" != "$TARGET_SHA" ]; then
+            echo "::error::main advanced to $MAIN_SHA after validation ($TARGET_SHA). Re-run the release for the new HEAD."
+            exit 1
+          fi
+          echo "✅ main still points to the validated SHA $TARGET_SHA"
 
       - name: Extract version from CMakeLists.txt
         id: version
@@ -73,6 +164,24 @@ jobs:
           target: esp32p4
           path: '.'
 
+      - name: Record production firmware provenance
+        env:
+          TARGET_SHA: ${{ needs.verify-validation.outputs.sha }}
+        run: |
+          set -euo pipefail
+          PROD_DIGEST=$(sha256sum build/arctic_controller.bin | awk '{print $1}')
+          echo "PROD_FW_SHA256=$PROD_DIGEST" >> "$GITHUB_ENV"
+          {
+            echo "### Production firmware provenance"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Source SHA | \`$TARGET_SHA\` |"
+            echo "| Production firmware SHA256 | \`$PROD_DIGEST\` |"
+            echo "| Test endpoints | disabled |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Production firmware sha256: $PROD_DIGEST (source $TARGET_SHA)"
+
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
@@ -84,17 +193,31 @@ jobs:
 
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
+        env:
+          TARGET_SHA: ${{ needs.verify-validation.outputs.sha }}
         run: |
+          set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
           VERSION="${{ steps.version.outputs.version }}"
-          
+
+          # Final guard: refuse to tag if main advanced past the validated SHA
+          # during the production build. This shrinks the TOCTOU window to the
+          # moment between this check and the tag push; the tag is always
+          # annotated on the validated TARGET_SHA that is checked out here.
+          git fetch origin main --depth=1
+          MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$MAIN_SHA" != "$TARGET_SHA" ]; then
+            echo "::error::main advanced to $MAIN_SHA after validation ($TARGET_SHA); aborting before tag. Re-run the release for the new HEAD."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git tag -a "$TAG" -m "Release $VERSION"
+
+          git tag -a "$TAG" "$TARGET_SHA" -m "Release $VERSION"
           git push origin "$TAG"
-          
-          echo "🏷️ Created tag: $TAG"
+
+          echo "🏷️ Created tag: $TAG -> $TARGET_SHA"
 
       - name: Upload firmware artifact
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -21,6 +21,15 @@ on:
       - 'tests/**'
       - '!tests/**/*.md'
       - '.github/workflows/device-tests.yml'
+  push:
+    # Authoritative post-merge validation of the exact main commit SHA. The
+    # release workflow consumes the attestation produced by these runs instead
+    # of re-running the physical device suite, and it requires the release
+    # target to equal main HEAD. To keep main HEAD always releasable, validate
+    # EVERY main commit (no paths filter). Version-bump commits carry [skip ci]
+    # and are therefore not redundantly re-validated.
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
 
@@ -581,6 +590,77 @@ jobs:
           resp = urllib.request.urlopen(req)
           print(f'Gist updated: {resp.status}')
           "
+
+      - name: Record release validation attestation
+        id: attestation
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.ui_tests.outcome == 'success' &&
+          steps.api_tests.outcome == 'success' &&
+          steps.web_tests.outcome == 'success'
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          REPOSITORY: ${{ github.repository }}
+          RUNNER_NAME: ${{ runner.name }}
+          ESP_IDF_VERSION: v5.5.2
+          UI_OUTCOME: ${{ steps.ui_tests.outcome }}
+          API_OUTCOME: ${{ steps.api_tests.outcome }}
+          WEB_OUTCOME: ${{ steps.web_tests.outcome }}
+        run: |
+          set -euo pipefail
+          # Authoritative record that this exact main SHA passed the physical
+          # device suite. create-release.yml consumes this instead of re-running
+          # the ~40-minute hardware suite.
+          TREE_SHA=$(git rev-parse "HEAD^{tree}")
+          FW_DIGEST=$(sha256sum build/arctic_controller.bin | awk '{print $1}')
+          export TREE_SHA FW_DIGEST
+          python3 - <<'PY'
+          import json, os, datetime
+
+          attestation = {
+              "schema_version": 1,
+              "kind": "arctic-device-validation",
+              "repository": os.environ["REPOSITORY"],
+              "commit_sha": os.environ["COMMIT_SHA"],
+              "tree_sha": os.environ["TREE_SHA"],
+              "workflow": "device-tests.yml",
+              "event": "push",
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": os.environ["RUN_ATTEMPT"],
+              "suites": {
+                  "ui": os.environ["UI_OUTCOME"],
+                  "api": os.environ["API_OUTCOME"],
+                  "web": os.environ["WEB_OUTCOME"],
+              },
+              "test_firmware": {
+                  "file": "build/arctic_controller.bin",
+                  "sha256": os.environ["FW_DIGEST"],
+                  "test_endpoints_enabled": True,
+              },
+              "environment": {
+                  "esp_idf_version": os.environ["ESP_IDF_VERSION"],
+                  "target": "esp32p4",
+                  "runner": os.environ["RUNNER_NAME"],
+              },
+              "created_at": datetime.datetime.now(
+                  datetime.timezone.utc
+              ).isoformat(),
+          }
+          with open("release-attestation.json", "w", encoding="utf-8") as fh:
+              json.dump(attestation, fh, indent=2, sort_keys=True)
+          print(json.dumps(attestation, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload release validation attestation
+        if: steps.attestation.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-attestation-${{ github.sha }}
+          path: release-attestation.json
+          retention-days: 90
 
       - name: Fail job if any tests failed
         if: always()


### PR DESCRIPTION
## Problem

- `create-release.yml` re-ran the ~40-minute physical device suite on every release attempt (via a reusable-workflow call), so release retries repeated the whole hardware run.
- Post-merge `main` commits were never physically validated - only PR heads were. A squash-merge produces a new, untested SHA.

## Design (implements `files/arctic-controller-ci-release-redesign.md`)

**`device-tests.yml`**
- Also triggers on `push` to `main` - authoritative post-merge validation of the exact commit SHA. No `paths` filter on push so `main` HEAD is always releasable; `[skip ci]` version-bump commits are not re-validated.
- On a push run where all three suites pass, writes `release-attestation.json` (commit SHA, tree SHA, run id/attempt, suite outcomes, **test firmware sha256**, esp-idf/runner identity) and uploads it as `release-attestation-<sha>`.

**`create-release.yml`**
- No longer runs the physical suite. New `verify-validation` job:
  - resolves target SHA (input or `main` HEAD) and requires it to equal current `origin/main`;
  - requires a **successful `push` device-tests run for that exact `head_sha`**;
  - downloads and verifies the attestation (`commit_sha` + `tree_sha` + all suites `success`).
- `build-and-release` checks out the validated SHA, re-verifies `main` still points to it (before build **and** immediately before tagging), records the **production** firmware sha256, tags the exact SHA, and publishes.

## Preserved

- PR physical suite remains the merge gate; suites stay monolithic; same self-hosted runner + `device-tests` concurrency group; production build still disables `CONFIG_TEST_ENDPOINTS`.

## Non-goals (deferred)

- Replacing the direct `bump-main` push with a PR.
- Splitting the physical suites into independent jobs.

Rubber-duck reviewed; addressed the "unmatched-path merge leaves main unreleasable" gap (dropped push `paths`) and tightened the pre-tag TOCTOU re-check.
