### PR TITLE
refactor: remove leaked Macon register/bit knowledge from consumer

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -17,6 +17,7 @@
 #include "heatpump_types.h"
 #include "macon_master.h"
 #include "macon_state.h"  // arctic::setpoint_limits / SetpointKind
+#include "macon_registers.h"  // arctic::REG_* address constants (single source of truth)
 #include "advanced_params.h"  // advanced_param_write() AP guardrail
 #include "heatpump_errors.h"
 #include "event_log.h"
@@ -3891,49 +3892,53 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     httpd_resp_sendstr_chunk(req, line);
     snprintf(line, sizeof(line), "System,Demo Mode,,,\"%s\",\r\n", demo ? "Yes" : "No");
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "System,Unit Power,,2000,\"%s\",\r\n", hp.unit_on ? "ON" : "OFF");
+    // Unit power and working mode are derived by the macon library from
+    // several registers, so there is no single canonical address to report.
+    snprintf(line, sizeof(line), "System,Unit Power,,,\"%s\",\r\n", hp.unit_on ? "ON" : "OFF");
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "System,Working Mode,,2001,\"%s\",\r\n", arctic::workingModeToString(hp.working_mode));
+    snprintf(line, sizeof(line), "System,Working Mode,,,\"%s\",\r\n", arctic::workingModeToString(hp.working_mode));
     httpd_resp_sendstr_chunk(req, line);
 
-    // --- Temperatures (stored as tenths of °C) ---
+    // --- Temperatures (whole °C, already decoded by the macon library) ---
+    // Addresses are the real macon register constants (single source of truth);
+    // the consumer never hardcodes wire addresses.
     #define DIAG_TEMP(name_str, field, addr) \
-        snprintf(line, sizeof(line), "Temperature,%s,,%d,%.1f,°C\r\n", name_str, addr, (field) / 10.0f); \
+        snprintf(line, sizeof(line), "Temperature,%s,,%u,%d,°C\r\n", name_str, (addr), (int)(field)); \
         httpd_resp_sendstr_chunk(req, line);
 
-    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       2100)
-    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     2102)
-    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      2103)
-    DIAG_TEMP("Discharge",        hp.discharge_temp,        2104)
-    DIAG_TEMP("Suction",          hp.suction_temp,          2105)
-    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     2107)
-    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      2108)
-    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  2110)
-    DIAG_TEMP("IPM Module",       hp.ipm_temp,              2114)
+    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       arctic::REG_WATER_TANK_TEMP)
+    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     arctic::REG_OUTLET_WATER_TEMP)
+    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      arctic::REG_INLET_WATER_TEMP)
+    DIAG_TEMP("Discharge",        hp.discharge_temp,        arctic::REG_DISCHARGE_TEMP)
+    DIAG_TEMP("Suction",          hp.suction_temp,          arctic::REG_SUCTION_TEMP)
+    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     arctic::REG_COIL_TEMP)
+    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      arctic::REG_COOL_COIL_TEMP)
+    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  arctic::REG_OUTDOOR_AMBIENT_TEMP)
+    DIAG_TEMP("IPM Module",       hp.ipm_temp,              arctic::REG_IPM_TEMP)
     #undef DIAG_TEMP
 
-    // --- Setpoints ---
-    snprintf(line, sizeof(line), "Setpoint,Cooling,,2002,%d,°C\r\n", hp.cooling_setpoint);
+    // --- Setpoints (whole °C) ---
+    snprintf(line, sizeof(line), "Setpoint,Cooling,,%u,%d,°C\r\n", arctic::REG_COOLING_SETPOINT, hp.cooling_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Heating,,2003,%d,°C\r\n", hp.heating_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Heating,,%u,%d,°C\r\n", arctic::REG_AUX_HEAT_SETPOINT, hp.heating_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Hot Water,,2004,%d,°C\r\n", hp.hot_water_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Hot Water,,%u,%d,°C\r\n", arctic::REG_HOT_WATER_SETPOINT, hp.hot_water_setpoint);
     httpd_resp_sendstr_chunk(req, line);
 
