### PR TITLE
DEMO (do not merge): broken build must fail at OTA rollback gate

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -311,6 +311,20 @@ extern "C" void app_main(void)
     if (ota_mgr_is_pending_verify()) {
         ESP_LOGW(TAG, "*** First boot after OTA — firmware pending verification ***");
         ESP_LOGW(TAG, "*** Will mark valid after UI creation succeeds ***");
+        // ================== DEMO — DO NOT MERGE ==================
+        // Simulate a broken build that crashes on the first post-OTA boot,
+        // BEFORE esp_ota_mark_app_valid_cancel_rollback() is ever reached. We
+        // crash here (before WiFi/HTTP start) so the broken image is NEVER
+        // reachable on the network — the device can only be observed AFTER the
+        // bootloader rolls back to the previous good image, making the CI
+        // identity gate deterministically fail (no race with a briefly-online
+        // broken image). Expected chain: OTA installs this image -> boots
+        // PENDING_VERIFY -> abort() -> panic reboot -> bootloader rolls back to
+        // the previous good image -> device comes online on the OLD firmware ->
+        // CI sees the OLD build_sha and FAILS the job. This block only exists in
+        // this broken image; the rolled-back image does not contain it.
+        ESP_LOGE(TAG, "DEMO: forcing early crash before mark_valid to exercise OTA rollback");
+        abort();
     }
 
     // Start WiFi initialization in background task (runs parallel to animation)


### PR DESCRIPTION
## ⚠️ DEMO — DO NOT MERGE

This PR intentionally ships a **broken build** to prove that our OTA rollback protection + CI identity gate (#102, #103) actually prevent a bad firmware from being released. It must **FAIL** device-tests. Close it once it goes red.

### What it does

`main/main.cpp` calls `abort()` on the first post-OTA boot, **before** `ota_mgr_mark_valid()` / `esp_ota_mark_app_valid_cancel_rollback()`.

### Expected chain

1. CI builds this (broken) firmware and OTA-installs it to the inactive slot.
2. Device reboots into it → boots in `PENDING_VERIFY` → hits `abort()` → panic reboot.
3. Bootloader sees the image never confirmed itself → **rolls back** to the previous good image (the current `main` firmware).
4. Device comes back online — but running the **OLD** firmware.
5. The **"Verify running firmware is the build under test (rollback guard)"** step queries `/api/ota/status`, sees the device reporting the OLD `build_sha` (not this PR's), and **fails the job before any test suite runs.**

### Why this matters

Without the identity gate, step 4 would let the device happily pass the entire suite against the rolled-back old firmware — a broken build would look green and be releasable. This PR demonstrates the gate closes that hole.

### Safety

The `abort()` block only exists in this (broken) image and only runs on the freshly-OTA'd `PENDING_VERIFY` boot. After rollback the device runs the previous good firmware, so the test device is **not bricked** — it self-recovers via rollback.
