### PR TITLE
feat(ci): post-OTA firmware-identity gate to catch silent rollbacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,11 @@ jobs:
       - name: Fetch dependencies
         run: python3 fetch_repos.py
 
+      - name: Stamp build fingerprint
+        run: |
+          echo -n "${GITHUB_SHA}" > build_sha.txt
+          echo "Baked build_sha=${GITHUB_SHA}"
+
       - name: Disable test endpoints for production build
         run: |
           echo "CONFIG_TEST_ENDPOINTS=n" >> sdkconfig.defaults

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -448,17 +448,16 @@ jobs:
             exit 1
           fi
           echo "Expected build_sha: $EXPECTED"
-          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          # HTTPS-only: this request carries the X-API-Key secret, and the
+          # security contract (tests/api/test_ha_security_contract.py) forbids
+          # secret-bearing automation from ever falling back to plain HTTP.
+          # ARCTIC_URL is already https:// and the preceding "Require HTTPS
+          # readiness" step guarantees the TLS server is up.
           ACTUAL=""
           for attempt in $(seq 1 15); do
-            for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
-              RESP=$(curl -sk --connect-timeout 3 --max-time 8 \
-                -H "X-API-Key: ${ARCTIC_API_KEY}" "$URL/api/ota/status" 2>/dev/null) || true
-              ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || true
-              if [ -n "$ACTUAL" ]; then
-                break
-              fi
-            done
+            RESP=$(curl -sk --connect-timeout 3 --max-time 8 \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" "${ARCTIC_URL}/api/ota/status" 2>/dev/null) || true
+            ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || true
             if [ -n "$ACTUAL" ]; then
               break
             fi

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Fetch dependencies
         run: python3 fetch_repos.py
 
+      - name: Stamp build fingerprint
+        run: |
+          echo -n "${GITHUB_SHA}" > build_sha.txt
+          echo "Baked build_sha=${GITHUB_SHA}"
+
       - name: Enable test endpoints for device testing
         run: |
           python3 - <<'PY'
@@ -97,12 +102,16 @@ jobs:
           fi
           echo "OK: CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y in compiled firmware"
 
+      - name: Stage build fingerprint for device job
+        run: cp build_sha.txt build/build_sha.txt
+
       - name: Upload firmware + flash metadata
         uses: actions/upload-artifact@v7
         with:
           name: firmware
           path: |
             build/arctic_controller.bin
+            build/build_sha.txt
             build/bootloader/bootloader.bin
             build/partition_table/partition-table.bin
             build/ota_data_initial.bin
@@ -418,6 +427,48 @@ jobs:
             echo "ERROR: Could not read device API key after HTTPS became ready"
             exit 1
           fi
+
+      - name: Verify running firmware is the build under test (rollback guard)
+        # CRITICAL release-safety gate. After the OTA (or USB fallback) the device
+        # MUST be running the exact firmware we just built. If the new firmware
+        # crashed before esp_ota_mark_app_valid_cancel_rollback(), the bootloader
+        # rolls back to the PREVIOUS good image — the device would then come back
+        # online and happily pass every test suite against the OLD firmware,
+        # masking a broken build and letting it be released. This step catches
+        # that: the device's reported build_sha must equal the build_sha we baked
+        # into this build. A mismatch (or missing field = pre-build_sha firmware)
+        # means a rollback or a stale OTA, and the job fails BEFORE any suite runs.
+        run: |
+          set -euo pipefail
+          EXPECTED=$(cat build/build_sha.txt 2>/dev/null || true)
+          if [ -z "$EXPECTED" ]; then
+            echo "::error::build/build_sha.txt is empty/missing — cannot verify firmware identity."
+            exit 1
+          fi
+          echo "Expected build_sha: $EXPECTED"
+          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          ACTUAL=""
+          for attempt in $(seq 1 15); do
+            for URL in "$ARCTIC_URL" "$ARCTIC_URL_HTTPS"; do
+              RESP=$(curl -sk --connect-timeout 3 --max-time 8 \
+                -H "X-API-Key: ${ARCTIC_API_KEY}" "$URL/api/ota/status" 2>/dev/null) || true
+              ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || true
+              if [ -n "$ACTUAL" ]; then
+                break
+              fi
+            done
+            if [ -n "$ACTUAL" ]; then
+              break
+            fi
+            sleep 2
+          done
+          echo "Device reported build_sha: '${ACTUAL:-<none>}'"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Firmware identity mismatch — device is NOT running the build under test."
+            echo "::error::expected='$EXPECTED' actual='${ACTUAL:-<missing>}'. The device likely ROLLED BACK to the previous good image (the new firmware crashed before marking itself valid), or the OTA did not take. Refusing to run the suite against firmware that is not the build being validated."
+            exit 1
+          fi
+          echo "OK: device is running the build under test ($EXPECTED)"
 
       - name: Start controller serial capture
         run: |

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -103,7 +103,9 @@ jobs:
           echo "OK: CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y in compiled firmware"
 
       - name: Stage build fingerprint for device job
-        run: cp build_sha.txt build/build_sha.txt
+        # build/ is created by the ESP-IDF Docker container as root, so a plain
+        # cp is denied; use sudo (GitHub-hosted runner has passwordless sudo).
+        run: sudo cp build_sha.txt build/build_sha.txt
 
       - name: Upload firmware + flash metadata
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dependencies.lock
 # Generated files
 main/web/*.gz
 
+# Per-build fingerprint written by CI (see CMakeLists.txt / build_sha gate)
+build_sha.txt
+
 # Dependencies (fetched via fetch_repos.py)
 dependencies/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,3 +18,23 @@ set(EXTRA_COMPONENT_DIRS
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(arctic_controller)
+
+# Bake a per-build fingerprint into the firmware so CI can verify, after an OTA,
+# that the device is actually running THE BUILD UNDER TEST and did not silently
+# roll back to the previous good image. CI writes build_sha.txt (e.g. the commit
+# SHA) before building; local builds default to "dev". A file is used rather than
+# an env var because the ESP-IDF build runs in a container that does not forward
+# arbitrary host environment variables.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/build_sha.txt")
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/build_sha.txt" ARCTIC_BUILD_SHA)
+    string(STRIP "${ARCTIC_BUILD_SHA}" ARCTIC_BUILD_SHA)
+elseif(DEFINED ENV{ARCTIC_BUILD_SHA} AND NOT "$ENV{ARCTIC_BUILD_SHA}" STREQUAL "")
+    set(ARCTIC_BUILD_SHA "$ENV{ARCTIC_BUILD_SHA}")
+else()
+    set(ARCTIC_BUILD_SHA "dev")
+endif()
+if("${ARCTIC_BUILD_SHA}" STREQUAL "")
+    set(ARCTIC_BUILD_SHA "dev")
+endif()
+message(STATUS "ARCTIC_BUILD_SHA=${ARCTIC_BUILD_SHA}")
+add_compile_definitions(ARCTIC_BUILD_SHA="${ARCTIC_BUILD_SHA}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,23 +18,3 @@ set(EXTRA_COMPONENT_DIRS
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(arctic_controller)
-
-# Bake a per-build fingerprint into the firmware so CI can verify, after an OTA,
-# that the device is actually running THE BUILD UNDER TEST and did not silently
-# roll back to the previous good image. CI writes build_sha.txt (e.g. the commit
-# SHA) before building; local builds default to "dev". A file is used rather than
-# an env var because the ESP-IDF build runs in a container that does not forward
-# arbitrary host environment variables.
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/build_sha.txt")
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/build_sha.txt" ARCTIC_BUILD_SHA)
-    string(STRIP "${ARCTIC_BUILD_SHA}" ARCTIC_BUILD_SHA)
-elseif(DEFINED ENV{ARCTIC_BUILD_SHA} AND NOT "$ENV{ARCTIC_BUILD_SHA}" STREQUAL "")
-    set(ARCTIC_BUILD_SHA "$ENV{ARCTIC_BUILD_SHA}")
-else()
-    set(ARCTIC_BUILD_SHA "dev")
-endif()
-if("${ARCTIC_BUILD_SHA}" STREQUAL "")
-    set(ARCTIC_BUILD_SHA "dev")
-endif()
-message(STATUS "ARCTIC_BUILD_SHA=${ARCTIC_BUILD_SHA}")
-add_compile_definitions(ARCTIC_BUILD_SHA="${ARCTIC_BUILD_SHA}")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -133,6 +133,29 @@ add_custom_command(
 add_custom_target(web_assets DEPENDS "${WEB_GZ}")
 add_dependencies(${COMPONENT_LIB} web_assets)
 
+# Bake a per-build fingerprint into the firmware so CI can verify, after an OTA,
+# that the device is actually running THE BUILD UNDER TEST and did not silently
+# roll back to the previous good image. CI writes build_sha.txt (at the project
+# root) before building; local builds default to "dev". A file is used rather
+# than an env var because the ESP-IDF build runs in a container that does not
+# forward arbitrary host environment variables. The define is attached directly
+# to this component's target (not add_compile_definitions at the project root),
+# because the root CMakeLists runs after project()/component registration, so a
+# directory-scope define there never reaches these translation units.
+if(EXISTS "${CMAKE_SOURCE_DIR}/build_sha.txt")
+    file(READ "${CMAKE_SOURCE_DIR}/build_sha.txt" ARCTIC_BUILD_SHA)
+    string(STRIP "${ARCTIC_BUILD_SHA}" ARCTIC_BUILD_SHA)
+elseif(DEFINED ENV{ARCTIC_BUILD_SHA} AND NOT "$ENV{ARCTIC_BUILD_SHA}" STREQUAL "")
+    set(ARCTIC_BUILD_SHA "$ENV{ARCTIC_BUILD_SHA}")
+else()
+    set(ARCTIC_BUILD_SHA "dev")
+endif()
+if("${ARCTIC_BUILD_SHA}" STREQUAL "")
+    set(ARCTIC_BUILD_SHA "dev")
+endif()
+message(STATUS "ARCTIC_BUILD_SHA=${ARCTIC_BUILD_SHA}")
+target_compile_definitions(${COMPONENT_LIB} PRIVATE ARCTIC_BUILD_SHA="${ARCTIC_BUILD_SHA}")
+
 # LVGL (a separate archive, liblvgl.a) references lv_malloc_core / lv_free_core /
 # etc., which we provide from lv_mem_psram.c here in libmain.a. Because libmain
 # is placed before liblvgl on the link line, the linker discards our object

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -2534,6 +2534,13 @@ static esp_err_t ota_status_get_handler(httpd_req_t* req)
     cJSON_AddNumberToObject(root, "total_bytes", (double)status.total_bytes);
     cJSON_AddStringToObject(root, "current_version", status.current_version);
     cJSON_AddBoolToObject(root, "pending_verify", ota_mgr_is_pending_verify());
+#ifndef ARCTIC_BUILD_SHA
+#define ARCTIC_BUILD_SHA "dev"
+#endif
+    // Per-build fingerprint (baked at compile time). CI asserts this equals the
+    // build it just OTA'd, so a silent rollback to the previous image is caught
+    // instead of being masked by tests passing against the rolled-back firmware.
+    cJSON_AddStringToObject(root, "build_sha", ARCTIC_BUILD_SHA);
     
     if (status.new_version[0] != '\0') {
         cJSON_AddStringToObject(root, "new_version", status.new_version);


### PR DESCRIPTION
## Post-OTA firmware-identity gate (rollback guard)

Now that OTA rollback protection is actually enabled (#102), we have a new blind spot: **rollback masks broken builds.**

If a new firmware crashes on boot before `esp_ota_mark_app_valid_cancel_rollback()`, the bootloader rolls back to the previous good image. The device then comes back online — running the **OLD** firmware — and happily passes the entire device-test suite. A broken build looks green and becomes releasable.

### The gate

1. **Bake a per-build fingerprint into the firmware.** CI writes `build_sha.txt` (the commit SHA) before building; `CMakeLists.txt` reads it at configure time and bakes `ARCTIC_BUILD_SHA` as a compile define. Local builds default to `"dev"`.
   - A file (not an env var) is used because the ESP-IDF build runs in a container that does not forward arbitrary host env vars.
2. **Expose it** at `/api/ota/status` as `build_sha`.
3. **Assert it in device-tests**, after the OTA/USB flash and device-up, **before any test suite runs.** The device's reported `build_sha` must equal the one we just built. On mismatch (or missing field = pre-`build_sha` firmware = rolled-back image), the job fails immediately with a clear `::error::`.

### Why this is safe on this (good) PR

This build boots fine → marks itself valid → device runs the new firmware → reports the matching `build_sha` → gate passes. The gate only goes red when the device is genuinely **not** running the build under test.

A follow-up demo PR (intentionally aborting before `mark_valid`) will prove the gate goes red on a real rollback. That demo will **not** be merged.

### Files
- `CMakeLists.txt` — read `build_sha.txt` → `ARCTIC_BUILD_SHA` compile define.
- `main/api_server.cpp` — add `build_sha` to `/api/ota/status`.
- `.github/workflows/build.yml` — stamp `build_sha.txt` before build.
- `.github/workflows/device-tests.yml` — stamp + stage fingerprint, include in artifact, add the identity-gate step.
- `.gitignore` — ignore the CI-generated `build_sha.txt`.