-    // --- System Readings ---
-    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,2118,%u,Hz\r\n", hp.compressor_freq);
+    // --- System Readings (already decoded to whole units by the macon library) ---
+    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,%u,%u,Hz\r\n", arctic::REG_COMPRESSOR_FREQ, hp.compressor_freq);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Fan Speed,,2119,%u,RPM\r\n", hp.fan_speed);
+    snprintf(line, sizeof(line), "Reading,Fan Speed,,%u,%u,RPM\r\n", arctic::REG_DC_MOTOR_SPEED, hp.fan_speed);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Voltage,,2120,%u,V\r\n", hp.ac_voltage);
+    snprintf(line, sizeof(line), "Reading,AC Voltage,,%u,%u,V\r\n", arctic::REG_AC_VOLTAGE, hp.ac_voltage);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Current,,2121,%.1f,A\r\n", hp.ac_current / 10.0f);
+    snprintf(line, sizeof(line), "Reading,AC Current,,%u,%u,A\r\n", arctic::REG_AC_CURRENT, hp.ac_current);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,DC Voltage,,2122,%.1f,V\r\n", hp.getDcVoltageV());
+    snprintf(line, sizeof(line), "Reading,DC Voltage,,%u,%.1f,V\r\n", arctic::REG_DC_BUS_VOLTAGE, hp.getDcVoltageV());
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,2124,%u,steps\r\n", hp.primary_eev_opening);
+    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,%u,%u,steps\r\n", arctic::REG_MAIN_EEV, hp.primary_eev_opening);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Power Consumption,,2114,%lu,W\r\n", (unsigned long)hp.realtime_power_w);
+    snprintf(line, sizeof(line), "Reading,Power Consumption,,%u,%lu,W\r\n", arctic::REG_REALTIME_POWER, (unsigned long)hp.realtime_power_w);
     httpd_resp_sendstr_chunk(req, line);
     if (hp.cop_valid) {
         snprintf(line, sizeof(line), "Reading,Heat Output (est),,,%ld,W\r\n", (long)hp.thermal_w);
@@ -3957,15 +3962,15 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     #undef DIAG_BOOL
 
     // --- Raw fault-register bytes (2007 + 2125-2128) ---
-    snprintf(line, sizeof(line), "Register,Fault Run/State (raw),,2007,0x%02X,\r\n", hp.fault_run);
+    snprintf(line, sizeof(line), "Register,Fault Run/State (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_RUNSTATE, hp.fault_run);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Sensor/EE (raw),,2125,0x%02X,\r\n", hp.fault_ee);
+    snprintf(line, sizeof(line), "Register,Fault Sensor/EE (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_SENSOR_EE, hp.fault_ee);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Sensor/Comp (raw),,2126,0x%02X,\r\n", hp.fault_comp);
+    snprintf(line, sizeof(line), "Register,Fault Sensor/Comp (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_SENSOR_COMP, hp.fault_comp);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Electrical (raw),,2127,0x%02X,\r\n", hp.fault_elec);
+    snprintf(line, sizeof(line), "Register,Fault Electrical (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_ELEC, hp.fault_elec);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Refrigerant (raw),,2128,0x%02X,\r\n", hp.fault_ref);
+    snprintf(line, sizeof(line), "Register,Fault Refrigerant (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT, hp.fault_ref);
     httpd_resp_sendstr_chunk(req, line);
 
     // --- Active Errors (natively decoded by the macon library) ---

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -338,36 +338,15 @@ bool isExternalFeed() {
     return s_feed_mode;
 }
 
-// Empirically-derived Macon (OEM) Tuya register->field mapping (index = reg-2000).
-// Confirmed against the unit's official o/A parameter-code legend cross-checked
-// with live ground truth (idle + running pump->fan->compressor staged states):
-//   TEMPERATURES (signed int8, whole °C):
-//     reg2008 = o1 water tank
-//     reg2132 = o3 water outlet/supply    (idle 28 -> running 40)
-//     reg2133 = o2 water inlet/return     (idle 28 -> running 36)
-//     reg2134 = o4 ambient/outdoor
-//     reg2135 = A6 cool coil
-//     reg2136 = A2 coil
-//     reg2137 = A3 suction
-//     reg2138 = A1 discharge
-//     reg2113 = A8 IPM module
-//   SETPOINT: reg2012 = hot-water setpoint
-//   STATUS:   reg2007 run/fault bitfield (0x20 = hot-water ON; bits0-3 = ΔT/temp faults),
-//             reg2130 icon bits #1 (0x01 heating, 0x04 compressor, 0x08 pump, 0x20 hours),
-//             reg2129 icon bits #2 (0x02 defrost, 0x10 fan)
-//   ELECTRICAL (register value == A-code menu value, 1:1):
-//     reg2000 = A4 AC input current    reg2101 = A13 AC input voltage
-//     reg2001 = A7 DC bus voltage(*10) reg2140 = A5 main EEV degree
-//     reg2003 = A10 DC motor (fan) speed
-//     reg2141 = A14 compressor frequency (Hz)   [telemetry window reaches 2142]
-//   real-time power comes from the macon library (reg2114/A9), in watts.
-// High/low pressure (A11/A12) read static nonsense values (-6 / 3), i.e.
-// uninstalled sensors on this DHW unit, so left cleared. The fault/protection
-// registers are reg2007 (holding) + the INPUT cluster reg2125-2128, all mapped
-// live 2026-07-05; their bit ordering differs from the legacy Arctic error
-// tables, so each confirmed bit is translated to its semantic legacy mask.
-// Adapt the confirmed reg2096 working-mode enum. In Auto, expose the actual
-// water-side direction while the compressor runs.
+// The arctic-macon library (decode_state) is the single source of truth for the
+// Macon Tuya register layout, scaling, and fault/icon bit positions — see
+// components/arctic-macon/include/macon_registers.h and macon_faults.h. This
+// adapter consumes the already-decoded MaconState; it does NOT re-interpret raw
+// registers. High/low pressure (A11/A12) are uninstalled sensors on this DHW
+// unit and are not reported.
+//
+// In Auto working mode, expose the actual water-side direction while the
+// compressor runs (rather than the raw menu enum).
 static WorkingMode to_working_mode(const MaconState& state) {
     switch (state.working_mode) {
         case MaconWorkingMode::Cooling:

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -76,8 +76,10 @@ static bool elapsed_within(uint32_t now, uint32_t then, uint32_t limit) {
 // exactly as the passive listener / active master / demo simulator populate
 // them. The arctic-macon library (decode_state) owns interpreting this image
 // into a MaconState; the controller only adapts that into HeatPumpState.
-static const uint16_t DEMO_REG_BASE = 2000;
-static const uint16_t DEMO_REG_COUNT = 143; // 2000..2142 inclusive (telemetry window reaches reg2142)
+static const uint16_t DEMO_REG_BASE = HOLDING_START;  // 2000
+// Spans both the holding (2000..2057) and telemetry (2093..2142) windows as a
+// single flat cache; bounds come from the macon library, not magic numbers.
+static const uint16_t DEMO_REG_COUNT = INPUT_START + INPUT_COUNT - HOLDING_START;  // 2000..2142
 static uint16_t s_demo_regs[DEMO_REG_COUNT];
 
 // Read a single register from the cache.
@@ -156,7 +158,9 @@ static void detectAndLogStateEvents() {
         const uint8_t cur_faults[5] = {
             s_state.fault_run, s_state.fault_ee, s_state.fault_comp,
             s_state.fault_elec, s_state.fault_ref };
-        static const uint16_t kFaultRegs[5] = {2007, 2125, 2126, 2127, 2128};
+        static const uint16_t kFaultRegs[5] = {
+            REG_FAULT_RUNSTATE, REG_FAULT_SENSOR_EE, REG_FAULT_SENSOR_COMP,
+            REG_FAULT_ELEC, REG_FAULT };
         for (int r = 0; r < 5; r++) {
             uint8_t appeared = cur_faults[r] & ~s_prev_fault_bytes[r];
             uint8_t cleared  = s_prev_fault_bytes[r] & ~cur_faults[r];
@@ -559,8 +563,8 @@ void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count) {
 
     const uint32_t now = getTimeMs();
     const uint32_t window_end = (uint32_t)reg_base + (uint32_t)count;
-    const bool has_holding_state = reg_base <= 2049 && window_end > 2049;
-    const bool has_telemetry_state = reg_base <= 2141 && window_end > 2141;
+    const bool has_holding_state = reg_base <= REG_OPERATING_MODE && window_end > REG_OPERATING_MODE;
+    const bool has_telemetry_state = reg_base <= REG_COMPRESSOR_FREQ && window_end > REG_COMPRESSOR_FREQ;
 
     // Copy the window's 1-byte registers into the register cache (bounds-checked).
     for (size_t i = 0; i < count; ++i) {
@@ -643,10 +647,14 @@ TelemetrySnapshot getTelemetrySnapshot() {
             elapsed_within(now, s_telemetry_window_ms, TELEMETRY_FRESHNESS_MS);
         snapshot.connected = telemetry_fresh;
         snapshot.inlet_valid = telemetry_fresh && s_inlet_valid &&
-            !(s_state.fault_ee & 0x02) &&   // E19 inlet-water sensor (reg2125 bit1)
+            !hasActiveFaultCode(s_state.fault_run, s_state.fault_ee,
+                                s_state.fault_comp, s_state.fault_elec,
+                                s_state.fault_ref, "E19") &&  // inlet-water sensor
             s_state.inlet_water_temp >= -50 && s_state.inlet_water_temp <= 150;
         snapshot.outlet_valid = telemetry_fresh && s_outlet_valid &&
-            !(s_state.fault_ee & 0x04) &&   // E18 outlet-water sensor (reg2125 bit2)
+            !hasActiveFaultCode(s_state.fault_run, s_state.fault_ee,
+                                s_state.fault_comp, s_state.fault_elec,
+                                s_state.fault_ref, "E18") &&  // outlet-water sensor
             s_state.outlet_water_temp >= -50 && s_state.outlet_water_temp <= 150;
         snapshot.compressor_valid = telemetry_fresh && s_compressor_valid;
         snapshot.compressor_running =
@@ -848,8 +856,10 @@ bool setHotWaterSetpoint(int16_t temp) {
 }
 
 bool writeRegister(uint16_t address, uint16_t value) {
-    const bool in_holding_window = address >= 2000 && address <= 2057;
-    const bool in_telemetry_window = address >= 2093 && address <= 2142;
+    const bool in_holding_window =
+        address >= HOLDING_START && address < HOLDING_START + HOLDING_COUNT;
+    const bool in_telemetry_window =
+        address >= INPUT_START && address < INPUT_START + INPUT_COUNT;
     if (!in_holding_window && !in_telemetry_window) {
         ESP_LOGE(TAG, "Register %u is outside known Macon windows",
                  (unsigned)address);

--- a/main/heatpump_errors.cpp
+++ b/main/heatpump_errors.cpp
@@ -10,6 +10,7 @@
 #include "heatpump_errors.h"
 #include "heatpump_controller.h"
 #include "macon_faults.h"
+#include "macon_registers.h"  // arctic::REG_FAULT_* address constants
 #include <cJSON.h>
 #include <esp_log.h>
 #include <stdio.h>
@@ -79,23 +80,23 @@ static const char* resolutionForCode(const char* code) {
 // MACON_FAULT_REGS: 2007, 2125, 2126, 2127, 2128).
 static int regIndex(uint16_t reg) {
     switch (reg) {
-        case 2007: return 0;
-        case 2125: return 1;
-        case 2126: return 2;
-        case 2127: return 3;
-        case 2128: return 4;
-        default:   return -1;
+        case REG_FAULT_RUNSTATE:    return 0;
+        case REG_FAULT_SENSOR_EE:   return 1;
+        case REG_FAULT_SENSOR_COMP: return 2;
+        case REG_FAULT_ELEC:        return 3;
+        case REG_FAULT:             return 4;
+        default:                    return -1;
     }
 }
 
 static uint8_t regByte(const HeatPumpState& s, uint16_t reg) {
     switch (reg) {
-        case 2007: return s.fault_run;
-        case 2125: return s.fault_ee;
-        case 2126: return s.fault_comp;
-        case 2127: return s.fault_elec;
-        case 2128: return s.fault_ref;
-        default:   return 0;
+        case REG_FAULT_RUNSTATE:    return s.fault_run;
+        case REG_FAULT_SENSOR_EE:   return s.fault_ee;
+        case REG_FAULT_SENSOR_COMP: return s.fault_comp;
+        case REG_FAULT_ELEC:        return s.fault_elec;
+        case REG_FAULT:             return s.fault_ref;
+        default:                    return 0;
     }
 }
 
@@ -352,6 +353,18 @@ bool isErrorActive(uint16_t reg, uint8_t bit) {
     HeatPumpState state = getState();
     if (regIndex(reg) < 0) return false;
     return (regByte(state, reg) >> bit) & 0x1;
+}
+
+bool hasActiveFaultCode(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
+                        uint8_t fault_elec, uint8_t fault_ref, const char* code) {
+    if (!code) return false;
+    MaconFault faults[32];
+    size_t n = macon_decode_faults(fault_run, fault_ee, fault_comp,
+                                   fault_elec, fault_ref, faults, 32);
+    for (size_t i = 0; i < n; ++i) {
+        if (faults[i].code && strcmp(faults[i].code, code) == 0) return true;
+    }
+    return false;
 }
 
 char* getErrorsAsJson() {

--- a/main/heatpump_errors.h
+++ b/main/heatpump_errors.h
@@ -119,4 +119,12 @@ const char* formatDuration(time_t start_time, time_t end_time = 0);
 // Check if a specific (reg, bit) fault is currently active.
 bool isErrorActive(uint16_t reg, uint8_t bit);
 
+// True if the fault identified by `code` (e.g. "E18", "E19") is currently
+// active in the supplied raw Macon fault-register bytes. The macon library
+// owns the code->(reg, bit) mapping; callers reference only the public code
+// string and never a bit position. Takes the raw bytes (rather than reading
+// global state) so it is safe to call while holding the controller state lock.
+bool hasActiveFaultCode(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
+                        uint8_t fault_elec, uint8_t fault_ref, const char* code);
+
 }  // namespace arctic

--- a/main/i18n/i18n.cpp
+++ b/main/i18n/i18n.cpp
@@ -243,13 +243,8 @@ static const char* strings_en[STR_COUNT] = {
     [STR_HP_AC_VOLTAGE] = "AC Voltage",
     [STR_HP_AC_CURRENT] = "AC Current",
     [STR_HP_DC_VOLTAGE] = "DC Voltage",
-    [STR_HP_DC_CURRENT] = "DC Current",
-    [STR_HP_PRESSURES] = "Pressures",
-    [STR_HP_HIGH_PRESSURE] = "High Pressure",
-    [STR_HP_LOW_PRESSURE] = "Low Pressure",
     [STR_HP_EXPANSION_VALVES] = "Expansion Valves",
     [STR_HP_PRIMARY_EEV] = "Primary EEV",
-    [STR_HP_SECONDARY_EEV] = "Secondary EEV",
     [STR_HP_SETPOINTS] = "Setpoints",
     
     // Heat Pump - Errors Screen
@@ -636,13 +631,8 @@ static const char* strings_fr[STR_COUNT] = {
     [STR_HP_AC_VOLTAGE] = "Tension CA",
     [STR_HP_AC_CURRENT] = "Courant CA",
     [STR_HP_DC_VOLTAGE] = "Tension CC",
-    [STR_HP_DC_CURRENT] = "Courant CC",
-    [STR_HP_PRESSURES] = "Pressions",
-    [STR_HP_HIGH_PRESSURE] = "Haute pression",
-    [STR_HP_LOW_PRESSURE] = "Basse pression",
     [STR_HP_EXPANSION_VALVES] = "Détendeurs",
     [STR_HP_PRIMARY_EEV] = "Détendeur primaire",
-    [STR_HP_SECONDARY_EEV] = "Détendeur secondaire",
     [STR_HP_SETPOINTS] = "Consignes",
     
     // Heat Pump - Errors Screen
@@ -1029,13 +1019,8 @@ static const char* strings_es[STR_COUNT] = {
     [STR_HP_AC_VOLTAGE] = "Tensión CA",
     [STR_HP_AC_CURRENT] = "Corriente CA",
     [STR_HP_DC_VOLTAGE] = "Tensión CC",
-    [STR_HP_DC_CURRENT] = "Corriente CC",
-    [STR_HP_PRESSURES] = "Presiones",
-    [STR_HP_HIGH_PRESSURE] = "Alta presión",
-    [STR_HP_LOW_PRESSURE] = "Baja presión",
     [STR_HP_EXPANSION_VALVES] = "Válvulas de expansión",
     [STR_HP_PRIMARY_EEV] = "VEE primaria",
-    [STR_HP_SECONDARY_EEV] = "VEE secundaria",
     [STR_HP_SETPOINTS] = "Consignas",
     
     // Heat Pump - Errors Screen

--- a/main/i18n/strings.h
+++ b/main/i18n/strings.h
@@ -264,13 +264,8 @@ typedef enum {
     STR_HP_AC_VOLTAGE,
     STR_HP_AC_CURRENT,
     STR_HP_DC_VOLTAGE,
-    STR_HP_DC_CURRENT,
-    STR_HP_PRESSURES,
-    STR_HP_HIGH_PRESSURE,
-    STR_HP_LOW_PRESSURE,
     STR_HP_EXPANSION_VALVES,
     STR_HP_PRIMARY_EEV,
-    STR_HP_SECONDARY_EEV,
     STR_HP_SETPOINTS,
     
     // ========================================================================

--- a/tests/api/test_diagnostic_api.py
+++ b/tests/api/test_diagnostic_api.py
@@ -343,6 +343,55 @@ class TestDiagnosticContent:
             assert addr.isdigit(), f"Parameter '{row['Name']}' has non-numeric address: {addr}"
 
 
+# ── Value scaling (regression guard) ──────────────────────────────────────
+
+
+class TestDiagnosticValues:
+    """Regression guard for CSV value magnitudes.
+
+    The arctic-macon library decodes raw registers into whole-unit values;
+    the diagnostic CSV must render those as-is and must NOT re-scale them. A
+    prior bug divided every temperature and the AC current by 10, so they
+    were reported 10x low (42 C -> "4.2", 5 A -> "0.5"). These tests inject
+    known demo register values and assert the exact rendered value, so any
+    reintroduced scaling error fails loudly. Demo injection writes the RAW
+    register byte; the library owns the raw->unit conversion.
+    """
+
+    def _row_value(self, category: str, name: str):
+        r = _get("/api/heatpump/diagnostic")
+        rows = _parse_csv(r.content.decode("utf-8-sig"))
+        for row in rows:
+            if row["Category"] == category and row["Name"] == name:
+                return row["Value"]
+        return None
+
+    def test_temperatures_are_whole_celsius(self):
+        # Raw temp registers decode 1:1 to whole degrees C.
+        _inject_demo({"water_tank_temp": 42, "inlet_water_temp": 38})
+        time.sleep(1.0)
+        assert self._row_value("Temperature", "Water Tank") == "42"
+        assert self._row_value("Temperature", "Inlet Water") == "38"
+
+    def test_ac_current_is_whole_amps(self):
+        # AC current decodes 1:1 to whole amps (not tenths).
+        _inject_demo({"ac_current": 5})
+        time.sleep(1.0)
+        assert self._row_value("Reading", "AC Current") == "5"
+
+    def test_ac_voltage_uses_library_scaling(self):
+        # Raw AC voltage is x10; the library decodes 23 -> 230 V and the CSV
+        # must show the decoded value without re-scaling.
+        _inject_demo({"ac_voltage": 23})
+        time.sleep(1.0)
+        assert self._row_value("Reading", "AC Voltage") == "230"
+
+    def test_compressor_frequency_value(self):
+        _inject_demo({"compressor_freq": 60})
+        time.sleep(1.0)
+        assert self._row_value("Reading", "Compressor Frequency") == "60"
+
+
 # ── Error Injection ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Remove leaked Macon register/bit knowledge from the consumer

Enforces the architectural rule that **only `components/arctic-macon/` knows protocol details** (register addresses, fault bit positions, value scaling). The controller / API layer now works purely in decoded units, fault **codes**, and library-owned register constants.

> ⚠️ **Stacked on #111** (`refactor/tuya-only-macon-state`). Review this diff against that base; it will retarget to `main` automatically once #111 lands. **Do not auto-merge.**

### What changed

- **Diagnostic CSV (`api_server.cpp`)**
  - **Bug fix:** dropped the `/10.0f` scaling. `HeatPumpState` now holds whole-unit values decoded by the library, so temperatures were reported **10× too low** and AC current **10× too low**.
  - Replaced the fictional hardcoded register addresses (`2100/2102/2118/2120/2121/…`) with the library's real `REG_*` constants. Derived values (unit power, working mode) no longer claim a bogus single address.
- **Sensor-validity gate (`heatpump_controller.cpp`)**
  - Replaced raw `s_state.fault_ee & 0x02 / & 0x04` bit tests with a new `hasActiveFaultCode(...)` helper that decodes via the library and matches on the public code string (`"E18"`/`"E19"`). The consumer no longer knows which register/bit a code lives at. The helper takes raw fault bytes so it is safe to call while holding the state lock.
- **Register windows (`heatpump_controller.cpp`)**
  - `writeRegister`, the demo register cache bounds, and the feed sentinels now use `HOLDING_START/COUNT`, `INPUT_START/COUNT`, `REG_OPERATING_MODE`, and `REG_COMPRESSOR_FREQ` instead of magic `2000/2057/2093/2142/2049/2141`.
- **Fault-register references (`heatpump_controller.cpp`, `heatpump_errors.cpp`)**
  - Fault-diff event emission and the `regIndex`/`regByte` helpers reference `REG_FAULT_*` constants instead of literal `2007/2125..2128`.

### Verification

- Firmware builds green (ESP32-P4, IDF v5.5.2, 49% free).
- No CSV/API contract change beyond the corrected temperature/current magnitudes; existing diagnostic tests (units present, numeric addresses, hex register rows, ≥7 status rows) still hold.

### Deliberately deferred (separate work)

These need either an **arctic-macon API addition** (own PR, coordinated with #20) or **live-unit ground truth**, so they are out of scope here:
- `encode_working_mode()` — the `WorkingMode` enum still bakes in wire byte values (`heatpump_types.h`); needs a library encode function.
- Demo-simulation re-encode helpers + demo-field raw scaling — need library encode ownership.
- Fan-speed → tier bucketing (`getFanSpeedLevel` `>=30/>=60`) — needs the real max-fan-speed register/range captured from a live Macon unit.
- Backup-heater register mapping + scaling verification — need live captures.
