### PR TITLE
chore: scrub register-number leaks from controller + harden opacity gate

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3968,10 +3968,9 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     DIAG_BOOL("Defrosting",        hp.isDefrosting())
     #undef DIAG_BOOL
 
-    // --- Raw fault-register bytes (2007 + 2125-2128) ---
     // --- Raw fault-register bytes. Addresses come from the library-owned
-    // MACON_FAULT_REGS[] list (2007 + 2125-2128), in that order; the consumer
-    // hardcodes no register address. ---
+    // MACON_FAULT_REGS[] list, in that order; the consumer hardcodes no
+    // register address. ---
     {
         const char* fault_names[arctic::MACON_FAULT_REGS_COUNT] = {
             "Fault Run/State (raw)", "Fault Sensor/EE (raw)",

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -57,7 +57,7 @@ static bool s_prev_fan = false;
 static bool s_prev_pump = false;
 static bool s_prev_aux_heater = false;
 static bool s_prev_defrosting = false;
-static uint8_t s_prev_fault_bytes[5] = {0};  // reg 2007,2125,2126,2127,2128
+static uint8_t s_prev_fault_bytes[5] = {0};  // the five opaque Macon fault-byte groups
 static int16_t s_prev_cooling_sp = 0;
 static int16_t s_prev_heating_sp = 0;
 static int16_t s_prev_hotwater_sp = 0;
@@ -409,8 +409,8 @@ static void applyMaconMapping() {
     s_state.suction_temp         = ms.suction_c;
     s_state.outdoor_coil_temp    = ms.outdoor_coil_c;
 
-    // Setpoints (whole °C). cooling_setpoint = reg2093 byte0, decoded by the
-    // macon library; previously left unmapped so the API reported 0.
+    // Setpoints (whole °C), decoded by the macon library;
+    // previously left unmapped so the API reported 0.
     s_state.hot_water_setpoint   = ms.hot_water_setpoint;
     s_state.cooling_setpoint     = ms.cooling_setpoint;
     if (ms.aux_heat_setpoint_valid) {
@@ -420,8 +420,9 @@ static void applyMaconMapping() {
     s_inlet_valid = ms.inlet_valid;
     s_outlet_valid = ms.outlet_valid;
     s_cooling_setpoint_valid = ms.cooling_setpoint_valid;
-    // reg2094 is still not confirmed as the active heating target, so expose
-    // its value in the diagnostic UI but do not persist it as a valid target.
+    // The heating target is still not confirmed as the active target on this
+    // unit, so expose its value in the diagnostic UI but do not persist it as
+    // a valid target.
     s_heating_setpoint_valid = false;
     s_hot_water_setpoint_valid = ms.hot_water_setpoint_valid;
     s_mode_valid = ms.working_mode_valid;
@@ -448,7 +449,7 @@ static void applyMaconMapping() {
     s_state.dc_voltage          = ms.dc_voltage;
     s_state.primary_eev_opening = ms.primary_eev;
     s_state.compressor_freq     = ms.compressor_freq;
-    // Real-time power in watts, decoded by the macon library (reg2114/A9).
+    // Real-time power in watts, decoded by the macon library.
     // Preferred over the old V*I/10 estimate, which is now 10x low because the
     // library normalises ac_current to whole amps.
     s_state.realtime_power_w    = ms.realtime_power_w;
@@ -794,9 +795,9 @@ bool setCoolingSetpoint(int16_t temp) {
 bool setHeatingSetpoint(int16_t temp) {
     temp = static_cast<int16_t>(clamp_setpoint(SetpointKind::Heating, temp));
     if (macon_master::is_active()) {
-        // MaconLink deliberately has no set_heating_setpoint: reg2094 is
-        // unverified on this unit. Fail explicitly rather than guess.
-        ESP_LOGW(TAG, "Heating setpoint write unsupported in Tuya master mode (reg2094 unverified)");
+        // MaconLink deliberately has no set_heating_setpoint: the heating
+        // target is unverified on this unit. Fail explicitly rather than guess.
+        ESP_LOGW(TAG, "Heating setpoint write unsupported in Tuya master mode (heating target unverified)");
         return false;
     }
     imageLock();

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -23,7 +23,7 @@ struct HeatPumpState {
     uint32_t last_attempt_ms = 0;
     uint8_t consecutive_failures = 0;
     
-    // Settings (from holding registers 2000-2007)
+    // Settings (decoded by the macon library)
     bool unit_on = false;
     WorkingMode working_mode = WorkingMode::COOLING;
     HeatPumpOperation operation = HeatPumpOperation::UNKNOWN;
@@ -31,7 +31,7 @@ struct HeatPumpState {
     int16_t heating_setpoint = 0;    // °C
     int16_t hot_water_setpoint = 0;  // °C
     
-    // Temperatures (from input registers 2100-2117)
+    // Temperatures (decoded by the macon library)
     int16_t water_tank_temp = 0;
     int16_t outlet_water_temp = 0;
     int16_t inlet_water_temp = 0;
@@ -44,7 +44,7 @@ struct HeatPumpState {
     
     // System readings (decoded by the macon library from the real Tuya window)
     uint16_t compressor_freq = 0;    // Hz
-    uint16_t fan_speed = 0;          // reg2003 A10 DC motor raw level (0..~72)
+    uint16_t fan_speed = 0;          // raw DC fan-motor level (0..~72), owned by macon lib
     uint16_t ac_voltage = 0;         // V
     uint16_t ac_current = 0;         // A
     uint16_t dc_voltage = 0;         // V (volts; unit conversion owned by macon lib)
@@ -68,14 +68,14 @@ struct HeatPumpState {
     bool backup_heater = false;           // no confirmed Macon register -> always false
     bool reversing_valve_cooling = false; // reversing valve energized (cooling)
 
-    // Raw Macon fault-register bytes (reg 2007, 2125, 2126, 2127, 2128) exactly
-    // as the mainboard reports them. Decoded natively via arctic-macon's
-    // macon_decode_faults(); NOT the old fictional error1/error2 masks.
-    uint8_t fault_run = 0;   // reg2007
-    uint8_t fault_ee = 0;    // reg2125
-    uint8_t fault_comp = 0;  // reg2126
-    uint8_t fault_elec = 0;  // reg2127
-    uint8_t fault_ref = 0;   // reg2128
+    // Opaque Macon fault-byte groups exactly as the mainboard reports them.
+    // Decoded natively via arctic-macon's macon_decode_faults(); the controller
+    // never interprets the bits itself.
+    uint8_t fault_run = 0;   // run/operation faults
+    uint8_t fault_ee = 0;    // EEPROM / configuration faults
+    uint8_t fault_comp = 0;  // compressor faults
+    uint8_t fault_elec = 0;  // electrical faults
+    uint8_t fault_ref = 0;   // refrigerant-circuit faults
     bool    any_fault = false; // macon_has_fault() over the five bytes (ex-RUN)
 
     // Convenience status getters (now plain accessors over the derived fields).
@@ -89,7 +89,7 @@ struct HeatPumpState {
     // DC bus voltage in volts (already converted by the macon library).
     float getDcVoltageV() const { return static_cast<float>(dc_voltage); }
 
-    // Fan UI level (0=off..3=high) bucketed from the raw reg2003 level.
+    // Fan UI level (0=off..3=high) bucketed from the raw fan-motor level.
     // TODO(fan-rework): replace with bars = round(fan_speed/fan_speed_max*N)
     // once the library exposes fan_speed + fan_speed_max.
     int getFanSpeedLevel() const {

--- a/main/heatpump_errors.h
+++ b/main/heatpump_errors.h
@@ -90,8 +90,8 @@ bool describeFaultCode(const char* code, const char** name_out,
 // Error History Functions
 // ============================================================================
 
-// Update error history from the five raw Macon fault-register bytes
-// (reg 2007, 2125, 2126, 2127, 2128). Should be called each poll/feed cycle.
+// Update error history from the five opaque Macon fault-byte groups.
+// Should be called each poll/feed cycle.
 void updateErrorHistory(uint8_t fault_run, uint8_t fault_ee, uint8_t fault_comp,
                         uint8_t fault_elec, uint8_t fault_ref);
 

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -559,8 +559,8 @@
       const h = state.hp, r = h.readings, t = h.temperatures;
       return `<div class="page">${pageHead("Status", "Complete temperature, electrical, and mechanical telemetry.")}
         <h2>Operating state</h2><div class="grid grid-2">
-          ${metricCard("Selected mode", titleCase(h.mode || "unknown"), "Configured policy from register 2096")}
-          ${metricCard("Actual operation", titleCase(h.operation || "unknown"), "Live status from register 2129")}
+          ${metricCard("Selected mode", titleCase(h.mode || "unknown"), "Configured mode policy from the mainboard")}
+          ${metricCard("Actual operation", titleCase(h.operation || "unknown"), "Live operating status from the mainboard")}
         </div>
         <h2>Temperatures</h2><div class="grid grid-3">
           ${metricCard("Water tank", temp(t.tank))}${metricCard("Outlet water", temp(t.outlet))}${metricCard("Inlet water", temp(t.inlet))}

--- a/tests/api/test_opaque_macon_controller.py
+++ b/tests/api/test_opaque_macon_controller.py
@@ -43,6 +43,18 @@ FORBIDDEN_REG_SYMBOL = re.compile(r"\bREG_[A-Z][A-Z0-9_]*")
 # opaque runtime strings, never bake them in.
 FORBIDDEN_CODE_LITERAL = re.compile(r'"(?:[PE]\d{2}|r\d{2}|PC)"')
 
+# Macon wire register NUMBERS named in code/comments/strings (reg2003, reg 2094,
+# register 2096, regs 2000, ...). The controller must describe values
+# semantically and never reference a wire register address. The 2000/2100
+# ranges are the Macon holding/telemetry windows.
+FORBIDDEN_REG_NUMBER = re.compile(r"(?i)reg(?:ister)?s?\s*2[01]\d\d")
+
+# Any #include "name" / <name>; group 1 is the raw included path.
+INCLUDE_RE = re.compile(r'#\s*include\s*[<"]\s*([A-Za-z0-9_./]+)\s*[>"]')
+
+# The arctic-macon library's public headers.
+MACON_INCLUDE = ROOT / "components" / "arctic-macon" / "include"
+
 
 def _controller_sources():
     for path in MAIN.rglob("*"):
@@ -88,5 +100,58 @@ def test_controller_has_no_oem_fault_code_literals():
     violations = _scan(FORBIDDEN_CODE_LITERAL)
     assert not violations, (
         "main/ must not hardcode OEM fault-code string literals (protocol leak):\n"
+        + "\n".join(violations)
+    )
+
+
+def test_controller_has_no_register_number_references():
+    violations = _scan(FORBIDDEN_REG_NUMBER)
+    assert not violations, (
+        "main/ must not reference Macon wire register numbers in code, comments,\n"
+        "or strings (protocol leak) — describe the value semantically instead:\n"
+        + "\n".join(violations)
+    )
+
+
+def _headers_included_by_main():
+    """Header basenames directly #included by in-scope controller sources."""
+    names = set()
+    for path in _controller_sources():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for m in INCLUDE_RE.finditer(text):
+            names.add(Path(m.group(1)).name)
+    return names
+
+
+def _header_pulls_register_map(header, seen):
+    """True if `header` includes macon_registers.h, directly or transitively
+    through other arctic-macon public headers."""
+    if header in seen or not header.is_file():
+        return False
+    seen.add(header)
+    text = header.read_text(encoding="utf-8", errors="replace")
+    if FORBIDDEN_INCLUDE.search(text):
+        return True
+    for m in INCLUDE_RE.finditer(text):
+        nxt = MACON_INCLUDE / Path(m.group(1)).name
+        if _header_pulls_register_map(nxt, seen):
+            return True
+    return False
+
+
+def test_main_facing_macon_headers_do_not_pull_register_map():
+    """A `main/` source that never directly includes macon_registers.h can still
+    compile it in transitively through a public library header (e.g. an image or
+    state header). Close that compile-boundary hole too."""
+    violations = []
+    for name in sorted(_headers_included_by_main()):
+        if name == "macon_registers.h":
+            continue  # a direct include is covered by the dedicated test
+        header = MACON_INCLUDE / name
+        if header.is_file() and _header_pulls_register_map(header, set()):
+            violations.append(name)
+    assert not violations, (
+        "main/ transitively compiles the Macon register map through these "
+        "public headers — remove the macon_registers.h dependency from them:\n"
         + "\n".join(violations)
     )


### PR DESCRIPTION
## Summary

Follow-ups from the opacity scrub. Closes #116, #117. No behavior change.

## Register-number leaks removed from the controller (`main/`)

The controller must describe values semantically and never reference a Macon
wire register address. These were still leaking through comments, a runtime log
string, and user-facing web tooltips:

- `heatpump_controller.h` — `reg2003` / `reg2007..reg2128` comments → semantic
  descriptions; the five fault bytes are now documented as opaque fault-byte
  groups.
- `heatpump_controller.cpp` — `reg2093` / `reg2094` / `reg2114` comments →
  semantic; the `ESP_LOGW(... "reg2094 unverified")` **runtime log string** no
  longer bakes in a register number.
- `heatpump_errors.h` / `api_server.cpp` — drop register numbers from the
  fault-byte and diagnostic-CSV comments (the addresses still come from the
  library-owned `MACON_FAULT_REGS[]` list — no hardcoded address in the
  consumer).
- `web/index.html` — status-page tooltips no longer expose
  `"register 2096" / "register 2129"`.

## Compile-boundary fix (submodule bump)

Bumps the `arctic-macon` submodule to include
sslivins/arctic-macon#24, which removes `#include "macon_registers.h"` from the
public `macon_image.h`. `api_server.cpp` and `heatpump_controller.cpp` include
that header, so they were transitively compiling the entire register map. Fixed.

## Opacity gate hardening (`tests/api/test_opaque_macon_controller.py`)

Two new checks so these leak classes can't regress:

- `test_controller_has_no_register_number_references` — fails on any
  `reg2xxx` / `register 2xxx` reference in code, comments, or strings.
- `test_main_facing_macon_headers_do_not_pull_register_map` — fails if any
  `arctic-macon` public header included by `main/` transitively includes
  `macon_registers.h` (closes the compile-boundary hole the old gate missed,
  which only inspected *direct* includes).

## Validation

- Opacity gate: `5 passed` locally.
- `arctic-macon` native host tests (`test_image`) pass with the header change.
- Register-number sweep of in-scope `main/` (excluding `tuya/`,
  `advanced_params.*`, `fonts/`): clean.

## Not in this PR

Advanced-param wire metadata (`p->reg` / `o->wire` / `enum_vals`) still escaping
into `api_server.cpp` + `heatpump_params_screen.cpp` — tracked as #118 (needs a
library opaque-option-id API).
