### PR TITLE
opacity(#118): consume opaque option ids, quarantine AP wire/register metadata

### DIFF
--- a/main/advanced_params.cpp
+++ b/main/advanced_params.cpp
@@ -87,3 +87,43 @@ arctic::AdvWriteResult advanced_param_write(uint8_t ap, int16_t value, bool* bus
     }
     return AdvWriteResult::OK;
 }
+
+arctic::AdvWriteResult advanced_param_write_option(uint8_t ap, size_t option_index,
+                                                   bool* bus_ok) {
+    if (bus_ok) *bus_ok = false;
+
+    // Build a validated write plan by opaque option id: arctic-macon maps the
+    // id to its wire code and runs the range/enum + register-known + unlocked
+    // guardrail. The raw wire code stays inside the library/this module.
+    AdvWritePlan plan{};
+    AdvWriteResult r = arctic::advanced_prepare_write_option(ap, option_index, &plan);
+    if (r != AdvWriteResult::OK) {
+        ESP_LOGW(TAG, "write AP%u option %u refused: %s",
+                 (unsigned)ap, (unsigned)option_index, arctic::adv_write_result_name(r));
+        return r;
+    }
+
+    // Demo mode - accept the (valid) write without touching the bus.
+    if (app_prefs_is_demo_mode()) {
+        ESP_LOGI(TAG, "[DEMO] AP%u option %u (reg%u=%u, not sent)",
+                 (unsigned)ap, (unsigned)option_index, (unsigned)plan.reg, (unsigned)plan.raw);
+        if (bus_ok) *bus_ok = true;
+        return AdvWriteResult::OK;
+    }
+
+    if (!arctic::isConnected()) {
+        ESP_LOGW(TAG, "write AP%u option: not connected", (unsigned)ap);
+        return AdvWriteResult::OK;  // guardrail passed; caller checks *bus_ok
+    }
+
+    bool ok = arctic::writeRegister(plan.reg, plan.raw);
+    if (bus_ok) *bus_ok = ok;
+    if (ok) {
+        ESP_LOGI(TAG, "Wrote AP%u option %u (reg%u = %u)",
+                 (unsigned)ap, (unsigned)option_index, (unsigned)plan.reg, (unsigned)plan.raw);
+    } else {
+        ESP_LOGE(TAG, "AP%u option guardrail OK but bus write of reg%u failed",
+                 (unsigned)ap, (unsigned)plan.reg);
+    }
+    return AdvWriteResult::OK;
+}

--- a/main/advanced_params.h
+++ b/main/advanced_params.h
@@ -36,3 +36,13 @@ bool advanced_param_read(uint8_t ap, int16_t* value_out);
 // A non-OK result means NOTHING was written. If the guardrail passes but the
 // bus write fails, returns REG_UNKNOWN-free failure via *bus_ok (see below).
 arctic::AdvWriteResult advanced_param_write(uint8_t ap, int16_t value, bool* bus_ok = nullptr);
+
+// Attempt to write an enum ("choice") advanced parameter AP `ap` by selecting
+// the option at opaque id `option_index` (its stable index in the parameter's
+// option list). arctic-macon maps the id to its wire code and runs the full
+// guardrail; the raw RS485 code never leaves the library / this quarantined
+// module. Returns the arctic::AdvWriteResult (NOT_IN_ENUM if the parameter has
+// no options or the index is out of range, UNKNOWN_PARAM for a bad AP). On a
+// guardrail pass, *bus_ok reports whether the live bus write succeeded.
+arctic::AdvWriteResult advanced_param_write_option(uint8_t ap, size_t option_index,
+                                                   bool* bus_ok = nullptr);

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3350,9 +3350,11 @@ static esp_err_t heatpump_windows_handler(httpd_req_t* req)
 // ============================================================================
 
 // Emit the locale-independent enum display options for `p` (if any) as an
