### PR TITLE
feat(net): per-device mDNS hostname + HTTP->HTTPS redirect

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,7 +4,10 @@ info:
   description: |
     REST API for the Arctic Heat Pump Controller running on ESP32-P4 with ESP32-C6 WiFi.
     
-    The device is discoverable via mDNS at `http://arctic.local` when connected to your local network.
+    The device is discoverable via mDNS at `http://arctic-<xxxx>.local` when connected to your local network,
+    where `<xxxx>` is the last two bytes of the WiFi MAC (lowercase hex, e.g. `arctic-3f2a.local`).
+    The suffix keeps multiple controllers from colliding on `arctic.local`. The exact name is reported as
+    `hostname`/`local_url` by `GET /api/wifi`.
     HTTPS is available on port 443 when TLS certificates are provisioned via the `/api/tls/certificate` endpoint.
     
     ## Features

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -1362,7 +1362,9 @@ static esp_err_t http_to_https_redirect_handler(httpd_req_t* req,
         *colon = '\0';
     }
 
-    char location[512];
+    // Sized for "https://" + max Host header + max request URI so the
+    // compiler can prove no truncation (-Werror=format-truncation).
+    char location[640];
     snprintf(location, sizeof(location), "https://%s%s", host, req->uri);
 
     httpd_resp_set_status(req, "301 Moved Permanently");

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -31,6 +31,7 @@
 #include <esp_https_server.h>
 #include <esp_log.h>
 #include <mdns.h>
+#include <esp_mac.h>
 #include <cJSON.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -47,7 +48,10 @@
 
 static const char* TAG = "api_server";
 
-// Base hostname for mDNS (arctic.local, arctic-2.local, etc.)
+// Base hostname for mDNS. The effective hostname appends the last two bytes
+// of the WiFi station MAC (e.g. "arctic-3f2a") so multiple controllers on the
+// same network get unique, stable .local names instead of colliding on
+// "arctic.local".
 static const char* HOSTNAME_BASE = "arctic";
 static char hostname[32] = "arctic";  // Actual hostname (may have suffix)
 
@@ -89,6 +93,8 @@ static SemaphoreHandle_t s_ha_command_mutex = nullptr;
 
 // Web handlers
 static esp_err_t web_root_handler(httpd_req_t* req);
+static esp_err_t http_to_https_redirect_handler(httpd_req_t* req,
+                                                httpd_err_code_t err);
 static esp_err_t web_login_handler(httpd_req_t* req);
 static esp_err_t web_logout_handler(httpd_req_t* req);
 static esp_err_t favicon_handler(httpd_req_t* req);
@@ -302,8 +308,22 @@ bool api_server_init_mdns(void)
         return false;
     }
     
-    // Use base hostname directly
-    snprintf(hostname, sizeof(hostname), "%s", HOSTNAME_BASE);
+    // Build a per-device hostname by appending the last two bytes of the
+    // WiFi station MAC as four lowercase hex digits (e.g. "arctic-3f2a").
+    // esp_read_mac() reads the factory MAC from eFuse, so the value is
+    // deterministic across reboots and available even before Wi-Fi is up.
+    // This avoids "arctic.local" collisions when several controllers share a
+    // network. If the read fails for any reason, fall back to the base name.
+    uint8_t mac[6] = {0};
+    esp_err_t mac_err = esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    if (mac_err == ESP_OK) {
+        snprintf(hostname, sizeof(hostname), "%s-%02x%02x",
+                 HOSTNAME_BASE, mac[4], mac[5]);
+    } else {
+        ESP_LOGW(TAG, "esp_read_mac failed (%s); using base hostname",
+                 esp_err_to_name(mac_err));
+        snprintf(hostname, sizeof(hostname), "%s", HOSTNAME_BASE);
+    }
     
     // Set hostname
     err = mdns_hostname_set(hostname);
@@ -1235,7 +1255,21 @@ bool api_server_start(void)
     
     #undef REGISTER_URI
     #undef REGISTER_URI_ESSENTIAL
