### PR TITLE
chore: bump version to 2.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project version - update this for releases
-set(PROJECT_VER "2.10.3")
+set(PROJECT_VER "2.11.0")
 
 # Add dependencies to component search path
 set(EXTRA_COMPONENT_DIRS


### PR DESCRIPTION
Bumps `PROJECT_VER` 2.10.3 -> 2.11.0 to cut the v2.11.0 firmware release.

This release delivers to devices:
- **#101** HA integration `state.error` enriched with `code`/`name`/`severity` (pairs with hass-macon 0.3.0 fault sensor)
- **#102** bootloader rollback enabled + P0 tripwire
- **#103** post-OTA firmware-identity gate
- **#105** device-tests flash via real OTA

After merge, the post-merge device-tests attestation for the new HEAD gates the `create-release` dispatch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>