-// "options" array: [{ wire, label, msg_id, arg_a, arg_b, en }]. The wire code
-// is the only value the UI ever PUTs back; label/msg_id/args/en drive display
-// and the UI's own localization (macon owns the code<->meaning mapping).
+// "options" array: [{ id, label, msg_id, arg_a, arg_b, en }]. `id` is the
+// opaque, stable option identifier (the option's list index) — the only value
+// the UI ever PUTs back. The library maps ids to wire codes internally, so no raw RS485
+// wire code is ever exposed here. label/msg_id/args/en drive display and the
+// UI's own localization.
 static void add_ap_enum_options(cJSON* obj, const arctic::AdvancedParam* p) {
     const size_t nopt = arctic::advanced_enum_option_count(p->ap);
     if (nopt == 0) return;
@@ -3361,7 +3363,7 @@ static void add_ap_enum_options(cJSON* obj, const arctic::AdvancedParam* p) {
         const arctic::AdvEnumOption* o = arctic::advanced_enum_option_at(p->ap, i);
         if (!o) continue;
         cJSON* io = cJSON_CreateObject();
-        cJSON_AddNumberToObject(io, "wire", o->wire);
+        cJSON_AddNumberToObject(io, "id", (double)i);   // opaque stable option id
         cJSON_AddStringToObject(io, "label", o->label ? o->label : "");
         cJSON_AddStringToObject(io, "msg_id", o->msg_id ? o->msg_id : "");
         cJSON_AddNumberToObject(io, "arg_a", o->arg_a);
@@ -3383,11 +3385,22 @@ static const char* ap_temperature_kind_name(uint8_t ap) {
     }
 }
 
+// For enum ("choice") params the API/UI works in opaque option-id space: the
+// value a client sees and PUTs back is the option's stable list index, never a
+// raw wire code. Scalar params pass their value through unchanged.
+static int16_t ap_value_to_client(uint8_t ap, int16_t read_value) {
+    if (arctic::advanced_enum_option_count(ap) > 0) {
+        int id = arctic::advanced_enum_option_index_for_wire(ap, read_value);
+        return (int16_t)(id < 0 ? 0 : id);
+    }
+    return read_value;
+}
+
 // Helper to add a single AP (advanced) parameter to a cJSON object, keyed "AP<n>".
 static void add_ap_to_json(cJSON* parent, const arctic::AdvancedParam* p, bool read_ok, int16_t value) {
     char key[8];
     snprintf(key, sizeof(key), "AP%u", (unsigned)p->ap);
-    const bool reg_known = (p->reg != arctic::ADV_REG_UNKNOWN);
+    const bool reg_known = arctic::advanced_param_reg_known(p->ap);
     const bool writable  = reg_known && !p->needs_sim_confirm && !p->read_only && !p->is_trigger;
     cJSON* obj = cJSON_CreateObject();
     cJSON_AddNumberToObject(obj, "ap", p->ap);
@@ -3396,7 +3409,7 @@ static void add_ap_to_json(cJSON* parent, const arctic::AdvancedParam* p, bool r
     cJSON_AddStringToObject(obj, "name_msg_id", p->name_msg_id ? p->name_msg_id : "");
     cJSON_AddStringToObject(obj, "detail_msg_id", p->detail_msg_id ? p->detail_msg_id : "");
     if (read_ok) {
-        cJSON_AddNumberToObject(obj, "value", value);
+        cJSON_AddNumberToObject(obj, "value", ap_value_to_client(p->ap, value));
     } else {
         cJSON_AddNullToObject(obj, "value");
     }
@@ -3441,7 +3454,7 @@ static esp_err_t heatpump_advanced_get_handler(httpd_req_t* req)
             const arctic::AdvancedParam* p = arctic::advanced_param_at(i);
             if (!p || !cat) continue;
             if (strcmp(p->category, cat) != 0) continue;
-            if (p->reg == arctic::ADV_REG_UNKNOWN) continue;  // hide unverified
+            if (!arctic::advanced_param_reg_known(p->ap)) continue;  // hide unverified
             int16_t value = 0;
             bool read_ok = advanced_param_read(p->ap, &value);
             add_ap_to_json(params, p, read_ok, value);
@@ -3483,7 +3496,7 @@ static esp_err_t heatpump_advanced_single_get_handler(httpd_req_t* req)
     }
     
     const arctic::AdvancedParam* p = arctic::advanced_param_lookup((uint8_t)ap_long);
-    if (!p || p->reg == arctic::ADV_REG_UNKNOWN) {
+    if (!p || !arctic::advanced_param_reg_known(p->ap)) {
         send_json_error(req, "404 Not Found", "Unknown advanced parameter");
         return ESP_OK;
     }
@@ -3496,7 +3509,7 @@ static esp_err_t heatpump_advanced_single_get_handler(httpd_req_t* req)
     cJSON* root = cJSON_CreateObject();
     char key[8];
     snprintf(key, sizeof(key), "AP%u", (unsigned)p->ap);
-    const bool writable = (p->reg != arctic::ADV_REG_UNKNOWN) && !p->needs_sim_confirm &&
+    const bool writable = arctic::advanced_param_reg_known(p->ap) && !p->needs_sim_confirm &&
                           !p->read_only && !p->is_trigger;
     cJSON_AddNumberToObject(root, "ap", p->ap);
     cJSON_AddStringToObject(root, "key", key);
@@ -3516,7 +3529,7 @@ static esp_err_t heatpump_advanced_single_get_handler(httpd_req_t* req)
     cJSON_AddBoolToObject(root, "writable", writable);
     add_ap_enum_options(root, p);
     if (read_ok) {
-        cJSON_AddNumberToObject(root, "value", value);
+        cJSON_AddNumberToObject(root, "value", ap_value_to_client(p->ap, value));
     } else {
         cJSON_AddNullToObject(root, "value");
     }
@@ -3566,7 +3579,7 @@ static esp_err_t heatpump_advanced_put_handler(httpd_req_t* req)
     uint8_t ap = (uint8_t)ap_long;
     
     const arctic::AdvancedParam* p = arctic::advanced_param_lookup(ap);
-    if (!p || p->reg == arctic::ADV_REG_UNKNOWN) {
+    if (!p || !arctic::advanced_param_reg_known(p->ap)) {
         send_json_error(req, "404 Not Found", "Unknown advanced parameter");
         return ESP_OK;
     }
@@ -3593,8 +3606,20 @@ static esp_err_t heatpump_advanced_put_handler(httpd_req_t* req)
     
     // Write through the arctic-macon guardrail (validates range/enum, confirmed
     // register, and write-lock) so we never blind-write an unverified/locked reg.
+    // For enum ("choice") params the body carries an opaque option id, not a
+    // wire value; the library maps the id to a wire code behind advanced_param_write_option.
     bool bus_ok = false;
-    arctic::AdvWriteResult r = advanced_param_write(ap, value, &bus_ok);
+    arctic::AdvWriteResult r;
+    if (arctic::advanced_enum_option_count(ap) > 0) {
+        if (val_long < 0) {
+            send_json_error(req, "400 Bad Request",
+                arctic::adv_write_result_name(arctic::AdvWriteResult::NOT_IN_ENUM));
+            return ESP_OK;
+        }
+        r = advanced_param_write_option(ap, (size_t)val_long, &bus_ok);
+    } else {
+        r = advanced_param_write(ap, value, &bus_ok);
+    }
     if (r != arctic::AdvWriteResult::OK) {
         send_json_error(req, "400 Bad Request", arctic::adv_write_result_name(r));
         return ESP_OK;
@@ -4031,17 +4056,27 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
         const size_t nparam = arctic::advanced_param_count();
         for (size_t i = 0; i < nparam; i++) {
             const arctic::AdvancedParam* p = arctic::advanced_param_at(i);
-            if (!p || p->reg == arctic::ADV_REG_UNKNOWN) continue;
+            if (!p || !arctic::advanced_param_reg_known(p->ap)) continue;
             int16_t value = 0;
             bool read_ok = advanced_param_read(p->ap, &value);
             const char* unit = arctic::advanced_display_unit(p->ap);
             if (!unit) unit = "";
+            // Register-address column: real addresses only in debug/test builds
+            // (see the "Register Address" gating above); blank in production so
+            // the CSV never surfaces the AP register map.
+#ifdef CONFIG_TEST_ENDPOINTS
+            char apaddr[12];
+            snprintf(apaddr, sizeof(apaddr), "%u",
+                     (unsigned)arctic::advanced_register_address(p->ap));
+#else
+            const char* apaddr = "";
+#endif
             if (read_ok) {
-                snprintf(line, sizeof(line), "Parameter,\"%s\",AP%u,%u,%d,%s\r\n",
-                         p->name, (unsigned)p->ap, p->reg, value, unit);
+                snprintf(line, sizeof(line), "Parameter,\"%s\",AP%u,%s,%d,%s\r\n",
+                         p->name, (unsigned)p->ap, apaddr, value, unit);
             } else {
-                snprintf(line, sizeof(line), "Parameter,\"%s\",AP%u,%u,READ_ERROR,%s\r\n",
-                         p->name, (unsigned)p->ap, p->reg, unit);
+                snprintf(line, sizeof(line), "Parameter,\"%s\",AP%u,%s,READ_ERROR,%s\r\n",
+                         p->name, (unsigned)p->ap, apaddr, unit);
             }
             httpd_resp_sendstr_chunk(req, line);
         }

--- a/main/heatpump_params_screen.cpp
+++ b/main/heatpump_params_screen.cpp
@@ -169,8 +169,8 @@ static void show_ap_trigger_confirm(uint8_t ap);
 static void ap_trigger_run_cb(lv_event_t* e);
 static void create_ap_section(lv_obj_t* parent);
 static void ap_update_display(int slot);
-static const char* enum_option_label(uint8_t ap, int wire);
-static void enum_option_desc(uint8_t ap, int wire, char* buf, size_t n);
+static const char* enum_option_label(uint8_t ap, int index);
+static void enum_option_desc(uint8_t ap, int index, char* buf, size_t n);
 
 // ============================================================================
 // Demo Setpoints (screen-local)
@@ -794,7 +794,15 @@ static void edit_save_cb(lv_event_t* e) {
         uint8_t ap = (uint8_t)state.current_ap;
         int16_t save_val = (int16_t)roundf(state.edit_value);
         bool bus_ok = false;
-        arctic::AdvWriteResult r = advanced_param_write(ap, save_val, &bus_ok);
+        // Enum ("choice") params store an opaque option id in edit_value; the
+        // library maps the id to a wire code behind advanced_param_write_option.
+        // Scalars write their value directly. The controller never sees the wire code.
+        arctic::AdvWriteResult r;
+        if (arctic::advanced_enum_option_count(ap) > 0) {
+            r = advanced_param_write_option(ap, (size_t)save_val, &bus_ok);
+        } else {
+            r = advanced_param_write(ap, save_val, &bus_ok);
+        }
         if (r == arctic::AdvWriteResult::OK && bus_ok) {
             ESP_LOGI(TAG, "Saved AP%u = %d", (unsigned)ap, save_val);
             // Refresh the row label for this AP.
@@ -887,10 +895,10 @@ static void edit_roller_cb(lv_event_t* e) {
     if (state.current_ap < 0) return;
     const arctic::AdvancedParam* p =
         arctic::advanced_param_lookup((uint8_t)state.current_ap);
-    if (!p || !p->enum_vals) return;
+    if (!p || arctic::advanced_enum_option_count(p->ap) == 0) return;
     uint32_t idx = lv_roller_get_selected(state.edit_roller);
-    if (idx >= p->enum_count) return;
-    state.edit_value = (float)p->enum_vals[idx];
+    if (idx >= arctic::advanced_enum_option_count(p->ap)) return;
+    state.edit_value = (float)idx;  // opaque option id (list index)
     update_edit_value_display();
 }
 
@@ -916,30 +924,32 @@ static void configure_slider_editor(int min_val, int max_val, int value,
     show_configured_editor();
 }
 
-static void configure_enum_editor(const arctic::AdvancedParam* p, int value) {
-    if (!p || !p->enum_vals || p->enum_count == 0) return;
+static void configure_enum_editor(const arctic::AdvancedParam* p, int wire_value) {
+    const size_t count = arctic::advanced_enum_option_count(p->ap);
+    if (!p || count == 0) return;
 
     char options[256] = {};
     size_t used = 0;
-    uint32_t selected = 0;
-    for (uint8_t i = 0; i < p->enum_count; i++) {
+    int sel = arctic::advanced_enum_option_index_for_wire(p->ap, (int16_t)wire_value);
+    uint32_t selected = (sel >= 0) ? (uint32_t)sel : 0;
+    for (size_t i = 0; i < count; i++) {
         const arctic::AdvEnumOption* option = arctic::advanced_enum_option_at(p->ap, i);
         char numeric[16];
         const char* label = nullptr;
         if (option && option->label && option->label[0]) {
             label = i18n_get_key(option->msg_id, option->label);
         } else {
-            snprintf(numeric, sizeof(numeric), "%u", (unsigned)p->enum_vals[i]);
+            snprintf(numeric, sizeof(numeric), "%u", (unsigned)i);
             label = numeric;
         }
         int written = snprintf(options + used, sizeof(options) - used, "%s%s",
                                i == 0 ? "" : "\n", label);
         if (written < 0 || (size_t)written >= sizeof(options) - used) break;
         used += (size_t)written;
-        if ((int)p->enum_vals[i] == value) selected = i;
     }
 
     state.edit_uses_enum = true;
+    state.edit_value = (float)selected;  // opaque option id (list index)
     lv_roller_set_options(state.edit_roller, options, LV_ROLLER_MODE_NORMAL);
     lv_roller_set_selected(state.edit_roller, selected, LV_ANIM_OFF);
     show_configured_editor();
@@ -1015,7 +1025,8 @@ static void update_edit_value_display(void) {
         lv_label_set_text(state.edit_value_label, "--");
         if (state.current_ap >= 0 && state.edit_description) {
             const arctic::AdvancedParam* p = arctic::advanced_param_lookup((uint8_t)state.current_ap);
-            if (p && p->enum_vals) lv_label_set_text(state.edit_description, "");
+            if (p && arctic::advanced_enum_option_count(p->ap) > 0)
+                lv_label_set_text(state.edit_description, "");
         }
         return;
     }
@@ -1025,7 +1036,7 @@ static void update_edit_value_display(void) {
     if (state.current_ap >= 0) {
         const arctic::AdvancedParam* p = arctic::advanced_param_lookup((uint8_t)state.current_ap);
         char val_buf[32];
-        if (p && p->enum_vals) {
+        if (p && arctic::advanced_enum_option_count(p->ap) > 0) {
             const char* s = enum_option_label((uint8_t)state.current_ap, display_val);
             if (s) snprintf(val_buf, sizeof(val_buf), "%s", s);
             else   snprintf(val_buf, sizeof(val_buf), "%d", display_val);
@@ -1071,18 +1082,19 @@ static void update_edit_value_display(void) {
 // plain-language description; both come from the shared macon library so the
 // controller never hardcodes the wire-code<->meaning mapping.
 
-// Display label for an enum wire code, sourced from the macon library.
-static const char* enum_option_label(uint8_t ap, int wire) {
+// Display label for an enum option id (list index), sourced from the macon library.
+static const char* enum_option_label(uint8_t ap, int index) {
+    if (index < 0) return nullptr;
     const arctic::AdvEnumOption* o =
-        arctic::advanced_enum_option_for_wire(ap, (int16_t)wire);
+        arctic::advanced_enum_option_at(ap, (size_t)index);
     return o ? o->label : nullptr;
 }
 
-// Localized human description of an enum choice. K-ratio options use structured
-// arguments; other enums use their keyed library fallback directly.
-static void enum_option_desc(uint8_t ap, int wire, char* buf, size_t n) {
-    const arctic::AdvEnumOption* o =
-        arctic::advanced_enum_option_for_wire(ap, (int16_t)wire);
+// Localized human description of an enum choice by option id. K-ratio options use
+// structured arguments; other enums use their keyed library fallback directly.
+static void enum_option_desc(uint8_t ap, int index, char* buf, size_t n) {
+    const arctic::AdvEnumOption* o = (index < 0) ? nullptr
+        : arctic::advanced_enum_option_at(ap, (size_t)index);
     if (!o) { if (n) buf[0] = '\0'; return; }
     if (strcmp(o->msg_id, "kratio_none") == 0) {
         snprintf(buf, n, "%s", i18n_get(STR_HP_KRATIO_NONE));
@@ -1096,8 +1108,9 @@ static void enum_option_desc(uint8_t ap, int wire, char* buf, size_t n) {
 // Format a AP parameter's raw register value into a display string.
 static void format_ap_value(const arctic::AdvancedParam* p, int16_t raw,
                             char* buf, size_t n) {
-    if (p->enum_vals) {
-        const char* s = enum_option_label(p->ap, raw);
+    if (arctic::advanced_enum_option_count(p->ap) > 0) {
+        int idx = arctic::advanced_enum_option_index_for_wire(p->ap, raw);
+        const char* s = enum_option_label(p->ap, idx);
         if (s) snprintf(buf, n, "%s", s);
         else   snprintf(buf, n, "%d", raw);
     } else if (arctic::advanced_display_unit(p->ap)) {
@@ -1146,7 +1159,7 @@ static void ap_row_cb(lv_event_t* e) {
 static void create_ap_row(lv_obj_t* parent, const arctic::AdvancedParam* p) {
     if (state.ap_display_count >= 64) return;
     const int slot = state.ap_display_count;
-    const bool reg_known = (p->reg != arctic::ADV_REG_UNKNOWN);
+    const bool reg_known = arctic::advanced_param_reg_known(p->ap);
     // Three interactive kinds + a passive locked kind:
     //   trigger   -> tappable, fires a momentary command (confirm dialog)
     //   read_only -> reg known but purpose unclear: displayed, not tappable
@@ -1228,7 +1241,7 @@ static void create_ap_section(lv_obj_t* parent) {
             const arctic::AdvancedParam* p = arctic::advanced_param_at(i);
             if (!p || !cat) continue;
             if (strcmp(p->category, cat) != 0) continue;
-            if (p->reg == arctic::ADV_REG_UNKNOWN) continue;  // hide unverified
+            if (!arctic::advanced_param_reg_known(p->ap)) continue;  // hide unverified
             if (!header_done) {
                 create_section_header(parent, cat);
                 header_done = true;
@@ -1279,7 +1292,7 @@ static void format_detail_temps(const char* tmpl, char* out, size_t out_sz) {
 
 static void show_ap_edit_dialog(uint8_t ap) {
     const arctic::AdvancedParam* p = arctic::advanced_param_lookup(ap);
-    if (!p || p->reg == arctic::ADV_REG_UNKNOWN || p->needs_sim_confirm) return;
+    if (!p || !arctic::advanced_param_reg_known(ap) || p->needs_sim_confirm) return;
 
     state.current_ap = ap;
     state.current_setpoint_type = -1;
@@ -1306,7 +1319,7 @@ static void show_ap_edit_dialog(uint8_t ap) {
     edit_label_set_or_hide(state.edit_detail, detail_buf);
 
     // Enum choices have a live meaning line; numeric sliders do not.
-    if (p->enum_vals) {
+    if (arctic::advanced_enum_option_count(ap) > 0) {
         lv_obj_remove_flag(state.edit_description, LV_OBJ_FLAG_HIDDEN);
         configure_enum_editor(p, v);
     } else {
@@ -1351,7 +1364,7 @@ static void ap_trigger_run_cb(lv_event_t* e) {
 
 static void show_ap_trigger_confirm(uint8_t ap) {
     const arctic::AdvancedParam* p = arctic::advanced_param_lookup(ap);
-    if (!p || !p->is_trigger || p->reg == arctic::ADV_REG_UNKNOWN) return;
+    if (!p || !p->is_trigger || !arctic::advanced_param_reg_known(ap)) return;
     s_trigger_ap = ap;
 
     lv_obj_t* mbox = lv_msgbox_create(lv_layer_top());

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -603,10 +603,10 @@
       let input;
       if (!p.writable) input = `<span class="badge">${p.value == null ? "--" : `${esc(value)} ${esc(displayUnit || "")}`}</span>`;
       else if (hasChoices) {
-        const selected = p.options.find(o => o.wire === p.value) || p.options[0];
+        const selected = p.options.find(o => o.id === p.value) || p.options[0];
         input = `<div class="choice-editor"><select name="value" class="choice-select"
           aria-label="${esc(p.name)} options">${p.options.map(o =>
-          `<option value="${o.wire}" data-description="${esc(o.en || "")}" ${o.wire === p.value ? "selected" : ""}>${esc(o.label)}</option>`).join("")}</select>
+          `<option value="${o.id}" data-description="${esc(o.en || "")}" ${o.id === p.value ? "selected" : ""}>${esc(o.label)}</option>`).join("")}</select>
           <div class="choice-description" aria-live="polite">${esc(selected.en || "")}</div></div>`;
       }
       else input = rangeEditor(value ?? min, min, max, isTemp ? 1 : (p.step || 1), displayUnit);

--- a/tests/api/test_opaque_macon_controller.py
+++ b/tests/api/test_opaque_macon_controller.py
@@ -7,8 +7,9 @@ that lives behind the arctic-macon library's typed/opaque APIs.
 Scope of the gate is the controller sources under ``main/`` only, excluding:
   * ``main/tuya/`` — the Macon master transport shim (relocated into the library
     in a later phase; not part of the opaque-consumer contract yet).
-  * ``advanced_params.{cpp,h}`` — the advanced-parameters subsystem is a
-    separate future phase and legitimately references raw registers.
+  * ``advanced_params.{cpp,h}`` — the advanced-parameters *quarantine wrapper*.
+    It is the sole controller file allowed to touch raw AP registers/wire codes,
+    translating the library's opaque option ids into wire writes (#118).
 """
 
 import re
@@ -51,6 +52,17 @@ FORBIDDEN_REG_NUMBER = re.compile(r"(?i)reg(?:ister)?s?\s*2[01]\d\d")
 
 # Any #include "name" / <name>; group 1 is the raw included path.
 INCLUDE_RE = re.compile(r'#\s*include\s*[<"]\s*([A-Za-z0-9_./]+)\s*[>"]')
+
+# Advanced-parameter wire/register metadata that must stay behind the library's
+# opaque option-id API (#118). In-scope consumers (api_server.cpp,
+# heatpump_params_screen.cpp, web/index.html handling) must consume stable option
+# ids + semantic accessors, never the raw AdvancedParam.reg register address, the
+# AdvEnumOption.wire RS485 code, the enum_vals/enum_count arrays, or the
+# ADV_REG_UNKNOWN sentinel. The advanced_params.{cpp,h} quarantine wrapper is the
+# sole excluded consumer (see EXCLUDED_FILES) — it owns the id<->wire mapping.
+FORBIDDEN_ADV_WIRE_META = re.compile(
+    r"\benum_vals\b|\benum_count\b|(?:->|\.)wire\b|(?:->|\.)reg\b|\bADV_REG_UNKNOWN\b"
+)
 
 # The arctic-macon library's public headers.
 MACON_INCLUDE = ROOT / "components" / "arctic-macon" / "include"
@@ -110,6 +122,19 @@ def test_controller_has_no_register_number_references():
         "main/ must not reference Macon wire register numbers in code, comments,\n"
         "or strings (protocol leak) — describe the value semantically instead:\n"
         + "\n".join(violations)
+    )
+
+
+def test_controller_has_no_advanced_param_wire_metadata():
+    violations = _scan(FORBIDDEN_ADV_WIRE_META)
+    assert not violations, (
+        "main/ must not read advanced-parameter wire/register metadata "
+        "(AdvancedParam.reg, AdvEnumOption.wire, enum_vals/enum_count, "
+        "ADV_REG_UNKNOWN). Consume the opaque option-id API "
+        "(advanced_enum_option_index_for_wire / advanced_param_write_option) and "
+        "semantic accessors (advanced_param_reg_known, advanced_register_address) "
+        "instead (#118). The advanced_params.{cpp,h} quarantine wrapper is the "
+        "only file allowed to touch these:\n" + "\n".join(violations)
     )
 
 


### PR DESCRIPTION
## What & why

Closes #118 (part of epic #124). The controller (`main/`) must carry **zero** Macon protocol/register knowledge. This PR closes the last advanced-parameter leaks: the wire enum code (`AdvEnumOption.wire`), the register address (`AdvancedParam.reg`), the raw `enum_vals`/`enum_count` arrays, and the `ADV_REG_UNKNOWN` sentinel — all of which had escaped the `arctic-macon` quarantine into `api_server.cpp`, `heatpump_params_screen.cpp`, and the web UI.

## Approach

**Library (`arctic-macon` PR #25 — merged, submodule bumped to `382216d`):** added an opaque option-id API — `advanced_enum_option_index_for_wire()` (wire→id) and `advanced_prepare_write_option()` (id→wire→guardrail) — that maps the option **list index ↔ wire** entirely behind the boundary.

**Controller:**
- `advanced_params.{cpp,h}` (the legitimate quarantine wrapper): add `advanced_param_write_option()` — the sole wire-handling write path.
- `api_server.cpp`: options emit a stable `"id"` (list index) not `"wire"`; enum GET values convert wire→id (`ap_value_to_client`); enum PUT bodies carry the id and route through `advanced_param_write_option`; reg checks use `advanced_param_reg_known()`; the `/diagnostic` CSV address column uses `advanced_register_address()` gated behind `CONFIG_TEST_ENDPOINTS` (blank in production).
- `heatpump_params_screen.cpp`: enum editing refactored into option-id (index) space — roller selection, `edit_value`, label/description, and save all use ids. On-device K-ratio now shows vendor labels (`0/0.25/0.5/1/2/3/4/5`) instead of raw wire codes, matching the web UI.
- `web/index.html`: options key on `o.id` instead of `o.wire`.

## Safety

Lossless bijection — `enum_opts[i].wire == enum_vals[i]`, so the **exact same wire byte** is still written. No functional or safety change; the library guardrail still rejects out-of-enum writes.

## Opacity gate

Added `test_controller_has_no_advanced_param_wire_metadata` forbidding `enum_vals`/`enum_count`, `->wire`/`.wire`, `->reg`/`.reg`, and `ADV_REG_UNKNOWN` anywhere in `main/` — with `advanced_params.{cpp,h}` as the sole excluded quarantine consumer. Gate: **6 passed**.

## Testing
- arctic-macon native tests: `all advanced-param tests passed`.
- Opacity gate + `test_api_schema.py`: green locally.
- On-device screen behavior is not hardware-testable here; the change is a display/selection refactor guarded by the unchanged library guardrail.
