### PR TITLE
feat(demo): opaque fault set/clear + compile-time CONFIG_DEMO_MODE (P4+P5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,3 +132,47 @@ jobs:
           echo "- \`bootloader.bin\` - Bootloader" >> $GITHUB_STEP_SUMMARY
           echo "- \`partition-table.bin\` - Partition table" >> $GITHUB_STEP_SUMMARY
           echo "- \`ota_data_initial.bin\` - OTA data partition" >> $GITHUB_STEP_SUMMARY
+
+  # Compile-only guard for the demo-mode removal path. The production image
+  # ships with CONFIG_DEMO_MODE=y, so the =n branches (all the #if
+  # CONFIG_DEMO_MODE / #else gating around the demo scaffolding) are never
+  # exercised by the main build. Build once with demo disabled AND test
+  # endpoints enabled so the trickiest demo-off #else branches in
+  # test_endpoints.cpp are actually compiled. No artifacts are published; this
+  # job exists solely to keep the "ship without demo" path healthy.
+  build-demo-disabled:
+    runs-on: ubuntu-latest
+    env:
+      TARGET: ${{ inputs.target || 'esp32p4' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+
+      - name: Fetch dependencies
+        run: python3 fetch_repos.py
+
+      - name: Stamp build fingerprint
+        run: |
+          echo -n "${GITHUB_SHA}" > build_sha.txt
+
+      - name: Disable demo mode (keep test endpoints to cover demo-off branches)
+        run: |
+          echo "CONFIG_DEMO_MODE=n" >> sdkconfig.defaults
+          echo "CONFIG_TEST_ENDPOINTS=y" >> sdkconfig.defaults
+
+      - name: ESP-IDF Build (demo disabled)
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.5.2
+          target: ${{ env.TARGET }}
+          path: '.'
+
+      - name: Verify demo mode is compiled out
+        run: |
+          if grep -q '^#define CONFIG_DEMO_MODE 1$' build/config/sdkconfig.h; then
+            echo "::error::CONFIG_DEMO_MODE is still enabled in this variant — the demo-disabled build did not take effect."
+            exit 1
+          fi
+          echo "OK: CONFIG_DEMO_MODE is disabled in the compiled firmware"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,5 +1,20 @@
 menu "Arctic Controller"
 
+    config DEMO_MODE
+        bool "Include demo mode (simulated heat pump, no bus)"
+        default y
+        help
+            Compiles in demo mode: a fully simulated heat pump that runs with
+            no RS485 bus attached, driven by seeded register values and the
+            /api/heatpump/demo injection endpoint. Used for UI demos, kiosk
+            units, and the automated API/device test suites.
+
+            When disabled, all demo scaffolding (the seeded state, the demo
+            sync task, the /api/heatpump/demo endpoint, and the Settings demo
+            toggle) is excluded from the image and app_prefs_is_demo_mode()
+            is always false. Leave enabled for production images for now;
+            disable to ship a build that can only talk to a real bus.
+
     config TEST_ENDPOINTS
         bool "Enable test instrumentation endpoints (/api/test/*)"
         default n

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -2,6 +2,7 @@
  * Arctic Heat Pump Controller
  * REST API Server with mDNS, Web Interface, and Authentication
  */
+#include "sdkconfig.h"
 #include "api_server.h"
 #include "settings/settings_display_screen.h"
 #include "app_preferences.h"
@@ -141,7 +142,9 @@ static esp_err_t heatpump_mode_put_handler(httpd_req_t* req);
 static esp_err_t heatpump_setpoints_put_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_get_handler(httpd_req_t* req);
 static esp_err_t heatpump_errors_clear_handler(httpd_req_t* req);
+#if CONFIG_DEMO_MODE
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req);
+#endif
 static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req);
 static esp_err_t events_get_handler(httpd_req_t* req);
 static esp_err_t events_clear_handler(httpd_req_t* req);
@@ -920,6 +923,7 @@ bool api_server_start(void)
     REGISTER_URI(heatpump_diagnostic_uri);
 
     // PATCH /api/heatpump/demo - Write fields in demo mode (for testing)
+#if CONFIG_DEMO_MODE
     httpd_uri_t heatpump_demo_uri = {
         .uri = "/api/heatpump/demo",
         .method = HTTP_PATCH,
@@ -927,6 +931,7 @@ bool api_server_start(void)
         .user_ctx = NULL
     };
     REGISTER_URI(heatpump_demo_uri);
+#endif
     
     // GET /api/events - Get event log
     httpd_uri_t events_get_uri = {
@@ -4082,6 +4087,7 @@ static esp_err_t heatpump_errors_get_handler(httpd_req_t* req)
 //                              string; the arctic-macon library owns the
 //                              code -> register/bit mapping.
 // Only available when demo mode is enabled
+#if CONFIG_DEMO_MODE
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
 {
     if (!check_api_auth(req)) {
@@ -4178,6 +4184,7 @@ static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
     
     return ESP_OK;
 }
+#endif  // CONFIG_DEMO_MODE
 
 // ============================================================================
 // Events API

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -4076,6 +4076,11 @@ static esp_err_t heatpump_errors_get_handler(httpd_req_t* req)
 
 // PATCH /api/heatpump/demo - Write read-only fields for testing
 // Body: { "field1": value1, "field2": value2, ... }
+//   - Numeric telemetry/setpoint fields go to setDemoField() in natural units.
+//   - "clear_faults": 1        clears every active demo fault.
+//   - "fault:<CODE>": 1|0      sets/clears one fault by its opaque OEM code
+//                              string; the arctic-macon library owns the
+//                              code -> register/bit mapping.
 // Only available when demo mode is enabled
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
 {
@@ -4115,6 +4120,35 @@ static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
     // Iterate all keys in the JSON object
     cJSON* item = NULL;
     cJSON_ArrayForEach(item, root) {
+        // Reserved opaque fault controls. Faults are referenced by their
+        // canonical OEM code (an opaque runtime string) which the arctic-macon
+        // library maps to register/bit sites — no protocol knowledge here.
+        //   {"clear_faults": 1}      -> clear every active demo fault
+        //   {"fault:<CODE>": 1|0}    -> set/clear a single fault by code
+        if (strcmp(item->string, "clear_faults") == 0) {
+            arctic::clearDemoFaults();
+            cJSON_AddStringToObject(results, item->string, "ok");
+            success_count++;
+            continue;
+        }
+        if (strncmp(item->string, "fault:", 6) == 0) {
+            if (!cJSON_IsNumber(item)) {
+                cJSON_AddStringToObject(results, item->string, "error: value must be a number");
+                fail_count++;
+                continue;
+            }
+            const char* code = item->string + 6;
+            bool active = ((int32_t)item->valuedouble) != 0;
+            if (arctic::injectDemoFault(code, active) > 0) {
+                cJSON_AddStringToObject(results, item->string, "ok");
+                success_count++;
+            } else {
+                cJSON_AddStringToObject(results, item->string, "error: unknown fault code");
+                fail_count++;
+            }
+            continue;
+        }
+
         if (!cJSON_IsNumber(item)) {
             cJSON_AddStringToObject(results, item->string, "error: value must be a number");
             fail_count++;

--- a/main/app_preferences.cpp
+++ b/main/app_preferences.cpp
@@ -3,6 +3,7 @@
  * Application Preferences Implementation
  */
 
+#include "sdkconfig.h"
 #include "app_preferences.h"
 #include <nvs_flash.h>
 #include <nvs.h>
@@ -53,10 +54,18 @@ void app_prefs_init(void) {
 }
 
 bool app_prefs_is_demo_mode(void) {
+#if CONFIG_DEMO_MODE
     return s_prefs.demo_mode;
+#else
+    return false;
+#endif
 }
 
 void app_prefs_set_demo_mode(bool enabled) {
+#if !CONFIG_DEMO_MODE
+    (void)enabled;  // demo mode compiled out; toggle is a no-op
+    return;
+#else
     if (s_prefs.demo_mode == enabled) return;
     
     s_prefs.demo_mode = enabled;
@@ -71,6 +80,7 @@ void app_prefs_set_demo_mode(bool enabled) {
     } else {
         ESP_LOGE(TAG, "Failed to save demo_mode: %s", esp_err_to_name(err));
     }
+#endif
 }
 
 temp_unit_t app_prefs_get_temp_unit(void) {

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -2,6 +2,7 @@
  * Arctic Heat Pump State and Control
  */
 
+#include "sdkconfig.h"
 #include "heatpump_controller.h"
 #include "macon_master_iface.h"
 #include "heatpump_errors.h"
@@ -27,8 +28,10 @@ static void applyMaconMapping();
 // State protected by mutex
 static HeatPumpState s_state;
 static SemaphoreHandle_t s_state_mutex = nullptr;
+#if CONFIG_DEMO_MODE
 static TaskHandle_t s_demo_sync_task = nullptr;
 static bool s_demo_sync_enabled = false;
+#endif
 static bool s_demo_mode = false;
 static bool s_feed_mode = false;  // Passive Tuya external-feed mode
 static uint32_t s_holding_window_ms = 0;
@@ -191,6 +194,7 @@ static void detectAndLogStateEvents() {
 }
 
 // Periodically decode the register cache into HeatPumpState and emit events.
+#if CONFIG_DEMO_MODE
 static void demoSyncTask(void*) {
     ESP_LOGI(TAG, "Demo synchronization task started");
 
@@ -310,6 +314,7 @@ void initDemoState() {
 
     ESP_LOGI(TAG, "Demo state initialized");
 }
+#endif  // CONFIG_DEMO_MODE
 
 bool isDemoMode() {
     return s_demo_mode;
@@ -677,6 +682,7 @@ TelemetrySnapshot getTelemetrySnapshot() {
         return snapshot;
 }
 
+#if CONFIG_DEMO_MODE
 void startDemoSync() {
     if (!s_demo_mode) {
         ESP_LOGE(TAG, "Cannot start demo synchronization outside demo mode");
@@ -703,6 +709,7 @@ void startDemoSync() {
         s_demo_sync_enabled = false;
     }
 }
+#endif  // CONFIG_DEMO_MODE
 
 HeatPumpState getState() {
     HeatPumpState copy;
@@ -903,6 +910,7 @@ void getStatusDescription(char* buffer, size_t buffer_size) {
              state.getFanSpeedLevel());
 }
 
+#if CONFIG_DEMO_MODE
 bool setDemoField(const char* field, int32_t value) {
     if (!s_demo_mode || field == nullptr) return false;
 
@@ -995,5 +1003,6 @@ void clearDemoFaults() {
     applyMaconMapping();
     ESP_LOGI(TAG, "[DEMO] All faults cleared");
 }
+#endif  // CONFIG_DEMO_MODE
 
 }  // namespace arctic

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include "sdkconfig.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -124,13 +125,18 @@ struct TelemetrySnapshot {
 // ============================================================================
 
 // Initialize demo mode - populates state with simulated values
+#if CONFIG_DEMO_MODE
 void initDemoState();
+#endif
 
-// Check if running in demo mode
+// Check if running in demo mode (always available; returns false when demo
+// mode is compiled out so callers can guard without extra #ifdefs)
 bool isDemoMode();
 
 // Start the demo-state synchronization task.
+#if CONFIG_DEMO_MODE
 void startDemoSync();
+#endif
 
 // Get current state (thread-safe copy)
 HeatPumpState getState();
@@ -183,6 +189,7 @@ void getStatusDescription(char* buffer, size_t buffer_size);
 // ============================================================================
 // Demo State Injection (only works in demo mode)
 // ============================================================================
+#if CONFIG_DEMO_MODE
 
 // Set a field in the heat pump state by name. Returns true if the field was found.
 // Allows testing read-only values (temps, readings, errors, status) via REST API.
@@ -199,6 +206,9 @@ int injectDemoFault(const char* code, bool active);
 // Clear every active fault in the demo register cache (all five fault
 // registers), preserving the run/state indicator. Demo mode only.
 void clearDemoFaults();
+
+#endif  // CONFIG_DEMO_MODE
+
 
 // ============================================================================
 // External Feed (passive Tuya listen mode)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -250,11 +250,14 @@ extern "C" void app_main(void)
     event_log_record_reset_reason(reset_reason);
 
     // Initialize demo state or one of the two Macon/Tuya bus modes.
+#if CONFIG_DEMO_MODE
     if (app_prefs_is_demo_mode()) {
         mclog::tagInfo(TAG, "Demo mode enabled - initializing demo state");
         arctic::initDemoState();
         arctic::startDemoSync();
-    } else {
+    } else
+#endif
+    {
 #if CONFIG_ARCTIC_TUYA_LISTEN
         // Passive Tuya listen mode: RX-only decode of the existing bus.
         // The Tab5 stays silent on RS485.

--- a/main/settings/settings_menu.cpp
+++ b/main/settings/settings_menu.cpp
@@ -5,6 +5,7 @@
  * Main settings screen with a list of setting categories.
  * Each row opens a full-screen sub-setting when tapped.
  */
+#include "sdkconfig.h"
 #include "settings_menu.h"
 #include "settings_wifi_screen.h"
 #include "settings_firmware_screen.h"
@@ -100,7 +101,9 @@ static void create_header(void);
 static void create_menu_list(void);
 static void close_btn_event_cb(lv_event_t* e);
 static void row_click_cb(lv_event_t* e);
+#if CONFIG_DEMO_MODE
 static void demo_mode_switch_cb(lv_event_t* e);
+#endif
 static void temp_unit_switch_cb(lv_event_t* e);
 static void show_reboot_confirmation(void);
 static void reboot_confirm_cb(lv_event_t* e);
@@ -215,6 +218,7 @@ static lv_obj_t* create_toggle_row(lv_obj_t* parent, const char* icon,
 // Event Handlers
 // ============================================================================
 
+#if CONFIG_DEMO_MODE
 static void demo_mode_switch_cb(lv_event_t* e)
 {
     lv_obj_t* sw = (lv_obj_t*)lv_event_get_target(e);
@@ -224,6 +228,7 @@ static void demo_mode_switch_cb(lv_event_t* e)
     ESP_LOGI(TAG, "Demo mode %s — showing reboot confirmation", on ? "enabled" : "disabled");
     show_reboot_confirmation();
 }
+#endif  // CONFIG_DEMO_MODE
 
 // ============================================================================
 // Reboot Confirmation Panel
@@ -690,11 +695,13 @@ static void create_menu_list(void)
         "settings_security");
     
     // Demo Mode toggle
+#if CONFIG_DEMO_MODE
     lv_obj_t* demo_row = create_toggle_row(state.list_container, LV_SYMBOL_PLAY,
                       i18n_get(STR_SETTINGS_DEMO_MODE), app_prefs_is_demo_mode(),
                       &state.demo_mode_switch, demo_mode_switch_cb);
     lv_obj_set_user_data(demo_row, (void*)"settings_demo_mode");
     lv_obj_set_user_data(state.demo_mode_switch, (void*)"demo_mode_switch");
+#endif
     
     // Temperature Units toggle with °C / °F labels
     {

--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -1665,9 +1665,11 @@ static esp_err_t set_preference_post_handler(httpd_req_t* req)
         bool enable = cJSON_IsTrue(demo);
         app_prefs_set_demo_mode(enable);
         // Also set the runtime flag so isDemoMode() reflects the change immediately
+#if CONFIG_DEMO_MODE
         if (enable && !arctic::isDemoMode()) {
             arctic::initDemoState();
         }
+#endif
         ESP_LOGI(TAG, "set-preference: demo_mode=%s", enable ? "true" : "false");
     }
 
@@ -1725,10 +1727,13 @@ static esp_err_t set_demo_field_post_handler(httpd_req_t* req)
             continue;
         }
         int32_t value = (int32_t)item->valuedouble;
+#if CONFIG_DEMO_MODE
         if (arctic::setDemoField(item->string, value)) {
             cJSON_AddStringToObject(results, item->string, "ok");
             success_count++;
-        } else {
+        } else
+#endif
+        {
             cJSON_AddStringToObject(results, item->string, "error: unknown field");
             fail_count++;
         }
@@ -1824,7 +1829,11 @@ static esp_err_t inject_fault_post_handler(httpd_req_t* req)
     cJSON* active_item = cJSON_GetObjectItem(root, "active");
     bool active = active_item ? cJSON_IsTrue(active_item) : true;
 
+#if CONFIG_DEMO_MODE
     int sites = arctic::injectDemoFault(code->valuestring, active);
+#else
+    int sites = 0;
+#endif
     if (sites <= 0) {
         cJSON_Delete(root);
         send_json_error(req, "400 Bad Request", "Unknown fault code");
@@ -1856,7 +1865,9 @@ static esp_err_t clear_faults_post_handler(httpd_req_t* req)
         send_json_error(req, "403 Forbidden", "Demo mode is not enabled");
         return ESP_OK;
     }
+#if CONFIG_DEMO_MODE
     arctic::clearDemoFaults();
+#endif
 
     set_json_content_type(req);
     cJSON* resp = cJSON_CreateObject();

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -359,6 +359,62 @@ class TestDemoModeInjection:
         assert r.status_code in (200, 403)
 
 
+class TestDemoFaultControlViaDemoEndpoint:
+    """PATCH /api/heatpump/demo — opaque fault control on the production path.
+
+    Faults are set/cleared by their canonical OEM code through the always-on
+    demo endpoint (no CONFIG_TEST_ENDPOINTS build required). The code ->
+    register/bit mapping is owned by the arctic-macon library, so no protocol
+    knowledge is exposed on the wire.
+    """
+
+    def teardown_method(self):
+        # Leave the device with no active faults for subsequent tests.
+        _inject_demo({"clear_faults": 1})
+        time.sleep(0.3)
+
+    def test_set_fault_by_code(self):
+        """{"fault:P02": 1} activates the high-pressure fault."""
+        _inject_demo({"clear_faults": 1})
+        _inject_demo({"fault:P02": 1})
+        time.sleep(1.0)
+        assert _get("/api/heatpump/status").json()["has_error"] is True
+        codes = [e["code"] for e in _get("/api/heatpump/errors").json()["active"]]
+        assert "P02" in codes
+
+    def test_clear_single_fault_by_code(self):
+        """{"fault:P02": 0} clears only that fault, leaving others active."""
+        _inject_demo({"clear_faults": 1})
+        _inject_demo({"fault:P02": 1, "fault:E19": 1})
+        time.sleep(1.0)
+        _inject_demo({"fault:P02": 0})
+        time.sleep(1.0)
+        codes = [e["code"] for e in _get("/api/heatpump/errors").json()["active"]]
+        assert "P02" not in codes
+        assert "E19" in codes
+
+    def test_clear_all_faults(self):
+        """{"clear_faults": 1} clears every active fault."""
+        _inject_demo({"fault:P02": 1, "fault:E19": 1})
+        time.sleep(1.0)
+        _inject_demo({"clear_faults": 1})
+        time.sleep(1.0)
+        assert _get("/api/heatpump/status").json()["has_error"] is False
+        assert _get("/api/heatpump/errors").json()["error_count"] == 0
+
+    def test_unknown_fault_code_reports_failure(self):
+        """An unknown fault code is reported as failed, not silently applied."""
+        r = _patch("/api/heatpump/demo", json={"fault:ZZ99": 1})
+        assert r.status_code == 200
+        assert r.json()["failed"] > 0
+
+    def test_fault_key_non_numeric_value_fails(self):
+        """A non-numeric value for a fault key is rejected."""
+        r = _patch("/api/heatpump/demo", json={"fault:P02": "on"})
+        assert r.status_code == 200
+        assert r.json()["failed"] > 0
+
+
 # ── Component State Manipulation ─────────────────────────────────────────
 #
 # The unit's run-state is decoded natively by arctic-macon from the real Tuya


### PR DESCRIPTION
# Demo mode: opaque fault control + compile-time flag

Two related demo-mode changes, shipping together in one release.

## P4 — opaque fault set/clear via `/api/heatpump/demo`

P2 (#113) correctly removed the raw fault-register fields (`fault_run`,
`fault_ee`, …) from the production demo endpoint because they leaked
register knowledge into the controller. But the replacement opaque
fault control (`injectDemoFault()` / `clearDemoFaults()`) was only wired
to the CI-only `/api/test/*` endpoints — so **production firmware lost
the ability to clear a demo fault entirely** (e.g. the seeded P02 high-
pressure fixture could no longer be cleared on a real device).

This restores that capability on the production demo endpoint using
opaque, protocol-neutral reserved keys — no register or bit knowledge in
`main/`:

- `{"clear_faults": 1}` → clears every active demo fault.
- `{"fault:<CODE>": 1|0}` → set/clear one fault by its canonical OEM code
  string. The `arctic-macon` library owns the `code → register/bit`
  mapping; the controller passes the code through opaquely.

Numeric telemetry/setpoint fields continue to work exactly as before.

## P5 — `CONFIG_DEMO_MODE` compile-time flag

Demo mode is now a Kconfig option (`CONFIG_DEMO_MODE`, bool, **default
y**). Production images keep demo mode for now; the flag lets us build a
demo-free image later.

When disabled:
- `app_prefs_is_demo_mode()` / `isDemoMode()` are compile-time `false`;
  `app_prefs_set_demo_mode()` is a no-op.
- The demo seed, demo sync task + statics, `setDemoField`,
  `injectDemoFault`, `clearDemoFaults`, `initDemoState`, `startDemoSync`
  are excluded from the build.
- The `/api/heatpump/demo` endpoint (incl. the P4 keys) is not
  registered.
- The Settings demo-mode toggle row is hidden.
- The `/api/test/*` demo helper calls compile out; the endpoints stay
  registered but return `403 Demo mode not enabled`, matching the
  existing runtime behaviour.

`isDemoMode()` stays always-declared so callers guard without extra
`#ifdef`s. Every edited file now includes `sdkconfig.h` explicitly so
`CONFIG_DEMO_MODE` can never silently evaluate to false from a missing
transitive include.

### CI guard

Added a `build-demo-disabled` job that compiles with
`CONFIG_DEMO_MODE=n` **and** `CONFIG_TEST_ENDPOINTS=y`, so the demo-off
`#else` branches (the trickiest gating, in `test_endpoints.cpp`) are
actually exercised on every PR. The production build path is unchanged.

## Opacity

`tests/api/test_opaque_macon_controller.py` still passes — no register
map include, no `REG_*` symbols, and no OEM fault-code literals in
`main/` (the reserved-key docs use a `<CODE>` placeholder).

## Testing

- Opacity gate: 3 passed.
- New host/HIL tests in `tests/api/test_heatpump_api.py`
  (`TestDemoFaultControlViaDemoEndpoint`) cover set-by-code, clear-single,
  clear-all, unknown-code rejection, and non-numeric-value rejection via
  the production endpoint.
- Full firmware build (demo=y) + demo-disabled build (demo=n) both run in
  CI.

Once this lands and 1.21 is upgraded, the seeded demo P02 can finally be
cleared live via `PATCH /api/heatpump/demo {"clear_faults": 1}`.
