### PR TITLE
refactor(controller): make main/ fully opaque to the Macon protocol (P2)

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -17,7 +17,8 @@
 #include "heatpump_types.h"
 #include "macon_master.h"
 #include "macon_state.h"  // arctic::setpoint_limits / SetpointKind
-#include "macon_registers.h"  // arctic::REG_* address constants (single source of truth)
+#include "macon_image.h"   // arctic::MaconField / macon_field_address (opaque address lookup)
+#include "macon_faults.h"  // arctic::MACON_FAULT_REGS (fault-register addresses)
 #include "advanced_params.h"  // advanced_param_write() AP guardrail
 #include "heatpump_errors.h"
 #include "event_log.h"
@@ -3900,45 +3901,46 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     httpd_resp_sendstr_chunk(req, line);
 
     // --- Temperatures (whole °C, already decoded by the macon library) ---
-    // Addresses are the real macon register constants (single source of truth);
-    // the consumer never hardcodes wire addresses.
-    #define DIAG_TEMP(name_str, field, addr) \
-        snprintf(line, sizeof(line), "Temperature,%s,,%u,%d,°C\r\n", name_str, (addr), (int)(field)); \
+    // Addresses come from the library's opaque field->address lookup; the
+    // consumer never hardcodes a wire address.
+    #define DIAG_TEMP(name_str, field, macon_field) \
+        snprintf(line, sizeof(line), "Temperature,%s,,%u,%d,°C\r\n", name_str, \
+                 arctic::macon_field_address(macon_field), (int)(field)); \
         httpd_resp_sendstr_chunk(req, line);
 
-    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       arctic::REG_WATER_TANK_TEMP)
-    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     arctic::REG_OUTLET_WATER_TEMP)
-    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      arctic::REG_INLET_WATER_TEMP)
-    DIAG_TEMP("Discharge",        hp.discharge_temp,        arctic::REG_DISCHARGE_TEMP)
-    DIAG_TEMP("Suction",          hp.suction_temp,          arctic::REG_SUCTION_TEMP)
-    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     arctic::REG_COIL_TEMP)
-    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      arctic::REG_COOL_COIL_TEMP)
-    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  arctic::REG_OUTDOOR_AMBIENT_TEMP)
-    DIAG_TEMP("IPM Module",       hp.ipm_temp,              arctic::REG_IPM_TEMP)
+    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       arctic::MaconField::WaterTankTemp)
+    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     arctic::MaconField::OutletWaterTemp)
+    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      arctic::MaconField::InletWaterTemp)
+    DIAG_TEMP("Discharge",        hp.discharge_temp,        arctic::MaconField::DischargeTemp)
+    DIAG_TEMP("Suction",          hp.suction_temp,          arctic::MaconField::SuctionTemp)
+    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     arctic::MaconField::OutdoorCoilTemp)
+    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      arctic::MaconField::IndoorCoilTemp)
+    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  arctic::MaconField::OutdoorAmbientTemp)
+    DIAG_TEMP("IPM Module",       hp.ipm_temp,              arctic::MaconField::IpmTemp)
     #undef DIAG_TEMP
 
     // --- Setpoints (whole °C) ---
