### PR TITLE
ci: host-side fast test gate + merge-queue readiness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,11 @@ on:
         options:
           - esp32p4
 
+  # Run against the prospective merged state when a PR is queued via the merge
+  # queue. No paths filter here: skipping a required check in the queue would
+  # stall it, so build always runs for merge groups.
+  merge_group:
+
 permissions:
   contents: read
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -33,6 +33,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+  # Validate the prospective merged state when a PR is queued via the merge
+  # queue. No paths filter: a skipped required check would stall the queue, so
+  # the physical suite always runs for merge groups.
+  merge_group:
+
 # Only one device-test run at a time (single device on the network)
 concurrency:
   group: device-tests

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -42,8 +42,11 @@ jobs:
         run: pip install -r tests/requirements.txt
 
       - name: Run host-side tests (no hardware)
+        # tests/web has its own playwright dependency set and is browser-only;
+        # exclude it from collection so a missing browser dep can't abort the
+        # host-side run. The `hostside` marker still deselects everything else.
         run: >-
-          python -m pytest tests -m hostside -v --tb=short
+          python -m pytest tests -m hostside --ignore=tests/web -v --tb=short
           -p no:cacheprovider --junitxml=host-test-results.xml
 
       - name: Publish host-side test results

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,56 @@
+name: Host Tests
+
+# Fast, hardware-free gate. These tests read the firmware/web sources and
+# static contracts (openapi, partition layout, i18n, etc.) and never touch the
+# physical controller, so they run on a hosted runner in seconds. They are
+# selected by the `hostside` pytest marker rather than a hard-coded file list,
+# so any newly-marked test is automatically covered.
+#
+# Intentionally has NO `paths:` filter: a required check that gets skipped by a
+# path filter stays pending forever and blocks the merge queue. Keeping this
+# always-on guarantees it reports a conclusion on every PR and merge group.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  host-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: tests/requirements.txt
+
+      - name: Install test dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Run host-side tests (no hardware)
+        run: >-
+          python -m pytest tests -m hostside -v --tb=short
+          -p no:cacheprovider --junitxml=host-test-results.xml
+
+      - name: Publish host-side test results
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Host-Side Test Results
+          path: host-test-results.xml
+          reporter: java-junit
+          use-actions-summary: 'false'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    hostside: test runs without a physical device (host-side only); included in the fast PR gate

--- a/tests/api/test_display_idle_configuration.py
+++ b/tests/api/test_display_idle_configuration.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/api/test_no_legacy_modbus.py
+++ b/tests/api/test_no_legacy_modbus.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
 
 ROOT = Path(__file__).resolve().parents[2]
 THIS_FILE = Path(__file__).resolve()

--- a/tests/api/test_openapi_coverage.py
+++ b/tests/api/test_openapi_coverage.py
@@ -4,7 +4,9 @@ import re
 from pathlib import Path
 
 import yaml
+import pytest
 
+pytestmark = pytest.mark.hostside
 
 ROOT = Path(__file__).resolve().parents[2]
 API_SERVER = ROOT / "main" / "api_server.cpp"

--- a/tests/api/test_temperature_history.py
+++ b/tests/api/test_temperature_history.py
@@ -3,6 +3,10 @@
 import re
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
+
 
 ROOT = Path(__file__).resolve().parents[2]
 MAIN = ROOT / "main"

--- a/tests/api/test_update_check_rate_limit.py
+++ b/tests/api/test_update_check_rate_limit.py
@@ -3,6 +3,10 @@
 import re
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
+
 
 ROOT = Path(__file__).resolve().parents[2]
 MAIN = ROOT / "main" / "main.cpp"

--- a/tests/test_partition_layout.py
+++ b/tests/test_partition_layout.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
+
 
 FLASH_SIZE = 16 * 1024 * 1024
 


### PR DESCRIPTION
# CI: host-side fast gate + merge-queue readiness

Part 1 of making `main` reliably releasable without the strict-mode
re-run cascade on the single hardware runner.

## What this does

**Adds a fast, hardware-free test gate (`Host Tests`).** A new
`host-tests.yml` runs the existing static/contract tests (openapi
coverage, partition layout, i18n/source guards, no-legacy-modbus, etc.)
on a hosted runner in ~seconds — no physical controller involved. These
catch the majority of contract regressions long before the ~40-minute
device suite ever leases the runner.

Tests are selected by a new `hostside` pytest marker (registered in
`pytest.ini`), not a hard-coded file list, so any newly-marked test is
picked up automatically. Six existing device-free tests are marked in
this PR.

**Wires the workflows for GitHub merge queue.** Adds a bare
`merge_group:` trigger to `build.yml`, `device-tests.yml`, and the new
`host-tests.yml` so all required checks execute against the prospective
merged state when a PR is queued. None of them carry a `paths:` filter
on the merge-group path — a required check skipped by a path filter
would stall the queue forever.

Enabling the merge queue itself + adjusting branch protection (add
`Host-Side Test Results` as required, turn on the queue, drop the
`strict`/require-up-to-date rule the queue supersedes) is a follow-up
repo-settings change, done once these checks have reported on `main`.

## Why

- `main` should be green *by construction*. A merge queue tests each PR
  against real merged `main`, once, serialized onto the one device
  runner — instead of `strict: true` forcing every open PR to re-run the
  full hardware suite every time `main` moves.
- Most regressions don't need hardware to catch. The host-side gate
  gives fast, deterministic signal and keeps the expensive rig for true
  device-in-the-loop coverage.

## Notes / follow-ups

- `test_securing_decoupled_from_ha.py` (#97) and
  `test_web_home_assistant_page.py` (#98) are also host-side; they get
  the `hostside` marker when those branches rebase onto this.
- No behavior change to firmware or the web UI.
