### PR TITLE
fix(ota): enable bootloader rollback + P0 tripwire so it can't silently regress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,22 @@ jobs:
           target: ${{ env.TARGET }}
           path: '.'
 
+      - name: Verify OTA rollback protection is enabled
+        # P0 tripwire: assert the EFFECTIVE compiled config (not what
+        # sdkconfig.defaults merely requests) has bootloader app rollback
+        # enabled. A committed/stale sdkconfig silently overrides the default,
+        # which would ship firmware with the OTA rollback safety net disabled
+        # (esp_ota_mark_app_valid_cancel_rollback() becomes dead code because
+        # the bootloader never arms PENDING_VERIFY). A disabled bool has NO
+        # #define in sdkconfig.h, so this fails loudly. If it ever regresses we
+        # must know immediately, on every build.
+        run: |
+          if ! grep -q '^#define CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE 1$' build/config/sdkconfig.h; then
+            echo "::error::CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is NOT enabled in the compiled firmware — OTA rollback protection is OFF. A bad OTA would not auto-roll-back. Set it =y in the committed sdkconfig to match sdkconfig.defaults."
+            exit 1
+          fi
+          echo "OK: CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y in compiled firmware"
+
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -86,6 +86,17 @@ jobs:
       - name: Verify test instrumentation was compiled
         run: grep -q '^#define CONFIG_TEST_ENDPOINTS 1$' build/config/sdkconfig.h
 
+      - name: Verify OTA rollback protection is enabled
+        # P0 tripwire — see build.yml for rationale. A disabled bool has NO
+        # #define at all in sdkconfig.h, so this grep fails loudly if bootloader
+        # app rollback is not compiled in.
+        run: |
+          if ! grep -q '^#define CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE 1$' build/config/sdkconfig.h; then
+            echo "::error::CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is NOT enabled in the compiled firmware — OTA rollback protection is OFF."
+            exit 1
+          fi
+          echo "OK: CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y in compiled firmware"
+
       - name: Upload firmware + flash metadata
         uses: actions/upload-artifact@v7
         with:

--- a/sdkconfig
+++ b/sdkconfig
@@ -595,7 +595,7 @@ CONFIG_BOOTLOADER_PROJECT_VER=1
 #
 # Application Rollback
 #
-# CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is not set
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 # end of Application Rollback
 
 #


### PR DESCRIPTION
## P0: OTA rollback protection was silently disabled + a tripwire so it can never regress unnoticed

### The bug
sdkconfig.defaults requested CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y (added in #28), but the **committed sdkconfig** had it `# ... is not set`. In ESP-IDF, an existing sdkconfig takes precedence over sdkconfig.defaults for keys it already defines, so the default was silently overridden and **shipped firmware built with OTA rollback protection OFF**.

Effect: the bootloader never armed `ESP_OTA_IMG_PENDING_VERIFY` after an OTA, so a bad update would **not** auto-roll-back, and the app-side `esp_ota_mark_app_valid_cancel_rollback()` (correctly health-gated in `main.cpp`) was effectively dead code.

### What this PR does
1. **P0 tripwire (commit 1):** after every ESP-IDF build (both uild.yml and device-tests.yml), assert the **effective compiled** config (uild/config/sdkconfig.h) has `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=1`. This checks what actually got compiled, not what sdkconfig.defaults merely claims — so a stale/committed override is caught immediately, on every build, forever.
2. **Fix (commit 2):** set `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` in the committed sdkconfig, turning the tripwire green.

### Red -> green demonstration
Commit 1 was pushed **alone first** to prove the tripwire actually fails on the current (broken) tree. Commit 2 then flips it green. Check the build history on this PR.

### Follow-up (separate PR)
Tier-2 **behavioral** rollback test on the self-hosted device runner: OTA a deliberately-bad firmware that reboots without marking valid, assert the device autonomously rolls back to the previous good version (with an `if: always()` USB-serial recovery flash as cleanup, kept separate from the assertion so recovery can't mask a failure).
