### PR TITLE
fix(ci): make device-tests flash via real OTA, not USB fallback

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -201,7 +201,7 @@ jobs:
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           TEST_USERNAME="arctic"
           TEST_PASSWORD="ArcticTest!2026"
-          BODY=$(python3 -c 'import json,os; print(json.dumps({"username": os.environ["TEST_USERNAME"], "password": os.environ["TEST_PASSWORD"]}))')
+          BODY="{\"username\": \"$TEST_USERNAME\", \"password\": \"$TEST_PASSWORD\"}"
           DEVICE_KEY=""
 
           for i in $(seq 1 6); do

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -187,39 +187,55 @@ jobs:
 
       - name: Sync API key from device (pre-OTA)
         run: |
-          # Read the device's current API key before OTA so the upload can authenticate.
-          # The device may have a randomly-generated key or one from a previous NVS flash.
+          # Authenticate to the device that is CURRENTLY running (the previous
+          # build) so the OTA upload below can present a valid API key. The
+          # device's credentials are unknown at this point (a prior run set its
+          # own isolated test creds), so we first reset them to known values via
+          # the unauthenticated test-only endpoint /api/test/credentials, exactly
+          # like the post-flash "Provision isolated test credentials" step. We
+          # then log in and read the device's API key. Without this the upload
+          # 401s and the job silently falls back to a USB flash, which does NOT
+          # exercise the A/B OTA pending-verify path — so rollback would never be
+          # tested and a rolled-back broken build could pass. Real OTA is what
+          # the identity gate is meant to guard, so make OTA the primary path.
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          TEST_USERNAME="arctic"
+          TEST_PASSWORD="ArcticTest!2026"
+          BODY=$(python3 -c 'import json,os; print(json.dumps({"username": os.environ["TEST_USERNAME"], "password": os.environ["TEST_PASSWORD"]}))')
           DEVICE_KEY=""
 
-          for URL in "$ARCTIC_URL_HTTPS"; do
-            RESP=$(curl -sk --connect-timeout 3 --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
-            DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
+          for i in $(seq 1 6); do
+            # (Re)set the running firmware's credentials to known values. This is
+            # a test-only endpoint (CONFIG_TEST_ENDPOINTS) and needs no auth.
+            curl -sk --connect-timeout 3 --max-time 8 \
+              -X POST "$ARCTIC_URL_HTTPS/api/test/credentials" \
+              -H "Content-Type: application/json" \
+              -d "$BODY" > /dev/null 2>&1 || true
 
-            if [ -z "$DEVICE_KEY" ]; then
-              JAR=$(mktemp)
-              curl -sk -c "$JAR" -X POST "$URL/login" \
-                -H "Content-Type: application/json" \
-                -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
-              RESP=$(curl -sk -b "$JAR" --max-time 5 "$URL/api/auth/apikey" 2>/dev/null) || true
-              DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
-              rm -f "$JAR"
-            fi
+            JAR=$(mktemp)
+            curl -sk -c "$JAR" --connect-timeout 3 --max-time 8 \
+              -X POST "$ARCTIC_URL_HTTPS/login" \
+              -H "Content-Type: application/json" \
+              -d "{\"username\": \"$TEST_USERNAME\", \"password\": \"$TEST_PASSWORD\"}" > /dev/null 2>&1 || true
+            RESP=$(curl -sk -b "$JAR" --connect-timeout 3 --max-time 8 \
+              "$ARCTIC_URL_HTTPS/api/auth/apikey" 2>/dev/null) || true
+            rm -f "$JAR"
+            DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
 
             if [ -n "$DEVICE_KEY" ]; then
               break
             fi
+            sleep 2
           done
 
           if [ -n "$DEVICE_KEY" ]; then
             echo "ARCTIC_API_KEY=$DEVICE_KEY" >> $GITHUB_ENV
-            echo "Synced API key from device"
+            echo "Synced API key from device (OTA will authenticate)"
           else
-            echo "Could not read device API key — OTA will use secret"
+            echo "WARNING: Could not read device API key pre-OTA — OTA upload will"
+            echo "likely 401 and the job will fall back to USB serial flash, which"
+            echo "does NOT exercise the OTA rollback path."
           fi
-        env:
-          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
-          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
 
       - name: Flash device via OTA
         id: ota_flash


### PR DESCRIPTION
## Make device-tests actually flash via OTA (not silently USB-fallback)

While building the OTA identity gate (#103) and its rollback demo, I found that **device-tests has never actually exercised the A/B OTA path** — it silently falls back to a USB serial flash on every run.

### Root cause

The "Sync API key from device (pre-OTA)" step tries to read the device's API key so the `/api/ota/upload` POST can authenticate. But at that point the device is running the **previous** run's firmware with **unknown** credentials (each run provisions its own isolated test creds post-flash). The read fails, `ARCTIC_API_KEY` stays unset/stale, the upload returns **HTTP 401 "API key required"**, and the job falls back to `Fallback — flash via USB serial`.

USB flash writes the image straight through the ROM bootloader and **does not arm the OTA `PENDING_VERIFY` state**, so:
- the bootloader rollback mechanism is never triggered,
- the new firmware-identity gate passes trivially (USB always installs the exact build),
- a broken build that would roll back under real OTA is never caught.

Both #103 and the rollback demo (#104) logged `Could not read device API key — OTA will use secret` → `OTA upload failed on both HTTP and HTTPS` → `falling back to USB serial flash`.

### Fix

Before reading the key, reset the running firmware's credentials to known values via the unauthenticated, test-only `/api/test/credentials` endpoint (the same recipe the post-flash "Provision isolated test credentials" step already uses), then log in and read the device API key. Now `/api/ota/upload` authenticates and **OTA becomes the primary install path**. USB flash remains a genuine fallback for real OTA failures / partition-layout changes.

### Expected effect

- This (good) build: real OTA → boots `PENDING_VERIFY` → marks itself valid → identity gate matches → green. The device-tests log should now show `OTA upload successful` instead of the USB fallback.
- A broken build (crashes before `mark_valid`): real OTA → rollback → device reports the old `build_sha` → identity gate fails. (Demonstrated separately by the do-not-merge demo PR, rebased on top of this.)