-    snprintf(line, sizeof(line), "Setpoint,Cooling,,%u,%d,°C\r\n", arctic::REG_COOLING_SETPOINT, hp.cooling_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Cooling,,%u,%d,°C\r\n", arctic::macon_field_address(arctic::MaconField::CoolingSetpoint), hp.cooling_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Heating,,%u,%d,°C\r\n", arctic::REG_AUX_HEAT_SETPOINT, hp.heating_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Heating,,%u,%d,°C\r\n", arctic::macon_field_address(arctic::MaconField::HeatingSetpoint), hp.heating_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Hot Water,,%u,%d,°C\r\n", arctic::REG_HOT_WATER_SETPOINT, hp.hot_water_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Hot Water,,%u,%d,°C\r\n", arctic::macon_field_address(arctic::MaconField::HotWaterSetpoint), hp.hot_water_setpoint);
     httpd_resp_sendstr_chunk(req, line);
 
     // --- System Readings (already decoded to whole units by the macon library) ---
-    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,%u,%u,Hz\r\n", arctic::REG_COMPRESSOR_FREQ, hp.compressor_freq);
+    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,%u,%u,Hz\r\n", arctic::macon_field_address(arctic::MaconField::CompressorFreq), hp.compressor_freq);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Fan Speed,,%u,%u,RPM\r\n", arctic::REG_DC_MOTOR_SPEED, hp.fan_speed);
+    snprintf(line, sizeof(line), "Reading,Fan Speed,,%u,%u,RPM\r\n", arctic::macon_field_address(arctic::MaconField::FanLevel), hp.fan_speed);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Voltage,,%u,%u,V\r\n", arctic::REG_AC_VOLTAGE, hp.ac_voltage);
+    snprintf(line, sizeof(line), "Reading,AC Voltage,,%u,%u,V\r\n", arctic::macon_field_address(arctic::MaconField::AcVoltage), hp.ac_voltage);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Current,,%u,%u,A\r\n", arctic::REG_AC_CURRENT, hp.ac_current);
+    snprintf(line, sizeof(line), "Reading,AC Current,,%u,%u,A\r\n", arctic::macon_field_address(arctic::MaconField::AcCurrent), hp.ac_current);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,DC Voltage,,%u,%.1f,V\r\n", arctic::REG_DC_BUS_VOLTAGE, hp.getDcVoltageV());
+    snprintf(line, sizeof(line), "Reading,DC Voltage,,%u,%.1f,V\r\n", arctic::macon_field_address(arctic::MaconField::DcVoltage), hp.getDcVoltageV());
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,%u,%u,steps\r\n", arctic::REG_MAIN_EEV, hp.primary_eev_opening);
+    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,%u,%u,steps\r\n", arctic::macon_field_address(arctic::MaconField::PrimaryEev), hp.primary_eev_opening);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Power Consumption,,%u,%lu,W\r\n", arctic::REG_REALTIME_POWER, (unsigned long)hp.realtime_power_w);
+    snprintf(line, sizeof(line), "Reading,Power Consumption,,%u,%lu,W\r\n", arctic::macon_field_address(arctic::MaconField::RealtimePower), (unsigned long)hp.realtime_power_w);
     httpd_resp_sendstr_chunk(req, line);
     if (hp.cop_valid) {
         snprintf(line, sizeof(line), "Reading,Heat Output (est),,,%ld,W\r\n", (long)hp.thermal_w);
@@ -3962,16 +3964,22 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     #undef DIAG_BOOL
 
     // --- Raw fault-register bytes (2007 + 2125-2128) ---
-    snprintf(line, sizeof(line), "Register,Fault Run/State (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_RUNSTATE, hp.fault_run);
-    httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Sensor/EE (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_SENSOR_EE, hp.fault_ee);
-    httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Sensor/Comp (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_SENSOR_COMP, hp.fault_comp);
-    httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Electrical (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT_ELEC, hp.fault_elec);
-    httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Register,Fault Refrigerant (raw),,%u,0x%02X,\r\n", arctic::REG_FAULT, hp.fault_ref);
-    httpd_resp_sendstr_chunk(req, line);
+    // --- Raw fault-register bytes. Addresses come from the library-owned
+    // MACON_FAULT_REGS[] list (2007 + 2125-2128), in that order; the consumer
+    // hardcodes no register address. ---
+    {
+        const char* fault_names[arctic::MACON_FAULT_REGS_COUNT] = {
+            "Fault Run/State (raw)", "Fault Sensor/EE (raw)",
+            "Fault Sensor/Comp (raw)", "Fault Electrical (raw)",
+            "Fault Refrigerant (raw)" };
+        const uint8_t fault_vals[arctic::MACON_FAULT_REGS_COUNT] = {
+            hp.fault_run, hp.fault_ee, hp.fault_comp, hp.fault_elec, hp.fault_ref };
+        for (size_t i = 0; i < arctic::MACON_FAULT_REGS_COUNT; ++i) {
+            snprintf(line, sizeof(line), "Register,%s,,%u,0x%02X,\r\n",
+                     fault_names[i], arctic::MACON_FAULT_REGS[i], fault_vals[i]);
+            httpd_resp_sendstr_chunk(req, line);
+        }
+    }
 
     // --- Active Errors (natively decoded by the macon library) ---
     {
@@ -3981,8 +3989,8 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
             const char* label = actives[i].description && actives[i].description[0]
                                     ? actives[i].description
                                     : (actives[i].name ? actives[i].name : "");
-            snprintf(line, sizeof(line), "Error,\"%s\",%s,%u,ACTIVE,\r\n",
-                     label, actives[i].code, actives[i].reg);
+            snprintf(line, sizeof(line), "Error,\"%s\",%s,,ACTIVE,\r\n",
+                     label, actives[i].code);
             httpd_resp_sendstr_chunk(req, line);
         }
     }

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3983,8 +3983,8 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
 
     // --- Active Errors (natively decoded by the macon library) ---
     {
-        arctic::ActiveError actives[32];
-        int active_count = arctic::getActiveErrors(actives, 32);
+        arctic::ActiveError actives[arctic::MAX_ACTIVE_FAULTS];
+        int active_count = arctic::getActiveErrors(actives, arctic::MAX_ACTIVE_FAULTS);
         for (int i = 0; i < active_count; i++) {
             const char* label = actives[i].description && actives[i].description[0]
                                     ? actives[i].description

--- a/main/event_log_screen.cpp
+++ b/main/event_log_screen.cpp
@@ -223,14 +223,16 @@ static void format_event_detail(char* buf, size_t buf_size, const event_entry_t*
         }
         case EVENT_ERROR_APPEARED:
         case EVENT_ERROR_CLEARED: {
-            // Payload = (fault register << 8) | bit index, per detectAndLogStateEvents.
-            uint16_t reg = (p >> 8) & 0xFFFF;
-            uint8_t  bit = p & 0xFF;
-            const arctic::MaconFaultBit* fb = arctic::macon_fault_bit(reg, bit);
+            // Payload = opaque fault site id, per detectAndLogStateEvents. The
+            // library resolves it to a code/label; the screen handles no
+            // register or bit position.
+            const arctic::MaconFaultSiteId site =
+                static_cast<arctic::MaconFaultSiteId>(p);
+            const arctic::MaconFaultBit* fb = arctic::macon_fault_bit_for_site(site);
             if (fb != nullptr) {
                 snprintf(buf, buf_size, "(%s) %s", fb->code, fb->label);
             } else {
-                snprintf(buf, buf_size, "Reg %u bit %u", reg, bit);
+                snprintf(buf, buf_size, "Error %u", (unsigned)site);
             }
             break;
         }

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -7,7 +7,7 @@
 #include "heatpump_errors.h"
 #include "event_log.h"
 #include "macon_state.h"
-#include "macon_registers.h"
+#include "macon_image.h"
 #include "macon_faults.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -70,37 +70,26 @@ static bool elapsed_within(uint32_t now, uint32_t then, uint32_t limit) {
 }
 
 // ============================================================================
-// Register Cache
+// Register Image
 // ============================================================================
-// The real Tuya wire registers are cached here (index = reg - DEMO_REG_BASE),
-// exactly as the passive listener / active master / demo simulator populate
-// them. The arctic-macon library (decode_state) owns interpreting this image
-// into a MaconState; the controller only adapts that into HeatPumpState.
-static const uint16_t DEMO_REG_BASE = HOLDING_START;  // 2000
-// Spans both the holding (2000..2057) and telemetry (2093..2142) windows as a
-// single flat cache; bounds come from the macon library, not magic numbers.
-static const uint16_t DEMO_REG_COUNT = INPUT_START + INPUT_COUNT - HOLDING_START;  // 2000..2142
-static uint16_t s_demo_regs[DEMO_REG_COUNT];
+// The heat pump's register state is held OPAQUELY in a MaconImage. The
+// controller never references a register address, bit position, or scaling
+// factor: the arctic-macon library owns all of that. The image is mutated
+// through semantic operations (set_flag/set_value/set_fault/ingest/…) under
+// s_image_mutex; applyMaconMapping() copies it under that lock, releases it,
+// then decodes the copy — so the image lock and the state lock are never held
+// at the same time.
+static MaconImage s_image;
+static SemaphoreHandle_t s_image_mutex = nullptr;
 
-// Read a single register from the cache.
-static esp_err_t readCacheReg(uint16_t address, uint16_t* out) {
-    if (out == nullptr || address < DEMO_REG_BASE ||
-        (uint16_t)(address - DEMO_REG_BASE) >= DEMO_REG_COUNT) {
-        return ESP_ERR_INVALID_ARG;
+static void ensureImageMutex() {
+    if (s_image_mutex == nullptr) {
+        s_image_mutex = xSemaphoreCreateMutex();
     }
-    *out = s_demo_regs[address - DEMO_REG_BASE];
-    return ESP_OK;
 }
 
-// Write a single register into the cache (real Tuya layout).
-static esp_err_t writeCacheReg(uint16_t address, uint16_t value) {
-    if (address < DEMO_REG_BASE ||
-        (uint16_t)(address - DEMO_REG_BASE) >= DEMO_REG_COUNT) {
-        return ESP_ERR_INVALID_ARG;
-    }
-    s_demo_regs[address - DEMO_REG_BASE] = value;
-    return ESP_OK;
-}
+static inline void imageLock()   { if (s_image_mutex) xSemaphoreTake(s_image_mutex, portMAX_DELAY); }
+static inline void imageUnlock() { if (s_image_mutex) xSemaphoreGive(s_image_mutex); }
 
 
 // Compare the freshly-updated s_state against the previous snapshot and record
@@ -154,23 +143,31 @@ static void detectAndLogStateEvents() {
         if (cur_defrost != s_prev_defrosting) {
             event_log_record(cur_defrost ? EVENT_DEFROST_START : EVENT_DEFROST_END, 0);
         }
-        // Fault changes (per Macon fault register/bit; skip the RUN indicator).
-        const uint8_t cur_faults[5] = {
+        // Fault changes: decode the previous and current fault bytes into
+        // semantic sites (the library skips the RUN indicator) and diff by
+        // opaque site id. The event-log payload is that site id — no register
+        // or bit position is handled here.
+        MaconFault prev_f[32];
+        MaconFault cur_f[32];
+        const size_t np = macon_decode_faults(
+            s_prev_fault_bytes[0], s_prev_fault_bytes[1], s_prev_fault_bytes[2],
+            s_prev_fault_bytes[3], s_prev_fault_bytes[4], prev_f, 32);
+        const size_t nc = macon_decode_faults(
             s_state.fault_run, s_state.fault_ee, s_state.fault_comp,
-            s_state.fault_elec, s_state.fault_ref };
-        static const uint16_t kFaultRegs[5] = {
-            REG_FAULT_RUNSTATE, REG_FAULT_SENSOR_EE, REG_FAULT_SENSOR_COMP,
-            REG_FAULT_ELEC, REG_FAULT };
-        for (int r = 0; r < 5; r++) {
-            uint8_t appeared = cur_faults[r] & ~s_prev_fault_bytes[r];
-            uint8_t cleared  = s_prev_fault_bytes[r] & ~cur_faults[r];
-            for (int b = 0; b < 8; b++) {
-                const MaconFaultBit* fb = macon_fault_bit(kFaultRegs[r], b);
-                if (fb == nullptr || fb->severity == FaultSeverity::INFO) continue;
-                uint32_t payload = ((uint32_t)kFaultRegs[r] << 8) | (uint32_t)b;
-                if (appeared & (1 << b)) event_log_record(EVENT_ERROR_APPEARED, payload);
-                if (cleared & (1 << b))  event_log_record(EVENT_ERROR_CLEARED, payload);
+            s_state.fault_elec, s_state.fault_ref, cur_f, 32);
+        for (size_t i = 0; i < nc; ++i) {
+            bool was_present = false;
+            for (size_t j = 0; j < np; ++j) {
+                if (prev_f[j].site == cur_f[i].site) { was_present = true; break; }
             }
+            if (!was_present) event_log_record(EVENT_ERROR_APPEARED, cur_f[i].site);
+        }
+        for (size_t j = 0; j < np; ++j) {
+            bool still_present = false;
+            for (size_t i = 0; i < nc; ++i) {
+                if (cur_f[i].site == prev_f[j].site) { still_present = true; break; }
+            }
+            if (!still_present) event_log_record(EVENT_ERROR_CLEARED, prev_f[j].site);
         }
     }
 
@@ -241,52 +238,56 @@ void initDemoState() {
     if (s_state_mutex == nullptr) {
         s_state_mutex = xSemaphoreCreateMutex();
     }
+    ensureImageMutex();
 
     s_demo_mode = true;
 
-    // Seed the register cache with a realistic RUNNING image in the REAL Tuya
-    // wire layout (index = reg - DEMO_REG_BASE). The arctic-macon library
-    // (decode_state) interprets these exactly as it does live device registers.
-    memset(s_demo_regs, 0, sizeof(s_demo_regs));
-    auto seed = [&](uint16_t r, uint16_t v) { s_demo_regs[r - DEMO_REG_BASE] = v; };
+    // Seed a realistic RUNNING image entirely through the opaque semantic API:
+    // no register address, bit, or scaling factor appears here. The arctic-macon
+    // library applies the wire encoding (e.g. AcVoltage 230 V -> raw 23).
+    imageLock();
+    s_image.clear();
 
-    // Run-state / mode.
-    seed(REG_FAULT_RUNSTATE, 0x20);   // reg2007 bit5 = running
-    seed(REG_OPERATING_MODE, 0x00);   // reg2049 = heating (reversing valve)
-    seed(REG_WORKING_MODE, static_cast<uint16_t>(MaconWorkingMode::FloorHeating)); // reg2096 = 1
-    // Icon bits: compressor + pump (reg2130 bit2/bit3), fan (reg2129 bit4).
-    seed(REG_STATUS_BYTE, 0x04 | 0x08);
-    seed(REG_ICON_BITS2, 0x10);
+    // Run-state / mode. (Compressor run-state is derived from compressor_freq,
+    // and the operating-mode register is unused by the mapping, so neither is
+    // seeded.)
+    s_image.set_working_mode(MaconWorkingMode::FloorHeating);
+    s_image.set_flag(MaconFlag::Pump, true);
+    s_image.set_flag(MaconFlag::Fan, true);
 
     // Setpoints (whole °C).
-    seed(REG_COOLING_SETPOINT, 18);   // reg2093
-    seed(REG_AUX_HEAT_SETPOINT, 45);  // reg2094 (aux/heating, demo only)
-    seed(REG_HOT_WATER_SETPOINT, 50); // reg2095
-    seed(REG_HOT_WATER_CEILING, 50);  // reg2012 AP13 ceiling
+    s_image.set_temp(MaconField::CoolingSetpoint, 18);
+    s_image.set_temp(MaconField::HeatingSetpoint, 45);   // aux/heating, demo only
+    s_image.set_temp(MaconField::HotWaterSetpoint, 50);
+    s_image.set_value(MaconField::HotWaterCeiling, 50);   // AP13 ceiling
 
     // Temperatures (signed whole °C).
-    seed(REG_WATER_TANK_TEMP, 42);       // reg2008 o1
-    seed(REG_OUTLET_WATER_TEMP, 45);     // reg2132 o3
-    seed(REG_INLET_WATER_TEMP, 38);      // reg2133 o2
-    seed(REG_OUTDOOR_AMBIENT_TEMP, 22);  // reg2134 o4
-    seed(REG_COOL_COIL_TEMP, 40);        // reg2135 A6 (indoor coil)
-    seed(REG_COIL_TEMP, 35);             // reg2136 A2 (outdoor coil)
-    seed(REG_SUCTION_TEMP, 12);          // reg2137 A3
-    seed(REG_DISCHARGE_TEMP, 85);        // reg2138 A1
-    seed(REG_IPM_TEMP, 55);              // reg2113 A8
+    s_image.set_temp(MaconField::WaterTankTemp, 42);
+    s_image.set_temp(MaconField::OutletWaterTemp, 45);
+    s_image.set_temp(MaconField::InletWaterTemp, 38);
+    s_image.set_temp(MaconField::OutdoorAmbientTemp, 22);
+    s_image.set_temp(MaconField::IndoorCoilTemp, 40);
+    s_image.set_temp(MaconField::OutdoorCoilTemp, 35);
+    s_image.set_temp(MaconField::SuctionTemp, 12);
+    s_image.set_temp(MaconField::DischargeTemp, 85);
+    s_image.set_temp(MaconField::IpmTemp, 55);
 
-    // Electrical / system readings (raw register values; decode owns scaling).
-    seed(REG_AC_CURRENT, 5);        // reg2000 A4 (whole A)
-    seed(REG_AC_VOLTAGE, 23);       // reg2101 A13 (x10 => 230 V)
-    seed(REG_DC_BUS_VOLTAGE, 38);   // reg2001 A7 (x10 => 380 V)
-    seed(REG_DC_MOTOR_SPEED, 40);   // reg2003 A10 fan level
-    seed(REG_MAIN_EEV, 200);        // reg2104 A5 EEV steps
-    seed(REG_COMPRESSOR_FREQ, 60);  // reg2141 A14 Hz
-    seed(REG_REALTIME_POWER, 12);   // reg2114 A9 (x100 => 1200 W)
+    // Electrical / system readings (natural units; the library owns scaling).
+    s_image.set_value(MaconField::AcCurrent, 5);        // A
+    s_image.set_value(MaconField::AcVoltage, 230);      // V
+    s_image.set_value(MaconField::DcVoltage, 380);      // V
+    s_image.set_value(MaconField::FanLevel, 40);        // raw DC motor level
+    s_image.set_value(MaconField::PrimaryEev, 200);     // EEV steps
+    s_image.set_value(MaconField::CompressorFreq, 60);  // Hz
+    s_image.set_value(MaconField::RealtimePower, 1200); // W
 
-    // Seed one active fault — P02 high pressure — via the library's canonical
-    // (reg,bit) encoder so no bit position is hardcoded here.
-    macon_set_fault_by_code(s_demo_regs, DEMO_REG_BASE, DEMO_REG_COUNT, "P02", true);
+    // Mark all five fault registers present (so faults decode as valid), keep
+    // the unit running, then light the demo's default high-pressure protection
+    // fault by semantic identity — no OEM code string here.
+    s_image.clear_faults();
+    s_image.set_flag(MaconFlag::UnitOn, true);
+    s_image.set_fault(MaconFaultId::HighPressureProtection, true);
+    imageUnlock();
 
     // Decode the seeded cache into HeatPumpState and mark connected.
     applyMaconMapping();
@@ -322,9 +323,12 @@ void initExternalFeed() {
     if (s_state_mutex == nullptr) {
         s_state_mutex = xSemaphoreCreateMutex();
     }
+    ensureImageMutex();
     s_feed_mode = true;
 
-    memset(s_demo_regs, 0, sizeof(s_demo_regs));
+    imageLock();
+    s_image.clear();
+    imageUnlock();
 
     xSemaphoreTake(s_state_mutex, portMAX_DELAY);
     s_state = HeatPumpState();  // Reset to defaults (connected=false until first feed)
@@ -338,11 +342,10 @@ bool isExternalFeed() {
     return s_feed_mode;
 }
 
-// The arctic-macon library (decode_state) is the single source of truth for the
-// Macon Tuya register layout, scaling, and fault/icon bit positions — see
-// components/arctic-macon/include/macon_registers.h and macon_faults.h. This
-// adapter consumes the already-decoded MaconState; it does NOT re-interpret raw
-// registers. High/low pressure (A11/A12) are uninstalled sensors on this DHW
+// The arctic-macon library is the single source of truth for the Macon Tuya
+// register layout, scaling, and fault/icon bit positions. This adapter consumes
+// the already-decoded MaconState; it does NOT re-interpret raw registers.
+// High/low pressure (A11/A12) are uninstalled sensors on this DHW
 // unit and are not reported.
 //
 // In Auto working mode, expose the actual water-side direction while the
@@ -377,13 +380,16 @@ static HeatPumpOperation to_operation(const MaconState& state) {
 }
 
 static void applyMaconMapping() {
-    // The arctic-macon library owns the register->field mapping: it knows which
-    // wire register carries which field and how to interpret it. This function
-    // now only (a) drives that decode over the fed register cache and (b) adapts
-    // the native MaconState into the controller's legacy HeatPumpState (status
-    // bitfields, WorkingMode enum, error masks).
+    // The arctic-macon library owns the register->field mapping. Copy the opaque
+    // image under its own lock, release it, then decode the copy — so the image
+    // lock and the state lock are never held simultaneously. This adapter only
+    // (a) drives that decode and (b) adapts the native MaconState into the
+    // controller's legacy HeatPumpState (status bitfields, WorkingMode enum).
+    imageLock();
+    MaconImage snapshot = s_image;
+    imageUnlock();
     MaconState ms;
-    decode_state(DEMO_REG_BASE, s_demo_regs, DEMO_REG_COUNT, &ms);
+    snapshot.decode(&ms);
 
     xSemaphoreTake(s_state_mutex, portMAX_DELAY);
 
@@ -470,16 +476,11 @@ static void applyMaconMapping() {
 }
 
 uint16_t getRawRegisters(uint16_t* out, uint16_t max_count, uint16_t* base_out) {
-    if (base_out) {
-        *base_out = DEMO_REG_BASE;
-    }
-    if (out == nullptr || max_count == 0) {
-        return 0;
-    }
-    uint16_t n = (max_count < DEMO_REG_COUNT) ? max_count : DEMO_REG_COUNT;
-    for (uint16_t i = 0; i < n; ++i) {
-        out[i] = s_demo_regs[i];
-    }
+    // The image relays its bytes without interpretation; it owns the window base
+    // so the controller needs no window-bound constants of its own.
+    imageLock();
+    uint16_t n = s_image.raw(base_out, out, max_count);
+    imageUnlock();
     return n;
 }
 
@@ -541,27 +542,20 @@ void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count) {
     }
 
     const uint32_t now = getTimeMs();
-    const uint32_t window_end = (uint32_t)reg_base + (uint32_t)count;
-    const bool has_holding_state = reg_base <= REG_OPERATING_MODE && window_end > REG_OPERATING_MODE;
-    const bool has_telemetry_state = reg_base <= REG_COMPRESSOR_FREQ && window_end > REG_COMPRESSOR_FREQ;
 
-    // Copy the window's 1-byte registers into the register cache (bounds-checked).
-    for (size_t i = 0; i < count; ++i) {
-        int32_t idx = (int32_t)reg_base + (int32_t)i - (int32_t)DEMO_REG_BASE;
-        if (idx >= 0 && idx < (int32_t)DEMO_REG_COUNT) {
-            s_demo_regs[idx] = regs[i];
-        }
-    }
+    // Feed the window into the opaque image; it reports which decode-relevant
+    // windows were covered (status / telemetry) without exposing any register
+    // number to the controller.
+    imageLock();
+    const MaconCoverage cov = s_image.ingest_bytes(reg_base, regs, count);
+    imageUnlock();
 
-    // Map the cache into HeatPumpState using the empirically-derived ECO-600
-    // Tuya layout (see applyMaconMapping). The Arctic/ECO-600 doc-based poll parsers do
-    // NOT apply here: the real byte offsets differ and the doc's status/error
-    // registers (2135-2138) are actually live temperature bytes on this unit.
+    // Map the image into HeatPumpState using the library-owned decode.
     applyMaconMapping();
 
     xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-    if (has_holding_state) s_holding_window_ms = now;
-    if (has_telemetry_state) s_telemetry_window_ms = now;
+    if (cov.status_updated) s_holding_window_ms = now;
+    if (cov.telemetry_updated) s_telemetry_window_ms = now;
     s_state.connected = true;
     s_state.last_successful_read_ms = now;
     s_state.last_attempt_ms = s_state.last_successful_read_ms;
@@ -626,14 +620,14 @@ TelemetrySnapshot getTelemetrySnapshot() {
             elapsed_within(now, s_telemetry_window_ms, TELEMETRY_FRESHNESS_MS);
         snapshot.connected = telemetry_fresh;
         snapshot.inlet_valid = telemetry_fresh && s_inlet_valid &&
-            !hasActiveFaultCode(s_state.fault_run, s_state.fault_ee,
+            !macon_has_fault_id(s_state.fault_run, s_state.fault_ee,
                                 s_state.fault_comp, s_state.fault_elec,
-                                s_state.fault_ref, "E19") &&  // inlet-water sensor
+                                s_state.fault_ref, MaconFaultId::InletWaterSensor) &&
             s_state.inlet_water_temp >= -50 && s_state.inlet_water_temp <= 150;
         snapshot.outlet_valid = telemetry_fresh && s_outlet_valid &&
-            !hasActiveFaultCode(s_state.fault_run, s_state.fault_ee,
+            !macon_has_fault_id(s_state.fault_run, s_state.fault_ee,
                                 s_state.fault_comp, s_state.fault_elec,
-                                s_state.fault_ref, "E18") &&  // outlet-water sensor
+                                s_state.fault_ref, MaconFaultId::OutletWaterSensor) &&
             s_state.outlet_water_temp >= -50 && s_state.outlet_water_temp <= 150;
         snapshot.compressor_valid = telemetry_fresh && s_compressor_valid;
         snapshot.compressor_running =
@@ -743,18 +737,14 @@ bool setUnitPower(bool on) {
         ESP_LOGW(TAG, "Unit power write unsupported in Tuya master mode (no verified fc06 mapping)");
         return false;
     }
-    // Toggle only the run-state bit (reg2007 bit5); other bits carry faults.
-    uint16_t rs = 0;
-    readCacheReg(REG_FAULT_RUNSTATE, &rs);
-    if (on) rs |= 0x20; else rs &= ~0x20;
-    esp_err_t err = writeCacheReg(REG_FAULT_RUNSTATE, rs);
-    if (err == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Unit power set to %s", on ? "ON" : "OFF");
-        return true;
-    }
-    ESP_LOGW(TAG, "Unit power write rejected outside demo mode");
-    return false;
+    // Set the run-state flag by identity; the library owns the bit position and
+    // preserves the fault bits sharing that register.
+    imageLock();
+    s_image.set_flag(MaconFlag::UnitOn, on);
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Unit power set to %s", on ? "ON" : "OFF");
+    return true;
 }
 
 bool setWorkingMode(WorkingMode mode) {
@@ -762,14 +752,15 @@ bool setWorkingMode(WorkingMode mode) {
         ESP_LOGW(TAG, "Working-mode write unsupported in Tuya master mode (no verified fc06 mapping)");
         return false;
     }
-    esp_err_t err = writeCacheReg(REG_WORKING_MODE, static_cast<uint16_t>(mode));
-    if (err == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Working mode set to %s", workingModeToString(mode));
-        return true;
-    }
-    ESP_LOGW(TAG, "Working-mode write rejected outside demo mode");
-    return false;
+    // The controller's WorkingMode and the library's MaconWorkingMode share the
+    // same semantic encoding by construction; convert between the two enums
+    // without touching any register.
+    imageLock();
+    s_image.set_working_mode(static_cast<MaconWorkingMode>(static_cast<uint8_t>(mode)));
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Working mode set to %s", workingModeToString(mode));
+    return true;
 }
 
 bool setCoolingSetpoint(int16_t temp) {
@@ -785,14 +776,12 @@ bool setCoolingSetpoint(int16_t temp) {
         }
         return false;
     }
-    esp_err_t err = writeCacheReg(REG_COOLING_SETPOINT, static_cast<uint16_t>(temp));
-    if (err == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Cooling setpoint set to %d", temp);
-        return true;
-    }
-    ESP_LOGW(TAG, "Cooling setpoint write rejected in passive-listen mode");
-    return false;
+    imageLock();
+    s_image.set_temp(MaconField::CoolingSetpoint, temp);
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Cooling setpoint set to %d", temp);
+    return true;
 }
 
 bool setHeatingSetpoint(int16_t temp) {
@@ -803,14 +792,12 @@ bool setHeatingSetpoint(int16_t temp) {
         ESP_LOGW(TAG, "Heating setpoint write unsupported in Tuya master mode (reg2094 unverified)");
         return false;
     }
-    esp_err_t err = writeCacheReg(REG_AUX_HEAT_SETPOINT, static_cast<uint16_t>(temp));
-    if (err == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Heating setpoint set to %d", temp);
-        return true;
-    }
-    ESP_LOGW(TAG, "Heating setpoint write rejected outside demo mode");
-    return false;
+    imageLock();
+    s_image.set_temp(MaconField::HeatingSetpoint, temp);
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Heating setpoint set to %d", temp);
+    return true;
 }
 
 bool setHotWaterSetpoint(int16_t temp) {
@@ -824,22 +811,18 @@ bool setHotWaterSetpoint(int16_t temp) {
         }
         return false;
     }
-    esp_err_t err = writeCacheReg(REG_HOT_WATER_SETPOINT, static_cast<uint16_t>(temp));
-    if (err == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Hot water setpoint set to %d", temp);
-        return true;
-    }
-    ESP_LOGW(TAG, "Hot-water setpoint write rejected in passive-listen mode");
-    return false;
+    imageLock();
+    s_image.set_temp(MaconField::HotWaterSetpoint, temp);
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Hot water setpoint set to %d", temp);
+    return true;
 }
 
 bool writeRegister(uint16_t address, uint16_t value) {
-    const bool in_holding_window =
-        address >= HOLDING_START && address < HOLDING_START + HOLDING_COUNT;
-    const bool in_telemetry_window =
-        address >= INPUT_START && address < INPUT_START + INPUT_COUNT;
-    if (!in_holding_window && !in_telemetry_window) {
+    // The image owns the window bounds, so the controller keeps no window
+    // constants of its own.
+    if (!s_image.in_window(address)) {
         ESP_LOGE(TAG, "Register %u is outside known Macon windows",
                  (unsigned)address);
         return false;
@@ -852,24 +835,26 @@ bool writeRegister(uint16_t address, uint16_t value) {
     if (macon_master::is_active()) {
         return macon_master::write_register(address, static_cast<uint8_t>(value));
     }
-    if (writeCacheReg(address, value) == ESP_OK) {
-        applyMaconMapping();
-        ESP_LOGI(TAG, "Register %d set to %d", address, value);
-        return true;
-    }
-    ESP_LOGW(TAG, "Register write rejected in passive-listen mode");
-    return false;
+    imageLock();
+    s_image.set_register(address, value);
+    imageUnlock();
+    applyMaconMapping();
+    ESP_LOGI(TAG, "Register %d set to %d", address, value);
+    return true;
 }
 
 bool readRegister(uint16_t address, uint16_t* value_out) {
     if (value_out == nullptr) {
         return false;
     }
-    // Demo, passive-listen, and active-master polling all populate this cache.
+    // Demo, passive-listen, and active-master polling all populate this image.
     if (s_demo_mode || s_feed_mode) {
-        return readCacheReg(address, value_out) == ESP_OK;
+        imageLock();
+        bool ok = s_image.get_register(address, value_out);
+        imageUnlock();
+        return ok;
     }
-    ESP_LOGW(TAG, "Register cache is not initialized");
+    ESP_LOGW(TAG, "Register image is not initialized");
     return false;
 }
 
@@ -919,77 +904,81 @@ void getStatusDescription(char* buffer, size_t buffer_size) {
 }
 
 bool setDemoField(const char* field, int32_t value) {
-    if (!s_demo_mode) return false;
-    
-    // Map the demo field name to its REAL Tuya register address (index =
-    // reg - DEMO_REG_BASE). Fault injection is done by writing the raw fault
-    // register bytes directly (fault_run/ee/comp/elec/ref) — the macon library
-    // decodes them into P/E codes. There are no fictional status/error regs.
-    uint16_t addr = 0;
-    // For bit-level (read-modify-write) fields we set rmw_reg/rmw_mask instead
-    // of writing a whole register, so unrelated bits in shared icon/run
-    // registers are preserved.
-    uint16_t rmw_reg = 0;
-    uint16_t rmw_mask = 0;
+    if (!s_demo_mode || field == nullptr) return false;
 
-    // Temperatures
-    if (strcmp(field, "water_tank_temp") == 0)            addr = REG_WATER_TANK_TEMP;
-    else if (strcmp(field, "outlet_water_temp") == 0)     addr = REG_OUTLET_WATER_TEMP;
-    else if (strcmp(field, "inlet_water_temp") == 0)      addr = REG_INLET_WATER_TEMP;
-    else if (strcmp(field, "discharge_temp") == 0)        addr = REG_DISCHARGE_TEMP;
-    else if (strcmp(field, "suction_temp") == 0)          addr = REG_SUCTION_TEMP;
-    else if (strcmp(field, "outdoor_coil_temp") == 0)     addr = REG_COIL_TEMP;
-    else if (strcmp(field, "indoor_coil_temp") == 0)      addr = REG_COOL_COIL_TEMP;
-    else if (strcmp(field, "outdoor_ambient_temp") == 0)  addr = REG_OUTDOOR_AMBIENT_TEMP;
-    else if (strcmp(field, "ipm_temp") == 0)              addr = REG_IPM_TEMP;
-    // System readings
-    else if (strcmp(field, "compressor_freq") == 0)       addr = REG_COMPRESSOR_FREQ;
-    else if (strcmp(field, "fan_speed") == 0)             addr = REG_DC_MOTOR_SPEED;
-    else if (strcmp(field, "ac_voltage") == 0)            addr = REG_AC_VOLTAGE;
-    else if (strcmp(field, "ac_current") == 0)            addr = REG_AC_CURRENT;
-    else if (strcmp(field, "dc_voltage") == 0)            addr = REG_DC_BUS_VOLTAGE;
-    else if (strcmp(field, "main_eev") == 0 ||
-             strcmp(field, "primary_eev_opening") == 0)   addr = REG_MAIN_EEV;
-    else if (strcmp(field, "realtime_power") == 0)        addr = REG_REALTIME_POWER;
-    // Raw fault-register bytes (fault injection). Decoded natively.
-    else if (strcmp(field, "fault_run") == 0)             addr = REG_FAULT_RUNSTATE;
-    else if (strcmp(field, "fault_ee") == 0)              addr = REG_FAULT_SENSOR_EE;
-    else if (strcmp(field, "fault_comp") == 0)            addr = REG_FAULT_SENSOR_COMP;
-    else if (strcmp(field, "fault_elec") == 0)            addr = REG_FAULT_ELEC;
-    else if (strcmp(field, "fault_ref") == 0)             addr = REG_FAULT;
-    // Component run-state (bit-level, decoded live). Compressor state is driven
-    // by compressor_freq (reg2141), not an icon bit.
-    else if (strcmp(field, "fan_on") == 0)                { rmw_reg = REG_ICON_BITS2; rmw_mask = 0x10; }  // bit4
-    else if (strcmp(field, "cooling_on") == 0)            { rmw_reg = REG_ICON_BITS2; rmw_mask = 0x04; }  // bit2 (reversing valve = cooling)
-    else if (strcmp(field, "pump_on") == 0)               { rmw_reg = REG_STATUS_BYTE; rmw_mask = 0x08; } // bit3
-    // Settings
-    else if (strcmp(field, "unit_on") == 0)               { rmw_reg = REG_FAULT_RUNSTATE; rmw_mask = 0x20; } // bit5
-    else if (strcmp(field, "working_mode") == 0)          addr = REG_WORKING_MODE;
-    else if (strcmp(field, "cooling_setpoint") == 0)      addr = REG_COOLING_SETPOINT;
-    else if (strcmp(field, "heating_setpoint") == 0)      addr = REG_AUX_HEAT_SETPOINT;
-    else if (strcmp(field, "hot_water_setpoint") == 0)    addr = REG_HOT_WATER_SETPOINT;
-    else return false;
+    // Map the demo field name to an opaque MaconImage operation. No register
+    // address, bit position, or scaling factor appears here — the arctic-macon
+    // library owns all of that. Fault injection is NOT a field write: use
+    // injectDemoFault()/clearDemoFaults() (which reference faults by identity).
+    struct FieldEntry { const char* name; MaconField field; };
+    static const FieldEntry kFields[] = {
+        { "water_tank_temp",      MaconField::WaterTankTemp },
+        { "outlet_water_temp",    MaconField::OutletWaterTemp },
+        { "inlet_water_temp",     MaconField::InletWaterTemp },
+        { "discharge_temp",       MaconField::DischargeTemp },
+        { "suction_temp",         MaconField::SuctionTemp },
+        { "outdoor_coil_temp",    MaconField::OutdoorCoilTemp },
+        { "indoor_coil_temp",     MaconField::IndoorCoilTemp },
+        { "outdoor_ambient_temp", MaconField::OutdoorAmbientTemp },
+        { "ipm_temp",             MaconField::IpmTemp },
+        { "compressor_freq",      MaconField::CompressorFreq },
+        { "fan_speed",            MaconField::FanLevel },
+        { "ac_voltage",           MaconField::AcVoltage },
+        { "ac_current",           MaconField::AcCurrent },
+        { "dc_voltage",           MaconField::DcVoltage },
+        { "main_eev",             MaconField::PrimaryEev },
+        { "primary_eev_opening",  MaconField::PrimaryEev },
+        { "realtime_power",       MaconField::RealtimePower },
+        { "cooling_setpoint",     MaconField::CoolingSetpoint },
+        { "heating_setpoint",     MaconField::HeatingSetpoint },
+        { "hot_water_setpoint",   MaconField::HotWaterSetpoint },
+    };
+    struct FlagEntry { const char* name; MaconFlag flag; };
+    static const FlagEntry kFlags[] = {
+        { "fan_on",     MaconFlag::Fan },
+        { "cooling_on", MaconFlag::Cooling },
+        { "pump_on",    MaconFlag::Pump },
+        { "unit_on",    MaconFlag::UnitOn },
+    };
 
-    if (rmw_mask != 0) {
-        // Read-modify-write a single bit, preserving the rest of the register.
-        uint16_t& r = s_demo_regs[rmw_reg - DEMO_REG_BASE];
-        if (value) r |= rmw_mask; else r &= ~rmw_mask;
-        addr = rmw_reg;  // for the log line below
-    } else {
-        s_demo_regs[addr - DEMO_REG_BASE] = (uint16_t)value;
+    bool matched = false;
+    imageLock();
+    for (const FieldEntry& e : kFields) {
+        if (strcmp(field, e.name) == 0) {
+            s_image.set_value(e.field, value);
+            matched = true;
+            break;
+        }
     }
+    if (!matched) {
+        for (const FlagEntry& e : kFlags) {
+            if (strcmp(field, e.name) == 0) {
+                s_image.set_flag(e.flag, value != 0);
+                matched = true;
+                break;
+            }
+        }
+    }
+    if (!matched && strcmp(field, "working_mode") == 0) {
+        s_image.set_working_mode(static_cast<MaconWorkingMode>(static_cast<uint8_t>(value)));
+        matched = true;
+    }
+    imageUnlock();
 
-    // Re-decode the cache into HeatPumpState so the change is reflected live.
+    if (!matched) return false;
+
+    // Re-decode the image into HeatPumpState so the change is reflected live.
     applyMaconMapping();
 
-    ESP_LOGI(TAG, "[DEMO] Field '%s' (reg %d) set to %ld", field, addr, (long)value);
+    ESP_LOGI(TAG, "[DEMO] Field '%s' set to %ld", field, (long)value);
     return true;
 }
 
 int injectDemoFault(const char* code, bool active) {
     if (!s_demo_mode || code == nullptr) return 0;
-    int sites = macon_set_fault_by_code(s_demo_regs, DEMO_REG_BASE,
-                                        DEMO_REG_COUNT, code, active);
+    imageLock();
+    int sites = s_image.set_fault_by_code(code, active);
+    imageUnlock();
     if (sites > 0) {
         applyMaconMapping();
         ESP_LOGI(TAG, "[DEMO] Fault '%s' %s (%d site%s)",
@@ -1000,13 +989,9 @@ int injectDemoFault(const char* code, bool active) {
 
 void clearDemoFaults() {
     if (!s_demo_mode) return;
-    // Clear the four telemetry fault registers entirely; on the run/state
-    // register keep bit5 (RUN indicator) and clear only the fault bits.
-    s_demo_regs[REG_FAULT_RUNSTATE - DEMO_REG_BASE]   &= 0x20;
-    s_demo_regs[REG_FAULT_SENSOR_EE - DEMO_REG_BASE]   = 0;
-    s_demo_regs[REG_FAULT_SENSOR_COMP - DEMO_REG_BASE] = 0;
-    s_demo_regs[REG_FAULT_ELEC - DEMO_REG_BASE]        = 0;
-    s_demo_regs[REG_FAULT - DEMO_REG_BASE]             = 0;
+    imageLock();
+    s_image.clear_faults();
+    imageUnlock();
     applyMaconMapping();
     ESP_LOGI(TAG, "[DEMO] All faults cleared");
 }

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -147,14 +147,14 @@ static void detectAndLogStateEvents() {
         // semantic sites (the library skips the RUN indicator) and diff by
         // opaque site id. The event-log payload is that site id — no register
         // or bit position is handled here.
-        MaconFault prev_f[32];
-        MaconFault cur_f[32];
+        MaconFault prev_f[arctic::MAX_ACTIVE_FAULTS];
+        MaconFault cur_f[arctic::MAX_ACTIVE_FAULTS];
         const size_t np = macon_decode_faults(
             s_prev_fault_bytes[0], s_prev_fault_bytes[1], s_prev_fault_bytes[2],
-            s_prev_fault_bytes[3], s_prev_fault_bytes[4], prev_f, 32);
+            s_prev_fault_bytes[3], s_prev_fault_bytes[4], prev_f, arctic::MAX_ACTIVE_FAULTS);
         const size_t nc = macon_decode_faults(
             s_state.fault_run, s_state.fault_ee, s_state.fault_comp,
-            s_state.fault_elec, s_state.fault_ref, cur_f, 32);
+            s_state.fault_elec, s_state.fault_ref, cur_f, arctic::MAX_ACTIVE_FAULTS);
         for (size_t i = 0; i < nc; ++i) {
             bool was_present = false;
             for (size_t j = 0; j < np; ++j) {
@@ -869,8 +869,8 @@ int getErrorDescriptions(char* buffer, size_t buffer_size) {
 
     // Iterate the natively-decoded active faults (macon library owns the
     // canonical (reg,bit) -> code/label table); no fictional error1/error2 masks.
-    arctic::ActiveError active[32];
-    int n = arctic::getActiveErrors(active, 32);
+    arctic::ActiveError active[arctic::MAX_ACTIVE_FAULTS];
+    int n = arctic::getActiveErrors(active, arctic::MAX_ACTIVE_FAULTS);
     for (int i = 0; i < n && offset < buffer_size - 1; ++i) {
         const char* label = active[i].name ? active[i].name : active[i].code;
         int written = snprintf(buffer + offset, buffer_size - offset, "%s%s",

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -188,7 +188,8 @@ void getStatusDescription(char* buffer, size_t buffer_size);
 // Allows testing read-only values (temps, readings, errors, status) via REST API.
 bool setDemoField(const char* field, int32_t value);
 
-// Inject (or clear) a fault by its canonical Macon code (e.g. "P02", "E19").
+// Inject (or clear) a fault by its canonical Macon code (opaque to the
+// controller — the arctic-macon library owns the code namespace).
 // Delegates the code -> (register, bit) mapping to the arctic-macon library so
 // no bit positions are hardcoded here. Returns the number of register-bit sites
 // written (a code such as E28/E05 maps to two sites), or 0 if the code is

--- a/main/heatpump_errors.cpp
+++ b/main/heatpump_errors.cpp
@@ -110,10 +110,10 @@ static void addHistoryEntry(const char* code, bool is_clearing, time_t occurred_
 
 int getActiveErrors(ActiveError* errors, int max_errors) {
     HeatPumpState state = getState();
-    MaconFault faults[32];
+    MaconFault faults[MAX_ACTIVE_FAULTS];
     size_t n = macon_decode_faults(state.fault_run, state.fault_ee,
                                    state.fault_comp, state.fault_elec,
-                                   state.fault_ref, faults, 32);
+                                   state.fault_ref, faults, MAX_ACTIVE_FAULTS);
     time_t now = time(nullptr);
     int count = 0;
     for (size_t i = 0; i < n && count < max_errors; ++i) {
@@ -134,18 +134,18 @@ int getActiveErrors(ActiveError* errors, int max_errors) {
 
 int getActiveErrorCount() {
     HeatPumpState state = getState();
-    MaconFault faults[32];
+    MaconFault faults[MAX_ACTIVE_FAULTS];
     return (int)macon_decode_faults(state.fault_run, state.fault_ee,
                                     state.fault_comp, state.fault_elec,
-                                    state.fault_ref, faults, 32);
+                                    state.fault_ref, faults, MAX_ACTIVE_FAULTS);
 }
 
 ErrorSeverity getHighestSeverity() {
     HeatPumpState state = getState();
-    MaconFault faults[32];
+    MaconFault faults[MAX_ACTIVE_FAULTS];
     size_t n = macon_decode_faults(state.fault_run, state.fault_ee,
                                    state.fault_comp, state.fault_elec,
-                                   state.fault_ref, faults, 32);
+                                   state.fault_ref, faults, MAX_ACTIVE_FAULTS);
     ErrorSeverity highest = ErrorSeverity::INFO;
     for (size_t i = 0; i < n; ++i) {
         ErrorSeverity sv = toErrorSeverity(faults[i].severity);
@@ -176,11 +176,11 @@ void updateErrorHistory(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
     // Decode previous and current fault bytes into opaque fault sites, then diff
     // by site id. The controller never inspects register/bit here — the library
     // owns the bit layout; we only compare and store site tokens.
-    MaconFault prev_f[32], cur_f[32];
+    MaconFault prev_f[MAX_ACTIVE_FAULTS], cur_f[MAX_ACTIVE_FAULTS];
     size_t np = macon_decode_faults(s_prev_regs[0], s_prev_regs[1], s_prev_regs[2],
-                                    s_prev_regs[3], s_prev_regs[4], prev_f, 32);
+                                    s_prev_regs[3], s_prev_regs[4], prev_f, MAX_ACTIVE_FAULTS);
     size_t nc = macon_decode_faults(fault_run, fault_ee, fault_comp,
-                                    fault_elec, fault_ref, cur_f, 32);
+                                    fault_elec, fault_ref, cur_f, MAX_ACTIVE_FAULTS);
 
     // Newly appeared: present now, absent before.
     for (size_t i = 0; i < nc; ++i) {
@@ -334,8 +334,8 @@ const char* formatDuration(time_t start_time, time_t end_time) {
 char* getErrorsAsJson() {
     cJSON* root = cJSON_CreateArray();
 
-    ActiveError errors[32];
-    int count = getActiveErrors(errors, 32);
+    ActiveError errors[MAX_ACTIVE_FAULTS];
+    int count = getActiveErrors(errors, MAX_ACTIVE_FAULTS);
 
     for (int i = 0; i < count; i++) {
         cJSON* err = cJSON_CreateObject();

--- a/main/heatpump_errors.cpp
+++ b/main/heatpump_errors.cpp
@@ -10,7 +10,6 @@
 #include "heatpump_errors.h"
 #include "heatpump_controller.h"
 #include "macon_faults.h"
-#include "macon_registers.h"  // arctic::REG_FAULT_* address constants
 #include <cJSON.h>
 #include <esp_log.h>
 #include <stdio.h>
@@ -35,70 +34,12 @@ static ErrorSeverity toErrorSeverity(FaultSeverity s) {
 }
 
 // ============================================================================
-// Controller-owned remedy text, keyed by fault code
+// Controller-owned remedy text
 // ============================================================================
-// The arctic-macon library owns the code/label/severity/(reg,bit) identity but
-// deliberately does NOT carry human remedy steps. Those installation-facing
-// instructions live here, keyed by the LCD code. Codes absent from this table
-// fall back to kDefaultResolution.
-static const char* kDefaultResolution = "Contact the dealer.";
-
-struct CodeResolution { const char* code; const char* resolution; };
-static const CodeResolution kResolutions[] = {
-    { "E19", "Check the inlet water temperature sensor at the heat exchanger for a short or open circuit and correct or replace." },
-    { "E18", "Check the outlet water temperature sensor at the heat exchanger for a short or open circuit and correct or replace." },
-    { "E13", "Check the coil temperature sensor for a short or open circuit and correct or replace." },
-    { "E05", "Check the heat pump coil temperature sensor and wires for a short or open circuit and correct or replace sensors." },
-    { "E01", "Check if the compressor discharge temperature sensor for short or open circuit and correct or replace." },
-    { "E09", "Check if the compressor suction temperature sensor for short or open circuit and correct or replace." },
-    { "E22", "Check if the ambient temperature sensor for the heat pump or its wiring has a short or open circuit and correct or replace." },
-    { "E21", "Check the wired controller's cable and its connections." },
-    { "r06", "This applies to 3-phase units where the phasing of the wires is incorrect and needs to be corrected." },
-    { "P11", "1) Check water system is operating normal, look for reduction in normal water flow. 2) Check whether there was a refrigerant leak and repair. 3) Verify unit is in normal operation with proper exhaust temperature and system pressure." },
-    { "P02", "1) Check whether the water temperature is too high or blocked. 2) Check whether the fan blades are blocked or if evaporator fins are blocked. 3) Check whether snow or ice has built up inside the unit. 4) Check that the water tank temperature setting is not too high." },
-    { "P06", "1) Check whether the unit is leaking refrigerant. 2) Repair and vacuum system, then refill with exact amount of refrigerant as per nameplate." },
-    { "P27", "Check that the fan is in good condition and that the evaporator fins are not in need of cleaning." },
-    { "P01", "Flow is too low or wiring is open circuit. Check the water system, water pump, and operation of water flow switch and correct problem." },
-    { "P15", "1) Check if water system is operating abnormally, such as water flow is too low. 2) Verify unit is in normal operation with proper exhaust temperature and system pressure." },
-    { "P16", "1) Check water system is normal and water flow is adequate. 2) Verify unit is in normal operation with proper exhaust temperature and system pressure." },
-    { "PC",  "Ambient temperature is out of the allowed operating range. Wait for conditions to improve." },
-};
-
-static const char* resolutionForCode(const char* code) {
-    if (code) {
-        for (const auto& r : kResolutions) {
-            if (strcmp(r.code, code) == 0) return r.resolution;
-        }
-    }
-    return kDefaultResolution;
-}
-
-// ============================================================================
-// Fault register indexing helpers
-// ============================================================================
-// Map a Macon fault register address to a 0..4 index (order matches
-// MACON_FAULT_REGS: 2007, 2125, 2126, 2127, 2128).
-static int regIndex(uint16_t reg) {
-    switch (reg) {
-        case REG_FAULT_RUNSTATE:    return 0;
-        case REG_FAULT_SENSOR_EE:   return 1;
-        case REG_FAULT_SENSOR_COMP: return 2;
-        case REG_FAULT_ELEC:        return 3;
-        case REG_FAULT:             return 4;
-        default:                    return -1;
-    }
-}
-
-static uint8_t regByte(const HeatPumpState& s, uint16_t reg) {
-    switch (reg) {
-        case REG_FAULT_RUNSTATE:    return s.fault_run;
-        case REG_FAULT_SENSOR_EE:   return s.fault_ee;
-        case REG_FAULT_SENSOR_COMP: return s.fault_comp;
-        case REG_FAULT_ELEC:        return s.fault_elec;
-        case REG_FAULT:             return s.fault_ref;
-        default:                    return 0;
-    }
-}
+// Remedy ("resolution") text lives in the arctic-macon library, keyed by the
+// semantic MaconFaultId so multi-site codes cannot drift; the controller only
+// looks it up via macon_fault_resolution(id) and carries no code strings of
+// its own.
 
 // ============================================================================
 // Error History
@@ -107,10 +48,37 @@ static ErrorHistoryEntry s_history[ERROR_HISTORY_SIZE];
 static int s_history_head = 0;  // Next write position
 static int s_history_count = 0;
 
-// Previous raw fault-register bytes and per-(reg,bit) first-seen tracking.
-// Indexed by position in the library's MACON_FAULT_BITS table.
+// Previous raw fault-register bytes (for edge detection) and first-seen
+// timestamps keyed by OPAQUE fault site id. The site store is a small linear
+// table (there are ~31 distinct sites); the controller never derives a register
+// or bit from a site — it only compares and stores the token.
 static uint8_t s_prev_regs[5] = {0};
-static time_t  s_first_seen[64] = {0};  // >= MACON_FAULT_BITS_COUNT
+
+struct FirstSeen { MaconFaultSiteId site; time_t when; };
+static FirstSeen s_first_seen[64];
+static size_t    s_first_seen_count = 0;
+
+static time_t getFirstSeen(MaconFaultSiteId site) {
+    for (size_t i = 0; i < s_first_seen_count; ++i) {
+        if (s_first_seen[i].site == site) return s_first_seen[i].when;
+    }
+    return 0;
+}
+
+static void setFirstSeen(MaconFaultSiteId site, time_t when) {
+    for (size_t i = 0; i < s_first_seen_count; ++i) {
+        if (s_first_seen[i].site == site) { s_first_seen[i].when = when; return; }
+    }
+    if (s_first_seen_count < (sizeof(s_first_seen) / sizeof(s_first_seen[0]))) {
+        s_first_seen[s_first_seen_count++] = { site, when };
+    }
+}
+
+static void clearFirstSeen(MaconFaultSiteId site) {
+    for (size_t i = 0; i < s_first_seen_count; ++i) {
+        if (s_first_seen[i].site == site) { s_first_seen[i].when = 0; return; }
+    }
+}
 
 // Add entry to history ring buffer
 static void addHistoryEntry(const char* code, bool is_clearing, time_t occurred_time) {
@@ -136,16 +104,6 @@ static void addHistoryEntry(const char* code, bool is_clearing, time_t occurred_
     }
 }
 
-// Find the MACON_FAULT_BITS index for a (reg, bit), or -1.
-static int faultTableIndex(uint16_t reg, uint8_t bit) {
-    for (size_t i = 0; i < MACON_FAULT_BITS_COUNT; ++i) {
-        if (MACON_FAULT_BITS[i].reg == reg && MACON_FAULT_BITS[i].bit == bit) {
-            return (int)i;
-        }
-    }
-    return -1;
-}
-
 // ============================================================================
 // Public Functions
 // ============================================================================
@@ -163,12 +121,11 @@ int getActiveErrors(ActiveError* errors, int max_errors) {
         e.code = faults[i].code;
         e.name = faults[i].label;
         e.description = faults[i].label;
-        e.resolution = resolutionForCode(faults[i].code);
+        e.resolution = macon_fault_resolution(faults[i].id);
         e.severity = toErrorSeverity(faults[i].severity);
-        e.reg = faults[i].reg;
-        e.bit = faults[i].bit;
-        int ti = faultTableIndex(faults[i].reg, faults[i].bit);
-        e.first_seen = (ti >= 0 && s_first_seen[ti] > 0) ? s_first_seen[ti] : now;
+        e.site = faults[i].site;
+        time_t fs = getFirstSeen(faults[i].site);
+        e.first_seen = (fs > 0) ? fs : now;
         e.last_seen = now;
         e.active = true;
     }
@@ -207,7 +164,7 @@ bool describeFaultCode(const char* code, const char** name_out,
     const MaconFaultBit* fb = sites[0];
     if (name_out)        *name_out = fb->label;
     if (description_out)  *description_out = fb->label;
-    if (resolution_out)   *resolution_out = resolutionForCode(code);
+    if (resolution_out)   *resolution_out = macon_fault_resolution(fb->id);
     if (severity_out)     *severity_out = toErrorSeverity(fb->severity);
     return true;
 }
@@ -215,30 +172,50 @@ bool describeFaultCode(const char* code, const char** name_out,
 void updateErrorHistory(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
                         uint8_t fault_elec, uint8_t fault_ref) {
     time_t now = time(nullptr);
-    const uint8_t cur[5] = { fault_run, fault_ee, fault_comp, fault_elec, fault_ref };
 
-    for (size_t i = 0; i < MACON_FAULT_BITS_COUNT; ++i) {
-        const MaconFaultBit& fb = MACON_FAULT_BITS[i];
-        if (fb.severity == FaultSeverity::INFO) continue;  // skip RUN indicator
-        int ri = regIndex(fb.reg);
-        if (ri < 0) continue;
-        bool now_set = (cur[ri] >> fb.bit) & 0x1;
-        bool was_set = (s_prev_regs[ri] >> fb.bit) & 0x1;
-        if (now_set && !was_set) {
-            s_first_seen[i] = now;
-            ESP_LOGW(TAG, "Error SET: %s - %s", fb.code, fb.label);
-            addHistoryEntry(fb.code, false, 0);
-        } else if (!now_set && was_set) {
-            time_t occurred = s_first_seen[i];
-            time_t duration = (occurred > 0 && now > occurred) ? (now - occurred) : 0;
-            ESP_LOGI(TAG, "Error CLEARED: %s - %s (duration: %d sec)",
-                     fb.code, fb.label, (int)duration);
-            addHistoryEntry(fb.code, true, occurred);
-            s_first_seen[i] = 0;
+    // Decode previous and current fault bytes into opaque fault sites, then diff
+    // by site id. The controller never inspects register/bit here — the library
+    // owns the bit layout; we only compare and store site tokens.
+    MaconFault prev_f[32], cur_f[32];
+    size_t np = macon_decode_faults(s_prev_regs[0], s_prev_regs[1], s_prev_regs[2],
+                                    s_prev_regs[3], s_prev_regs[4], prev_f, 32);
+    size_t nc = macon_decode_faults(fault_run, fault_ee, fault_comp,
+                                    fault_elec, fault_ref, cur_f, 32);
+
+    // Newly appeared: present now, absent before.
+    for (size_t i = 0; i < nc; ++i) {
+        bool was = false;
+        for (size_t j = 0; j < np; ++j) {
+            if (prev_f[j].site == cur_f[i].site) { was = true; break; }
+        }
+        if (!was) {
+            setFirstSeen(cur_f[i].site, now);
+            ESP_LOGW(TAG, "Error SET: %s - %s", cur_f[i].code, cur_f[i].label);
+            addHistoryEntry(cur_f[i].code, false, 0);
         }
     }
 
-    for (int r = 0; r < 5; ++r) s_prev_regs[r] = cur[r];
+    // Cleared: present before, absent now.
+    for (size_t j = 0; j < np; ++j) {
+        bool still = false;
+        for (size_t i = 0; i < nc; ++i) {
+            if (cur_f[i].site == prev_f[j].site) { still = true; break; }
+        }
+        if (!still) {
+            time_t occurred = getFirstSeen(prev_f[j].site);
+            time_t duration = (occurred > 0 && now > occurred) ? (now - occurred) : 0;
+            ESP_LOGI(TAG, "Error CLEARED: %s - %s (duration: %d sec)",
+                     prev_f[j].code, prev_f[j].label, (int)duration);
+            addHistoryEntry(prev_f[j].code, true, occurred);
+            clearFirstSeen(prev_f[j].site);
+        }
+    }
+
+    s_prev_regs[0] = fault_run;
+    s_prev_regs[1] = fault_ee;
+    s_prev_regs[2] = fault_comp;
+    s_prev_regs[3] = fault_elec;
+    s_prev_regs[4] = fault_ref;
 }
 
 int getErrorHistory(ErrorHistoryEntry* history, int max_entries) {
@@ -267,9 +244,14 @@ void populateDemoErrorHistory() {
 
     time_t now = time(nullptr);
 
-    // E26 - Low ambient / comm, cleared 15 minutes ago (was active for 45 min)
+    // Codes come from the library by semantic fault id — the controller bakes in
+    // no OEM code strings of its own.
+    const char* comm_code = macon_code_for_fault_id(MaconFaultId::IndoorOutdoorCommunication);
+    const char* inlet_code = macon_code_for_fault_id(MaconFaultId::InletWaterSensor);
+
+    // Comm fault, cleared 15 minutes ago (was active for 45 min)
     ErrorHistoryEntry& e1 = s_history[s_history_head];
-    strncpy(e1.code, "E26", sizeof(e1.code) - 1);
+    strncpy(e1.code, comm_code ? comm_code : "", sizeof(e1.code) - 1);
     e1.code[sizeof(e1.code) - 1] = '\0';
     e1.occurred = now - 3600;   // Started 1h ago
     e1.cleared = now - 900;     // Cleared 15m ago
@@ -277,9 +259,9 @@ void populateDemoErrorHistory() {
     s_history_head = (s_history_head + 1) % ERROR_HISTORY_SIZE;
     s_history_count++;
 
-    // E19 - Inlet sensor, cleared 18 minutes ago (was active for 12 min)
+    // Inlet sensor, cleared 18 minutes ago (was active for 12 min)
     ErrorHistoryEntry& e2 = s_history[s_history_head];
-    strncpy(e2.code, "E19", sizeof(e2.code) - 1);
+    strncpy(e2.code, inlet_code ? inlet_code : "", sizeof(e2.code) - 1);
     e2.code[sizeof(e2.code) - 1] = '\0';
     e2.occurred = now - 1800;   // Started 30m ago
     e2.cleared = now - 1080;    // Cleared 18m ago
@@ -347,24 +329,6 @@ const char* formatDuration(time_t start_time, time_t end_time) {
     }
 
     return buf;
-}
-
-bool isErrorActive(uint16_t reg, uint8_t bit) {
-    HeatPumpState state = getState();
-    if (regIndex(reg) < 0) return false;
-    return (regByte(state, reg) >> bit) & 0x1;
-}
-
-bool hasActiveFaultCode(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
-                        uint8_t fault_elec, uint8_t fault_ref, const char* code) {
-    if (!code) return false;
-    MaconFault faults[32];
-    size_t n = macon_decode_faults(fault_run, fault_ee, fault_comp,
-                                   fault_elec, fault_ref, faults, 32);
-    for (size_t i = 0; i < n; ++i) {
-        if (faults[i].code && strcmp(faults[i].code, code) == 0) return true;
-    }
-    return false;
 }
 
 char* getErrorsAsJson() {

--- a/main/heatpump_errors.h
+++ b/main/heatpump_errors.h
@@ -24,6 +24,14 @@ namespace arctic {
 // Maximum number of error history entries (ring buffer — oldest entries are overwritten)
 constexpr int ERROR_HISTORY_SIZE = 50;
 
+// Upper bound on simultaneously-decodable fault sites. Must stay >= the
+// library's MACON_FAULT_BITS_COUNT (total decodable fault bits across all five
+// fault registers). macon_decode_faults fills the output buffer in table order
+// and stops at the buffer size, so an undersized buffer silently drops the
+// physically-last table entries (a critical fault could be lost). 64 leaves
+// ample headroom over the current fault-bit count.
+constexpr int MAX_ACTIVE_FAULTS = 64;
+
 // Error severity levels
 enum class ErrorSeverity {
     INFO,       // Informational (e.g., run indicator)

--- a/main/heatpump_errors.h
+++ b/main/heatpump_errors.h
@@ -2,19 +2,22 @@
  * Arctic Heat Pump Controller
  * Error Management Module
  *
- * Presentation adapter over the arctic-macon library's native fault decode
- * (macon_decode_faults / MACON_FAULT_BITS). The library owns the canonical
- * (reg, bit) -> code / label / severity table; this module adds the controller
- * concerns the library does not carry: human remedy ("resolution") text,
- * per-fault first-seen tracking, and a cleared/active history ring buffer.
+ * Presentation adapter over the arctic-macon library's opaque fault decode
+ * (macon_decode_faults). The library owns the canonical fault identity and
+ * emits an opaque per-fault site token (MaconFaultSiteId); this module adds the
+ * controller concerns the library does not surface directly: per-fault
+ * first-seen tracking (keyed by that opaque site token) and a cleared/active
+ * history ring buffer. Remedy ("resolution") text is looked up from the library
+ * by semantic fault id.
  *
- * There is no fictional Arctic error1/error2 bitfield here any more — a fault's
- * stable identity is the (reg, bit) pair straight from the Macon mainboard.
+ * A fault's stable identity here is the opaque site token from the library —
+ * the controller carries no register/bit/code knowledge of its own.
  */
 #pragma once
 
 #include <stdint.h>
 #include <time.h>
+#include "macon_faults.h"  // MaconFaultId / MaconFaultSiteId tokens + severity map
 
 namespace arctic {
 
@@ -29,17 +32,17 @@ enum class ErrorSeverity {
     CRITICAL    // Critical error (compressor protection, high pressure)
 };
 
-// Active fault with timestamp. Identity is (reg, bit) — the raw Macon fault
-// register and the bit within it — NOT a code string (codes are not unique;
-// e.g. E28 and E05 each appear at two distinct bits).
+// Active fault with timestamp. Identity is the opaque MaconFaultSiteId site
+// token from the arctic-macon library — NOT a code string (codes are not
+// unique; some appear at two distinct sites) and NOT a register/bit pair (that
+// layout is library-private).
 struct ActiveError {
-    const char* code;       // Code as shown on the OEM LCD (e.g. "P02", "E19")
+    const char* code;       // Code as shown on the OEM LCD (library-provided)
     const char* name;       // Short label (from the macon library)
     const char* description;// Human-readable description (from the macon library)
-    const char* resolution; // Suggested resolution steps (controller-owned)
+    const char* resolution; // Suggested resolution steps (library-provided)
     ErrorSeverity severity;
-    uint16_t reg;           // Macon fault register (2007/2125/2126/2127/2128)
-    uint8_t  bit;           // Bit within that register (0..7)
+    MaconFaultSiteId site;  // Opaque per-fault site token (library-owned)
     time_t first_seen;      // When error first appeared
     time_t last_seen;       // Last time error was active
     bool active;            // Currently active
@@ -115,16 +118,5 @@ const char* severityToString(ErrorSeverity severity);
 // Format duration as human readable string (e.g., "2h 15m", "45s", "Active")
 // Returns static buffer, not thread-safe
 const char* formatDuration(time_t start_time, time_t end_time = 0);
-
-// Check if a specific (reg, bit) fault is currently active.
-bool isErrorActive(uint16_t reg, uint8_t bit);
-
-// True if the fault identified by `code` (e.g. "E18", "E19") is currently
-// active in the supplied raw Macon fault-register bytes. The macon library
-// owns the code->(reg, bit) mapping; callers reference only the public code
-// string and never a bit position. Takes the raw bytes (rather than reading
-// global state) so it is safe to call while holding the controller state lock.
-bool hasActiveFaultCode(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
-                        uint8_t fault_elec, uint8_t fault_ref, const char* code);
 
 }  // namespace arctic

--- a/main/heatpump_errors_screen.cpp
+++ b/main/heatpump_errors_screen.cpp
@@ -51,7 +51,7 @@ static struct {
     lv_timer_t* load_timer = nullptr;
 
     // Stable snapshots used while progressively appending cards.
-    arctic::ActiveError active_errors[32] = {};
+    arctic::ActiveError active_errors[arctic::MAX_ACTIVE_FAULTS] = {};
     int active_count = 0;
     int active_displayed = 0;
     arctic::ErrorHistoryEntry cleared_history[arctic::ERROR_HISTORY_SIZE] = {};
@@ -409,7 +409,7 @@ static void update_error_list() {
     lv_obj_clean(state.error_list);
     
     // Get active errors and connection state
-    state.active_count = arctic::getActiveErrors(state.active_errors, 32);
+    state.active_count = arctic::getActiveErrors(state.active_errors, arctic::MAX_ACTIVE_FAULTS);
     state.active_displayed = 0;
     state.history_count = 0;
     state.history_displayed = 0;

--- a/main/heatpump_errors_screen.cpp
+++ b/main/heatpump_errors_screen.cpp
@@ -160,7 +160,7 @@ static lv_obj_t* create_error_card(lv_obj_t* parent, const arctic::ActiveError* 
     lv_obj_set_style_pad_all(top_row, 0, LV_PART_MAIN);
     lv_obj_clear_flag(top_row, LV_OBJ_FLAG_SCROLLABLE);
     
-    // Error code (e.g., "P02") with tap hint
+    // Error code text with tap hint
     lv_obj_t* code_label = lv_label_create(top_row);
     char code_buf[32];
     snprintf(code_buf, sizeof(code_buf), "%s %s  " LV_SYMBOL_DOWN, severity_to_icon(error->severity), error->code);

--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -1793,8 +1793,8 @@ static esp_err_t clear_error_history_post_handler(httpd_req_t* req)
 
 // ============================================================================
 // POST /api/test/inject-fault — inject or clear a fault by its Macon code
-// Body: {"code":"P02","active":true}. The (code -> register,bit) mapping is
-// owned by the arctic-macon library, so tests never hardcode bit positions.
+// Body: {"code":"<code>","active":true}. The code->site mapping is owned by
+// the arctic-macon library, so tests never hardcode bit positions.
 // ============================================================================
 
 static esp_err_t inject_fault_post_handler(httpd_req_t* req)

--- a/tests/api/test_diagnostic_api.py
+++ b/tests/api/test_diagnostic_api.py
@@ -379,10 +379,10 @@ class TestDiagnosticValues:
         time.sleep(1.0)
         assert self._row_value("Reading", "AC Current") == "5"
 
-    def test_ac_voltage_uses_library_scaling(self):
-        # Raw AC voltage is x10; the library decodes 23 -> 230 V and the CSV
-        # must show the decoded value without re-scaling.
-        _inject_demo({"ac_voltage": 23})
+    def test_ac_voltage_natural_units(self):
+        # Demo AC voltage is expressed in natural volts; it round-trips through
+        # the diagnostic CSV unchanged (the library handles any wire scaling).
+        _inject_demo({"ac_voltage": 230})
         time.sleep(1.0)
         assert self._row_value("Reading", "AC Voltage") == "230"
 

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -274,13 +274,13 @@ class TestDemoModeInjection:
 
     def test_inject_electrical_readings(self):
         """Inject voltage/current and verify they are reflected in status."""
-        # Demo fields write RAW register values; the macon library owns scaling.
-        # AC voltage (reg2101) is scaled x10 on decode; AC current (reg2000) is 1:1.
-        _inject_demo({"ac_voltage": 23, "ac_current": 50})
+        # Demo fields are expressed in NATURAL units; the macon library applies
+        # any wire scaling internally. AC voltage is in volts, current in amps.
+        _inject_demo({"ac_voltage": 230, "ac_current": 50})
         time.sleep(1.0)
         data = _get("/api/heatpump/status").json()
-        assert data["readings"]["ac_voltage"] == 230   # 23 x 10
-        assert data["readings"]["ac_current"] == 50     # 50 x 1
+        assert data["readings"]["ac_voltage"] == 230
+        assert data["readings"]["ac_current"] == 50
         # power_consumption is sourced from the unit's real-time power register
         # (reg2114), not derived from V*I, so it is reported independently.
         assert isinstance(data["readings"]["power_consumption"], (int, float))

--- a/tests/api/test_opaque_macon_controller.py
+++ b/tests/api/test_opaque_macon_controller.py
@@ -1,0 +1,92 @@
+"""Guard the opaque-Macon boundary in the controller (main/).
+
+The controller must carry ZERO Tuya/Macon protocol knowledge: no register-map
+header, no REG_* register symbols, and no OEM fault-code string literals. All of
+that lives behind the arctic-macon library's typed/opaque APIs.
+
+Scope of the gate is the controller sources under ``main/`` only, excluding:
+  * ``main/tuya/`` — the Macon master transport shim (relocated into the library
+    in a later phase; not part of the opaque-consumer contract yet).
+  * ``advanced_params.{cpp,h}`` — the advanced-parameters subsystem is a
+    separate future phase and legitimately references raw registers.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.hostside
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = ROOT / "main"
+THIS_FILE = Path(__file__).resolve()
+
+SOURCE_SUFFIXES = {".cpp", ".h", ".hpp", ".c", ".cc"}
+
+# Directories (relative to main/) that are out of scope for the gate.
+EXCLUDED_DIR_PARTS = {"tuya"}
+# Individual files (relative to main/) that are out of scope for the gate.
+EXCLUDED_FILES = {"advanced_params.cpp", "advanced_params.h"}
+# Generated font / image blobs — huge and never contain protocol knowledge.
+EXCLUDED_DIR_PARTS |= {"fonts"}
+
+# The register-map header must never be included by the controller.
+FORBIDDEN_INCLUDE = re.compile(r'#\s*include\s*[<"]\s*macon_registers\.h\s*[>"]')
+
+# Macon register-name symbols (REG_FAULT, REG_TEMP_OUTLET, ...). The word
+# boundary keeps this from matching MACON_FAULT_REGS / *_REGS_COUNT etc.
+FORBIDDEN_REG_SYMBOL = re.compile(r"\bREG_[A-Z][A-Z0-9_]*")
+
+# OEM fault-code string literals as shown on the mainboard LCD (P02, E19, r06,
+# PC, ...). These are library-owned; the controller must reference codes only as
+# opaque runtime strings, never bake them in.
+FORBIDDEN_CODE_LITERAL = re.compile(r'"(?:[PE]\d{2}|r\d{2}|PC)"')
+
+
+def _controller_sources():
+    for path in MAIN.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in SOURCE_SUFFIXES:
+            continue
+        if path.resolve() == THIS_FILE:
+            continue
+        rel_parts = path.relative_to(MAIN).parts
+        if any(part in EXCLUDED_DIR_PARTS for part in rel_parts):
+            continue
+        if path.name in EXCLUDED_FILES:
+            continue
+        yield path
+
+
+def _scan(pattern):
+    violations = []
+    for path in _controller_sources():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for m in pattern.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            violations.append(f"{path.relative_to(ROOT)}:{line}: {m.group(0)}")
+    return violations
+
+
+def test_controller_does_not_include_register_map():
+    violations = _scan(FORBIDDEN_INCLUDE)
+    assert not violations, (
+        "main/ must not include the Macon register-map header:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_controller_has_no_register_symbols():
+    violations = _scan(FORBIDDEN_REG_SYMBOL)
+    assert not violations, (
+        "main/ must not reference REG_* register symbols (protocol leak):\n"
+        + "\n".join(violations)
+    )
+
+
+def test_controller_has_no_oem_fault_code_literals():
+    violations = _scan(FORBIDDEN_CODE_LITERAL)
+    assert not violations, (
+        "main/ must not hardcode OEM fault-code string literals (protocol leak):\n"
+        + "\n".join(violations)
+    )

--- a/tests/device/test_main_screen.py
+++ b/tests/device/test_main_screen.py
@@ -74,7 +74,7 @@ def _ensure_demo_defaults(device: DeviceClient):
         fan_on=1,
         fan_speed=FAN_MED,
         pump_on=1,
-        ac_voltage=23,
+        ac_voltage=230,
         ac_current=52,
         inlet_water_temp=38,
         outlet_water_temp=45,
@@ -318,7 +318,7 @@ class TestPerformanceStrip:
     def test_power_displayed(self, device: DeviceClient):
         """Power consumption should be displayed when compressor is running."""
         device.clear_all_faults()
-        _running(device, ac_voltage=23, ac_current=52)
+        _running(device, ac_voltage=230, ac_current=52)
         _wait_for_update()
         power = device.find_widget(tag="perf_power")
         assert power is not None, "perf_power widget not found"


### PR DESCRIPTION
# Make the controller fully opaque to the Macon protocol (P2)

## Goal

The controller (`main/`) must carry **ZERO** Tuya/Macon protocol knowledge — no
register addresses (`REG_*`), bit masks, value scaling, or OEM fault-code
strings (`"P02"`, `"E19"`, …). All protocol knowledge lives behind the
`arctic-macon` library's typed/opaque APIs. This is the P2 "controller rip-out"
that builds on the P1 library foundation and the P1.5 consumer helpers.

## Library

- Bump `arctic-macon` submodule to **a3f8e56** (P1.5, PR sslivins/arctic-macon#22):
  adds `macon_field_address`, `macon_fault_bit_for_site`, and the
  `macon_fault_resolution` remedy lookup.

## Controller changes

**`heatpump_controller.cpp`**
- Replace the raw register cache (`DEMO_REG_*` / `readCacheReg` / `writeCacheReg`)
  with a `MaconImage` held under its own mutex.
- All demo/state mutation goes through semantic setters
  (`set_temp` / `set_value` / `set_flag` / `set_working_mode` / `set_fault`) in
  **natural units**; state is produced via `MaconImage::decode`.
- Event detection diffs decoded fault **sites** (opaque `MaconFaultSiteId`),
  not raw register bits.

**`heatpump_errors.cpp` / `.h`**
- Remove the local remedy table and all reg/bit indexing helpers; resolution
  text now comes from `macon_fault_resolution(id)`.
- First-seen tracking and cleared/active history diffing are keyed by opaque
  fault site tokens.
- `ActiveError` identity is a `MaconFaultSiteId` (was `reg`/`bit`). Demo history
  codes come from `macon_code_for_fault_id()`. Removed unused `isErrorActive` /
  `hasActiveFaultCode`.

**`api_server.cpp`**
- Diagnostic CSV addresses come from `macon_field_address(MaconField)` and the
  library-owned `MACON_FAULT_REGS[]`; the active-error row no longer emits a
  register address. **CSV output is byte-identical to before** (every field maps
  to the same wire address).

**`event_log_screen.cpp`**
- Decode the error payload as an opaque fault site via `macon_fault_bit_for_site`.

## Tests

- **New gate** `tests/api/test_opaque_macon_controller.py` (hostside): asserts
  `main/` (excluding `tuya/` and `advanced_params`) contains no
  `macon_registers.h` include, no `REG_*` symbols, and no OEM fault-code string
  literals — so a protocol leak can never be reintroduced.
- The demo API now takes **natural units**, so the few tests that posted raw
  `ac_voltage=23` expecting a decoded `230` now post `230`.

## Validation

- `pytest -m hostside tests/api` — all source-contract scanners pass locally
  (16 passed), including the new gate.
- C++ compile + device behavior are validated by CI (`build.yml` +
  `device-tests.yml`); the controller cannot be compiled host-side.

## ⚠️ Reviewer note — demo unit change

The demo/test API is now expressed in **natural units** (volts, amps, watts, °C)
rather than raw wire values. This is a deliberate, breaking change to the demo
contract. It needs a device-HIL sanity check on real hardware before this is
considered fully validated.

## Not in scope

- P3: relocating `main/tuya/macon_master.cpp` into the library (the transport
  shim is excluded from the gate for now).
- The advanced-parameters subsystem (`advanced_params.*`) is a separate future
  phase and is excluded from the gate.