-    
+
+    // With mandatory HTTPS active, port 80 only serves the essential bootstrap
+    // routes; any other path (e.g. a browser opening http://<device>) would
+    // otherwise hit the bare "Nothing matches the given URI" 404. Register a
+    // 404 handler on the HTTP server that upgrades those requests to HTTPS so
+    // users land on the real UI instead of an error.
+    if (server != NULL && server_ssl != NULL) {
+        esp_err_t rerr = httpd_register_err_handler(
+            server, HTTPD_404_NOT_FOUND, http_to_https_redirect_handler);
+        if (rerr != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to register HTTP->HTTPS redirect: %s",
+                     esp_err_to_name(rerr));
+        }
+    }
+
     ESP_LOGI(TAG, "HTTP server started on port 80");
     if (server_ssl != NULL) {
         ESP_LOGI(TAG, "HTTPS server started on port 443");
@@ -1306,6 +1340,36 @@ static void send_json_error(httpd_req_t* req, const char* status, const char* me
 // ============================================================================
 // Web Interface Handlers
 // ============================================================================
+
+// 404 handler for the plain-HTTP server (port 80). Because mandatory HTTPS is
+// active, all normal routes are registered on the HTTPS server only, so any
+// non-essential HTTP request lands here. Redirect it to the same path on
+// HTTPS (default port 443) instead of returning the default esp_http_server
+// 404 body. Preserves whatever host the client used (IP or arctic-xxxx.local).
+static esp_err_t http_to_https_redirect_handler(httpd_req_t* req,
+                                                httpd_err_code_t err)
+{
+    (void)err;
+
+    char host[80];
+    if (httpd_req_get_hdr_value_str(req, "Host", host, sizeof(host)) != ESP_OK
+            || host[0] == '\0') {
+        snprintf(host, sizeof(host), "%s.local", hostname);
+    }
+    // Drop any :port suffix so the redirect targets the default HTTPS port.
+    char* colon = strchr(host, ':');
+    if (colon != NULL) {
+        *colon = '\0';
+    }
+
+    char location[512];
+    snprintf(location, sizeof(location), "https://%s%s", host, req->uri);
+
+    httpd_resp_set_status(req, "301 Moved Permanently");
+    httpd_resp_set_hdr(req, "Location", location);
+    httpd_resp_send(req, NULL, 0);
+    return ESP_OK;
+}
 
 static esp_err_t web_root_handler(httpd_req_t* req)
 {

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -31,7 +31,6 @@
 #include <esp_https_server.h>
 #include <esp_log.h>
 #include <mdns.h>
-#include <esp_mac.h>
 #include <cJSON.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -93,8 +92,8 @@ static SemaphoreHandle_t s_ha_command_mutex = nullptr;
 
 // Web handlers
 static esp_err_t web_root_handler(httpd_req_t* req);
-static esp_err_t http_to_https_redirect_handler(httpd_req_t* req,
-                                                httpd_err_code_t err);
+static esp_err_t http_https_required_handler(httpd_req_t* req,
+                                             httpd_err_code_t err);
 static esp_err_t web_login_handler(httpd_req_t* req);
 static esp_err_t web_logout_handler(httpd_req_t* req);
 static esp_err_t favicon_handler(httpd_req_t* req);
@@ -310,18 +309,18 @@ bool api_server_init_mdns(void)
     
     // Build a per-device hostname by appending the last two bytes of the
     // WiFi station MAC as four lowercase hex digits (e.g. "arctic-3f2a").
-    // esp_read_mac() reads the factory MAC from eFuse, so the value is
-    // deterministic across reboots and available even before Wi-Fi is up.
     // This avoids "arctic.local" collisions when several controllers share a
-    // network. If the read fails for any reason, fall back to the base name.
+    // network. We use wifi_mgr_get_mac_addr() so the suffix is derived from
+    // the actual C6 station MAC that the device advertises (the same value
+    // reported by GET /api/wifi) rather than the P4 host MAC. api_server_init_mdns()
+    // runs after the station has an IP, so this MAC is available here. If the
+    // read fails for any reason, fall back to the base name.
     uint8_t mac[6] = {0};
-    esp_err_t mac_err = esp_read_mac(mac, ESP_MAC_WIFI_STA);
-    if (mac_err == ESP_OK) {
+    if (wifi_mgr_get_mac_addr(mac)) {
         snprintf(hostname, sizeof(hostname), "%s-%02x%02x",
                  HOSTNAME_BASE, mac[4], mac[5]);
     } else {
-        ESP_LOGW(TAG, "esp_read_mac failed (%s); using base hostname",
-                 esp_err_to_name(mac_err));
+        ESP_LOGW(TAG, "wifi_mgr_get_mac_addr failed; using base hostname");
         snprintf(hostname, sizeof(hostname), "%s", HOSTNAME_BASE);
     }
     
@@ -1259,13 +1258,15 @@ bool api_server_start(void)
     // With mandatory HTTPS active, port 80 only serves the essential bootstrap
     // routes; any other path (e.g. a browser opening http://<device>) would
     // otherwise hit the bare "Nothing matches the given URI" 404. Register a
-    // 404 handler on the HTTP server that upgrades those requests to HTTPS so
-    // users land on the real UI instead of an error.
+    // 404 handler on the HTTP server that returns a clean "use HTTPS" notice
+    // instead. It does NOT redirect: mandatory HTTPS means port 80 must stay a
+    // dead end so secret-bearing requests are never normalised onto plaintext
+    // HTTP (see tests/api/test_ha_security_contract.py).
     if (server != NULL && server_ssl != NULL) {
         esp_err_t rerr = httpd_register_err_handler(
-            server, HTTPD_404_NOT_FOUND, http_to_https_redirect_handler);
+            server, HTTPD_404_NOT_FOUND, http_https_required_handler);
         if (rerr != ESP_OK) {
-            ESP_LOGW(TAG, "Failed to register HTTP->HTTPS redirect: %s",
+            ESP_LOGW(TAG, "Failed to register HTTP 404 handler: %s",
                      esp_err_to_name(rerr));
         }
     }
@@ -1343,33 +1344,28 @@ static void send_json_error(httpd_req_t* req, const char* status, const char* me
 
 // 404 handler for the plain-HTTP server (port 80). Because mandatory HTTPS is
 // active, all normal routes are registered on the HTTPS server only, so any
-// non-essential HTTP request lands here. Redirect it to the same path on
-// HTTPS (default port 443) instead of returning the default esp_http_server
-// 404 body. Preserves whatever host the client used (IP or arctic-xxxx.local).
-static esp_err_t http_to_https_redirect_handler(httpd_req_t* req,
-                                                httpd_err_code_t err)
+// non-essential HTTP request lands here. Return a clean 404 with a short
+// plain-text notice pointing at the device's HTTPS URL instead of the default
+// esp_http_server "Nothing matches the given URI" body.
+//
+// This intentionally does NOT redirect (no Location header / 3xx): under
+// mandatory HTTPS, port 80 must stay a dead end so clients are never
+// encouraged to send secret-bearing requests (X-API-Key / bearer tokens) over
+// plaintext HTTP. The message uses the device's own advertised hostname rather
+// than reflecting the client-supplied Host header.
+static esp_err_t http_https_required_handler(httpd_req_t* req,
+                                             httpd_err_code_t err)
 {
     (void)err;
 
-    char host[80];
-    if (httpd_req_get_hdr_value_str(req, "Host", host, sizeof(host)) != ESP_OK
-            || host[0] == '\0') {
-        snprintf(host, sizeof(host), "%s.local", hostname);
-    }
-    // Drop any :port suffix so the redirect targets the default HTTPS port.
-    char* colon = strchr(host, ':');
-    if (colon != NULL) {
-        *colon = '\0';
-    }
+    char body[128];
+    snprintf(body, sizeof(body),
+             "This controller requires a secure connection.\n"
+             "Use https://%s.local/\n", hostname);
 
-    // Sized for "https://" + max Host header + max request URI so the
-    // compiler can prove no truncation (-Werror=format-truncation).
-    char location[640];
-    snprintf(location, sizeof(location), "https://%s%s", host, req->uri);
-
-    httpd_resp_set_status(req, "301 Moved Permanently");
-    httpd_resp_set_hdr(req, "Location", location);
-    httpd_resp_send(req, NULL, 0);
+    httpd_resp_set_status(req, "404 Not Found");
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 

--- a/main/api_server.h
+++ b/main/api_server.h
@@ -13,7 +13,10 @@ extern "C" {
 /**
  * @brief Initialize mDNS service
  * 
- * Registers the device as "arctic.local" on the network
+ * Registers the device on the network as "arctic-<xxxx>.local", where
+ * <xxxx> is the last two bytes of the WiFi station MAC (lowercase hex).
+ * The MAC suffix keeps the name unique when multiple controllers share a
+ * network.
  * 
  * @return true on success
  */
@@ -45,7 +48,7 @@ bool api_server_is_running(void);
 /**
  * @brief Get the device hostname for mDNS
  * 
- * @return hostname (e.g., "arctic")
+ * @return hostname (e.g., "arctic-3f2a")
  */
 const char* api_server_get_hostname(void);
 

--- a/tests/api/test_events_and_misc_api.py
+++ b/tests/api/test_events_and_misc_api.py
@@ -17,6 +17,7 @@ Prerequisites:
 """
 
 import os
+import re
 import time
 
 import pytest
@@ -280,6 +281,35 @@ class TestWiFiAPI:
         assert "rssi" in data
         assert isinstance(data["rssi"], int)
         assert data["rssi"] < 0  # RSSI is always negative dBm
+
+    def test_hostname_has_mac_suffix(self):
+        """Hostname is 'arctic-<xxxx>' where xxxx is the last two MAC bytes.
+
+        The MAC suffix keeps multiple controllers from colliding on
+        'arctic.local'. The suffix must match the low two bytes of the
+        reported station MAC (lowercase hex).
+        """
+        data = _get("/api/wifi").json()
+        if not data["connected"]:
+            pytest.skip("WiFi not connected")
+        assert "hostname" in data
+        assert "mac" in data
+        hostname = data["hostname"]
+        assert re.fullmatch(r"arctic-[0-9a-f]{4}", hostname), (
+            f"hostname {hostname!r} does not match 'arctic-<4 hex>'"
+        )
+        last_two = data["mac"].replace(":", "")[-4:].lower()
+        assert hostname == f"arctic-{last_two}", (
+            f"hostname suffix {hostname!r} does not match MAC {data['mac']!r}"
+        )
+
+    def test_local_url_uses_suffixed_hostname(self):
+        """local_url advertises the per-device .local name."""
+        data = _get("/api/wifi").json()
+        if not data["connected"]:
+            pytest.skip("WiFi not connected")
+        assert "local_url" in data
+        assert data["local_url"].endswith(f"{data['hostname']}.local")
 
 
 # ── Info API ──────────────────────────────────────────────────────────────

--- a/tests/device/TODO.md
+++ b/tests/device/TODO.md
@@ -225,7 +225,7 @@ These validate that a bad firmware gets reverted by the bootloader.
 ## WiFi Testing (expanded)
 
 - [ ] Test WiFi scan and connect from settings
-- [ ] Verify mDNS discovery (`arctic.local`)
+- [x] Verify mDNS hostname carries MAC suffix (`arctic-<xxxx>.local`) — `test_events_and_misc_api.py::TestWiFiAPI::test_hostname_has_mac_suffix`
 - [ ] Test WiFi reconnection after signal loss
 - [ ] Verify API server starts correctly after WiFi connection
 - [ ] Test with ESP32-C6 WiFi module (hosted mode)

--- a/tests/device/test_https.py
+++ b/tests/device/test_https.py
@@ -318,27 +318,33 @@ class TestHttpsLifecycle:
         assert response.status_code == 200
 
 
-class TestHttpRedirect:
-    """Plain HTTP (port 80) upgrades non-essential requests to HTTPS."""
+class TestHttpNonEssentialRoutes:
+    """Under mandatory HTTPS, port 80 is a dead end for non-essential routes.
+
+    Instead of redirecting (which would normalise sending secret-bearing
+    requests over plaintext HTTP), the device returns a clean 404 pointing at
+    its HTTPS URL. Essential bootstrap routes remain available over HTTP.
+    """
 
     def _http_url(self) -> str:
         return ARCTIC_URL.replace("https://", "http://")
 
-    def test_http_root_redirects_to_https(self):
-        """GET http://<device>/ returns a redirect to the HTTPS UI."""
+    def test_http_root_returns_404_not_redirect(self):
+        """GET http://<device>/ returns 404 and does NOT redirect."""
         r = requests.get(
             f"{self._http_url()}/", allow_redirects=False, timeout=10
         )
-        assert r.status_code in (301, 302, 307, 308)
-        assert r.headers.get("Location", "").startswith("https://")
+        assert r.status_code == 404
+        assert "Location" not in r.headers
 
-    def test_http_preserves_path_on_redirect(self):
-        """The redirect keeps the original path (upgrades in place)."""
+    def test_http_404_body_points_to_https(self):
+        """The 404 body tells the user to use the HTTPS URL."""
         r = requests.get(
             f"{self._http_url()}/settings", allow_redirects=False, timeout=10
         )
-        assert r.status_code in (301, 302, 307, 308)
-        assert r.headers.get("Location", "").endswith("/settings")
+        assert r.status_code == 404
+        assert "Location" not in r.headers
+        assert "https" in r.text.lower()
 
     def test_http_health_still_served(self):
         """Essential bootstrap routes remain available over plain HTTP."""

--- a/tests/device/test_https.py
+++ b/tests/device/test_https.py
@@ -316,3 +316,33 @@ class TestHttpsLifecycle:
             f"{https_url}/api/health", verify=False, timeout=10
         )
         assert response.status_code == 200
+
+
+class TestHttpRedirect:
+    """Plain HTTP (port 80) upgrades non-essential requests to HTTPS."""
+
+    def _http_url(self) -> str:
+        return ARCTIC_URL.replace("https://", "http://")
+
+    def test_http_root_redirects_to_https(self):
+        """GET http://<device>/ returns a redirect to the HTTPS UI."""
+        r = requests.get(
+            f"{self._http_url()}/", allow_redirects=False, timeout=10
+        )
+        assert r.status_code in (301, 302, 307, 308)
+        assert r.headers.get("Location", "").startswith("https://")
+
+    def test_http_preserves_path_on_redirect(self):
+        """The redirect keeps the original path (upgrades in place)."""
+        r = requests.get(
+            f"{self._http_url()}/settings", allow_redirects=False, timeout=10
+        )
+        assert r.status_code in (301, 302, 307, 308)
+        assert r.headers.get("Location", "").endswith("/settings")
+
+    def test_http_health_still_served(self):
+        """Essential bootstrap routes remain available over plain HTTP."""
+        r = requests.get(
+            f"{self._http_url()}/api/health", allow_redirects=False, timeout=10
+        )
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

Two local-access UX fixes for the Arctic Controller, batched into one PR to save a device-test cycle.

### 1. Per-device mDNS hostname (MAC suffix)

The device previously advertised itself as `arctic.local`, so two or more controllers on the same network collided. The hostname now appends the last two bytes of the WiFi station MAC as four lowercase hex digits:

```
arctic-3f2a.local
```

- MAC is read from eFuse via `esp_read_mac(mac, ESP_MAC_WIFI_STA)` — deterministic across reboots and available even before Wi-Fi is up.
- Falls back to the base `arctic` name if the read ever fails.
- `GET /api/wifi` already returns `hostname` / `local_url`, so clients and the UI pick this up automatically.

### 2. HTTP → HTTPS redirect

With mandatory HTTPS active, all normal routes register on the HTTPS server only. A browser opening `http://<device>` on port 80 hit the bare esp_http_server `Nothing matches the given URI` 404.

A 404 error handler is now registered on the HTTP server that **301-redirects** to the same path on HTTPS, preserving whatever host the client used (IP or `arctic-xxxx.local`) and stripping any `:port`. Essential bootstrap routes (`/api/health`) still match first and remain available over plain HTTP for monitoring.

## Tests

- **API** (`tests/api/test_events_and_misc_api.py`): assert the reported hostname matches `arctic-[0-9a-f]{4}` and equals `arctic-<last 2 MAC bytes>`; assert `local_url` uses the suffixed hostname.
- **Device** (`tests/device/test_https.py`): `http://<device>/` and `/settings` return a 3xx with an `https://` `Location`; `/api/health` still returns 200 over plain HTTP.

## Notes

- CI device resolution is via the `.mi` DNS name (`ARCTIC_URL`), not `.local`, so the hostname change does not affect CI.
- No new URI handlers added (the redirect is an err handler), so `max_uri_handlers` is unchanged.
