### PR TITLE
chore(opacity #123): relocate listener/master ingest into library; drop tuya gate exclusion

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3317,7 +3317,7 @@ static esp_err_t heatpump_windows_handler(httpd_req_t* req)
 
     set_json_content_type(req);
 
-    static arctic::ObservedWindow wins[64];
+    static arctic::MaconObservedWindow wins[64];
     uint16_t n = arctic::getObservedWindows(wins, sizeof(wins) / sizeof(wins[0]));
 
     cJSON* root = cJSON_CreateObject();

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -9,6 +9,8 @@
 #include "event_log.h"
 #include "macon_state.h"
 #include "macon_image.h"
+#include "macon_listener.h"
+#include "macon_master.h"
 #include "macon_faults.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -93,6 +95,15 @@ static void ensureImageMutex() {
 
 static inline void imageLock()   { if (s_image_mutex) xSemaphoreTake(s_image_mutex, portMAX_DELAY); }
 static inline void imageUnlock() { if (s_image_mutex) xSemaphoreGive(s_image_mutex); }
+
+// Observed-window diagnostic catalog and the passive/active ingest engines all
+// live in the arctic-macon library, so the controller holds no frame, window,
+// or register knowledge. The listener drains passive-bus bytes; the image sink
+// ingests active-master poll windows. Both write s_image + s_observed under the
+// image lock (the caller serialises access).
+static MaconObservedCatalog s_observed;
+static MaconListener        s_listener(s_image, s_observed);
+static MaconImageSink       s_live_sink(s_image, s_observed);
 
 
 // Compare the freshly-updated s_state against the previous snapshot and record
@@ -506,72 +517,29 @@ uint16_t getRawRegisters(uint16_t* out, uint16_t max_count, uint16_t* base_out) 
     return n;
 }
 
-// ---------------------------------------------------------------------------
-// Observed-window diagnostic catalog
-// ---------------------------------------------------------------------------
-static constexpr uint16_t OBS_WIN_MAX = 64;
-static ObservedWindow s_obs_windows[OBS_WIN_MAX] = {};
-static uint16_t       s_obs_window_count = 0;
-static portMUX_TYPE   s_obs_mux = portMUX_INITIALIZER_UNLOCKED;
-
-void recordObservedWindow(uint16_t field_a, uint16_t field_b, uint8_t known,
-                          const uint8_t* payload, size_t len) {
-    const uint32_t now = getTimeMs();
-    const uint8_t cap = (uint8_t)sizeof(s_obs_windows[0].payload);
-    const uint8_t n = (uint8_t)((len < cap) ? len : cap);
-
-    portENTER_CRITICAL(&s_obs_mux);
-    ObservedWindow* slot = nullptr;
-    for (uint16_t i = 0; i < s_obs_window_count; ++i) {
-        if (s_obs_windows[i].field_a == field_a &&
-            s_obs_windows[i].field_b == field_b) {
-            slot = &s_obs_windows[i];
-            break;
-        }
-    }
-    if (slot == nullptr && s_obs_window_count < OBS_WIN_MAX) {
-        slot = &s_obs_windows[s_obs_window_count++];
-        slot->field_a = field_a;
-        slot->field_b = field_b;
-        slot->hits    = 0;
-    }
-    if (slot != nullptr) {
-        slot->known       = known;
-        slot->hits       += 1;
-        slot->last_ms     = now;
-        slot->payload_len = n;
-        for (uint8_t i = 0; i < n && payload != nullptr; ++i) {
-            slot->payload[i] = payload[i];
-        }
-    }
-    portEXIT_CRITICAL(&s_obs_mux);
+MaconListenerStats getListenerStats() {
+    imageLock();
+    MaconListenerStats s = s_listener.stats();
+    imageUnlock();
+    return s;
 }
 
-uint16_t getObservedWindows(ObservedWindow* out, uint16_t max_count) {
+uint16_t getObservedWindows(MaconObservedWindow* out, uint16_t max_count) {
     if (out == nullptr || max_count == 0) return 0;
-    portENTER_CRITICAL(&s_obs_mux);
-    uint16_t n = (s_obs_window_count < max_count) ? s_obs_window_count : max_count;
+    imageLock();
+    uint16_t n = (uint16_t)s_observed.count();
+    if (n > max_count) n = max_count;
     for (uint16_t i = 0; i < n; ++i) {
-        out[i] = s_obs_windows[i];
+        out[i] = *s_observed.at(i);
     }
-    portEXIT_CRITICAL(&s_obs_mux);
+    imageUnlock();
     return n;
 }
 
-void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count) {
-    if (!s_feed_mode || regs == nullptr || count == 0) {
-        return;
-    }
-
-    const uint32_t now = getTimeMs();
-
-    // Feed the window into the opaque image; it reports which decode-relevant
-    // windows were covered (status / telemetry) without exposing any register
-    // number to the controller.
-    imageLock();
-    const MaconCoverage cov = s_image.ingest_bytes(reg_base, regs, count);
-    imageUnlock();
-
+// Re-sync HeatPumpState from the freshly-ingested image and update connection
+// bookkeeping. Shared by the passive listener and the active-master paths. The
+// caller must NOT hold the image lock (applyMaconMapping re-acquires it).
+static void applyIngestResult(const MaconCoverage& cov, uint32_t now) {
     // Map the image into HeatPumpState using the library-owned decode.
     applyMaconMapping();
 
@@ -582,7 +550,7 @@ void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count) {
     s_state.last_successful_read_ms = now;
     s_state.last_attempt_ms = s_state.last_successful_read_ms;
     s_state.consecutive_failures = 0;
-    // Log operational transitions for the Tuya feed path.
+    // Log operational transitions for the ingest path.
     detectAndLogStateEvents();
     const uint8_t f_run  = s_state.fault_run;
     const uint8_t f_ee   = s_state.fault_ee;
@@ -594,10 +562,44 @@ void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count) {
     updateErrorHistory(f_run, f_ee, f_comp, f_elec, f_ref);
 
     if (!s_was_connected) {
-        ESP_LOGI(TAG, "Heat pump connected (passive feed)");
+        ESP_LOGI(TAG, "Heat pump connected");
         s_was_connected = true;
         event_log_record(EVENT_CONNECTED, 0);
     }
+}
+
+void feedListenerBytes(const uint8_t* data, size_t len) {
+    if (!s_feed_mode || data == nullptr || len == 0) {
+        return;
+    }
+
+    const uint32_t now = getTimeMs();
+
+    // The library drains frames and ingests decoded response windows straight
+    // into the opaque image, returning only semantic coverage — no register
+    // number ever crosses back to the controller.
+    imageLock();
+    const MaconFeedResult r = s_listener.feed_bytes(data, len, now);
+    imageUnlock();
+
+    if (!r.any_response) return;
+    applyIngestResult(r.coverage, now);
+}
+
+// --- active bus-master live ingest -----------------------------------------
+MaconWindowSink& liveIngestSink() { return s_live_sink; }
+
+void liveIngestBeginCycle() {
+    imageLock();
+    s_live_sink.set_now_ms(getTimeMs());
+}
+
+void liveIngestEndCycle() {
+    const bool any = s_live_sink.any_since_reset();
+    const MaconCoverage cov = s_live_sink.take_coverage();
+    imageUnlock();
+    if (!any) return;
+    applyIngestResult(cov, getTimeMs());
 }
 
 TelemetrySnapshot getTelemetrySnapshot() {

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -9,8 +9,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include "heatpump_types.h"
+#include "macon_listener.h"   // MaconObservedWindow, MaconObservedCatalog, MaconListenerStats
 
 namespace arctic {
+
+class MaconWindowSink;   // fwd (defined in macon_master.h); used by liveIngestSink()
 
 // ============================================================================
 // Heat Pump State Structure
@@ -213,9 +216,10 @@ void clearDemoFaults();
 // ============================================================================
 // External Feed (passive Tuya listen mode)
 // ============================================================================
-// Populates HeatPumpState from register windows decoded off the RS485 bus by
-// the passive Tuya listener. The Tab5
-// never transmits in this mode. Registers are 1 byte each on the Tuya wire.
+// Populates HeatPumpState from frames decoded off the RS485 bus by the passive
+// listener. The Tab5 never transmits in this mode. All frame/register/window
+// decoding happens inside the arctic-macon library, so no register address ever
+// crosses into the controller.
 
 // Initialize external-feed mode (creates the state mutex, clears state).
 void initExternalFeed();
@@ -223,37 +227,44 @@ void initExternalFeed();
 // Returns true if running in external-feed (passive listen) mode.
 bool isExternalFeed();
 
-// Feed a decoded register window (reg_base..reg_base+count-1, one byte per
-// register) into the state. Re-syncs HeatPumpState and marks it connected.
-// Safe to call from the listener task.
-void feedRegisterWindow(uint16_t reg_base, const uint8_t* regs, size_t count);
+// Feed raw bytes read off the RS485 bus by the passive listener. The library
+// drains complete frames, ingests decoded response windows into the opaque
+// register image, and catalogs observed windows — all internally, so the
+// controller carries no wire knowledge. Re-syncs HeatPumpState and marks it
+// connected when a decode-relevant response arrives. Safe to call from the
+// listener task.
+void feedListenerBytes(const uint8_t* data, size_t len);
+
+// Snapshot of the library listener statistics (diagnostics / heartbeat).
+MaconListenerStats getListenerStats();
 
 // Debug/calibration: copy the raw fed register cache into `out` (up to
 // `max_count` entries). Returns the number of registers copied. `base_out`
 // receives the register number of index 0 (DEMO_REG_BASE).
 uint16_t getRawRegisters(uint16_t* out, uint16_t max_count, uint16_t* base_out);
 
-// Diagnostic: a distinct (field_a, field_b) response window observed on the
-// Tuya bus, with the FULL payload (including any window prefix bytes that
-// feedRegisterWindow() strips). Used to hunt for register blocks the codec
-// doesn't yet map (e.g. compressor frequency).
-struct ObservedWindow {
-    uint16_t field_a;       // wire addr field
-    uint16_t field_b;       // wire count field (payload byte length)
-    uint32_t hits;          // times this window has been seen
-    uint32_t last_ms;       // timestamp of most recent sighting
-    uint8_t  known;         // 1 if the codec maps it to a register base
-    uint8_t  payload_len;   // bytes captured (<= sizeof(payload))
-    uint8_t  payload[64];   // most-recent full payload (incl. prefix)
-};
+// Copy the library-owned observed-window diagnostic catalog into `out` (up to
+// `max_count`). Returns the number of distinct windows recorded.
+uint16_t getObservedWindows(MaconObservedWindow* out, uint16_t max_count);
 
-// Record a response window (known or unknown) into the diagnostic catalog.
-// Called by the listener for every parsed response frame.
-void recordObservedWindow(uint16_t field_a, uint16_t field_b, uint8_t known,
-                          const uint8_t* payload, size_t len);
+// ============================================================================
+// Active bus-master live ingest
+// ============================================================================
+// The active-master shim (main/tuya) drives the library MaconMaster with the
+// sink returned by liveIngestSink(), which ingests decoded windows into the
+// opaque image internally (no register address reaches the shim). A poll cycle
+// is bracketed by liveIngestBeginCycle()/liveIngestEndCycle(): begin acquires
+// the image lock so the sink's ingest is serialised, end applies the mapping
+// and connection bookkeeping if any response was seen.
 
-// Copy the observed-window catalog into `out` (up to `max_count`). Returns the
-// number of distinct windows recorded.
-uint16_t getObservedWindows(ObservedWindow* out, uint16_t max_count);
+// The window sink the active master feeds decoded windows into.
+MaconWindowSink& liveIngestSink();
+
+// Acquire the image lock ahead of an active-master poll cycle.
+void liveIngestBeginCycle();
+
+// Release the image lock after an active-master poll cycle and, if any response
+// was ingested, re-sync HeatPumpState and update connection bookkeeping.
+void liveIngestEndCycle();
 
 }  // namespace arctic

--- a/main/tuya/macon_master.cpp
+++ b/main/tuya/macon_master.cpp
@@ -7,12 +7,12 @@
  *
  *   * the concrete RS485 UART transport (tuya::MaconUartTransport),
  *   * a monotonic clock over esp_timer (EspClock),
- *   * a window sink that routes decoded windows into HeatPumpState
- *     (ControllerSink -> feedRegisterWindow / recordObservedWindow),
  *   * the FreeRTOS poll task and the bus mutex that serialises transactions.
  *
- * The controller carries no Tuya/Macon wire knowledge: every register/bit/frame
- * detail is behind the library API.
+ * Decoded windows are ingested into the opaque register image by the library
+ * sink returned from arctic::liveIngestSink(); a poll cycle is bracketed by
+ * arctic::liveIngestBeginCycle()/liveIngestEndCycle(). No register/bit/frame
+ * detail ever reaches this shim — it is all behind the library API.
  */
 #include "macon_master_iface.h"    // this module's public API (macon_master::)
 
@@ -25,9 +25,9 @@
 #include "esp_timer.h"
 
 #include "macon_uart_transport.h"   // tuya::MaconUartTransport
-#include "macon_master.h"           // arctic::MaconMaster / MaconClock / MaconWindowSink
+#include "macon_master.h"           // arctic::MaconMaster / MaconClock
 #include "macon_link.h"             // arctic::MaconResult / macon_result_name
-#include "heatpump_controller.h"    // feedRegisterWindow / recordObservedWindow
+#include "heatpump_controller.h"    // arctic::liveIngestSink / liveIngestBeginCycle / liveIngestEndCycle
 
 static const char *TAG = "macon_master";
 
@@ -53,25 +53,11 @@ public:
     }
 };
 
-// Routes windows decoded by the master into HeatPumpState. Keeps the library
-// free of any controller-state knowledge.
-class ControllerSink : public arctic::MaconWindowSink {
-public:
-    void on_window(uint16_t reg_base, const uint8_t *data, size_t len) override {
-        arctic::feedRegisterWindow(reg_base, data, len);
-    }
-    void on_observed(uint16_t field_a, uint16_t field_b,
-                     const uint8_t *payload, size_t payload_len) override {
-        arctic::recordObservedWindow(field_a, field_b, 1, payload, payload_len);
-    }
-};
-
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 static tuya::MaconUartTransport s_transport;   // trivial ctor; hardware set up in init()
 static EspClock                 s_clock;
-static ControllerSink           s_sink;
 static arctic::MaconMaster     *s_master      = nullptr;
 static SemaphoreHandle_t        s_bus_mutex   = nullptr;
 static TaskHandle_t             s_task        = nullptr;
@@ -89,12 +75,20 @@ static void poll_task(void *)
     ESP_LOGI(TAG, "Active-master poll task started");
     for (;;) {
         if (s_bus_mutex && s_master) {
+            // Each poll cycle is bracketed by the controller's image-lock so the
+            // library sink can ingest decoded windows internally; the bus mutex
+            // is released between polls so a UI/REST write waits at most one
+            // in-flight transaction.
             xSemaphoreTake(s_bus_mutex, portMAX_DELAY);
-            s_master->poll_holding();     // regs 2000.. (electrical/status/mode)
+            arctic::liveIngestBeginCycle();
+            s_master->poll_holding();
+            arctic::liveIngestEndCycle();
             xSemaphoreGive(s_bus_mutex);
 
             xSemaphoreTake(s_bus_mutex, portMAX_DELAY);
-            s_master->poll_telemetry();   // regs 2093.. (setpoint/temps/EEV)
+            arctic::liveIngestBeginCycle();
+            s_master->poll_telemetry();
+            arctic::liveIngestEndCycle();
             xSemaphoreGive(s_bus_mutex);
         }
         vTaskDelay(pdMS_TO_TICKS(POLL_INTERVAL_MS));
@@ -119,7 +113,8 @@ esp_err_t init()
         }
     }
     if (s_master == nullptr) {
-        s_master = new arctic::MaconMaster(s_transport, s_clock, s_sink,
+        s_master = new arctic::MaconMaster(s_transport, s_clock,
+                                           arctic::liveIngestSink(),
                                            RESP_TIMEOUT_MS, POLL_TXN_DEADLINE_MS);
     }
 

--- a/main/tuya/tuya_listener.cpp
+++ b/main/tuya/tuya_listener.cpp
@@ -1,9 +1,12 @@
 /*
  * Passive Tuya bus listener implementation. See tuya_listener.h.
+ *
+ * This file is only the platform glue: it installs an RX-only UART on the
+ * RS485 pins and pumps the raw bytes into the arctic-macon library, which owns
+ * ALL framing/register/window decoding. The controller (and this shim) carry no
+ * Tuya/Macon wire knowledge — bytes go in, semantic state comes out.
  */
 #include "tuya_listener.h"
-
-#include <string.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -12,9 +15,8 @@
 #include "driver/uart.h"
 #include "driver/gpio.h"
 
-#include "tuya_codec.h"
 #include "macon_bus_config.h"
-#include "heatpump_controller.h"  // arctic::feedRegisterWindow
+#include "heatpump_controller.h"  // arctic::feedListenerBytes / getListenerStats
 
 static const char *TAG = "tuya_listen";
 
@@ -28,12 +30,9 @@ namespace tuya {
 static constexpr uart_port_t UART_PORT   = UART_NUM_1;
 static constexpr int         TUYA_BAUD   = 4800;
 static constexpr size_t      RX_BUF_SIZE = 2048;   // driver ring buffer
-static constexpr size_t      ACC_SIZE    = 512;    // decode accumulator
-static constexpr size_t      MAX_HEXBUF  = 200;    // hex string scratch (58 regs*3 + slack)
+static constexpr size_t      READ_CHUNK  = 256;    // per read_bytes slice
 
 static bool          s_initialized = false;
-static ListenerStats s_stats       = {};
-static portMUX_TYPE  s_mux         = portMUX_INITIALIZER_UNLOCKED;
 static TaskHandle_t  s_task        = nullptr;
 
 // ---------------------------------------------------------------------------
@@ -45,137 +44,16 @@ static uint32_t now_ms()
     return (uint32_t)(esp_timer_get_time() / 1000);
 }
 
-// Format up to `len` bytes as space-separated hex into `out`.
-static void hex_dump(const uint8_t *data, size_t len, char *out, size_t out_cap)
-{
-    size_t pos = 0;
-    for (size_t i = 0; i < len && pos + 3 < out_cap; ++i) {
-        pos += snprintf(out + pos, out_cap - pos, "%02X ", data[i]);
-    }
-    if (out_cap > 0) out[(pos > 0 && pos < out_cap) ? pos - 1 : 0] = '\0';
-}
-
-static void log_frame(const uint8_t *frame, const tuya_codec::ParsedFrame &pf)
-{
-    static char hexbuf[MAX_HEXBUF];
-    if (pf.dir == tuya_codec::DIR_REQUEST) {
-        hex_dump(frame, pf.frame_len, hexbuf, sizeof(hexbuf));
-        ESP_LOGI(TAG, "REQ  reg%u cnt%u  [%s]",
-                 (unsigned)pf.window->reg_base, (unsigned)pf.field_b, hexbuf);
-    } else {
-        // For responses show the register payload (after the window prefix).
-        const uint8_t *regs = pf.payload + pf.window->prefix_len;
-        size_t reg_len = (pf.payload_len > pf.window->prefix_len)
-                             ? pf.payload_len - pf.window->prefix_len
-                             : 0;
-        hex_dump(regs, reg_len, hexbuf, sizeof(hexbuf));
-        ESP_LOGI(TAG, "RESP reg%u cnt%u  regs[%s]",
-                 (unsigned)pf.window->reg_base, (unsigned)pf.field_b, hexbuf);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Decode accumulator drain
-// ---------------------------------------------------------------------------
-//
-// Consumes as many complete frames as possible from the front of `acc`.
-// Returns the number of bytes consumed; the caller shifts the remainder.
-//
-static size_t drain(const uint8_t *acc, size_t acc_len)
-{
-    size_t consumed = 0;
-    while (acc_len - consumed >= tuya_codec::HDR_LEN) {
-        const uint8_t *p   = acc + consumed;
-        size_t         rem = acc_len - consumed;
-
-        // Locate the next plausible frame start (validated header).
-        size_t start = tuya_codec::find_frame_start(p, rem);
-        if (start == rem) {
-            // No frame start in the buffer. Drop everything except a possible
-            // partial magic at the tail (keep last HDR_LEN-1 bytes).
-            size_t keep = (rem < tuya_codec::HDR_LEN - 1) ? rem
-                                                          : tuya_codec::HDR_LEN - 1;
-            consumed = acc_len - keep;
-            break;
-        }
-        if (start > 0) {
-            // Junk before the frame start -> resync.
-            portENTER_CRITICAL(&s_mux);
-            s_stats.resync++;
-            portEXIT_CRITICAL(&s_mux);
-            consumed += start;
-            continue;
-        }
-
-        tuya_codec::ParsedFrame pf;
-        tuya_codec::ParseResult r =
-            tuya_codec::parse_frame(acc + consumed, acc_len - consumed, pf);
-
-        if (r == tuya_codec::ParseResult::OK) {
-            portENTER_CRITICAL(&s_mux);
-            s_stats.frames_ok++;
-            if (pf.dir == tuya_codec::DIR_REQUEST) s_stats.req_frames++;
-            else                                   s_stats.resp_frames++;
-            s_stats.last_frame_ms = now_ms();
-            portEXIT_CRITICAL(&s_mux);
-            log_frame(acc + consumed, pf);
-
-            // Feed response payloads (heat pump -> controller) into the state.
-            if (pf.dir == tuya_codec::DIR_RESPONSE && pf.window &&
-                pf.payload_len > pf.window->prefix_len) {
-                arctic::feedRegisterWindow(
-                    pf.window->reg_base,
-                    pf.payload + pf.window->prefix_len,
-                    pf.payload_len - pf.window->prefix_len);
-            }
-            // Catalog the FULL payload (incl. any window prefix bytes that the
-            // feed strips) for diagnostics.
-            if (pf.dir == tuya_codec::DIR_RESPONSE) {
-                arctic::recordObservedWindow(pf.field_a, pf.field_b, 1,
-                                             pf.payload, pf.payload_len);
-            }
-            consumed += pf.frame_len;
-        } else if (r == tuya_codec::ParseResult::UNKNOWN_WINDOW) {
-            // Valid framing + checksum but a window the codec doesn't map. This
-            // is exactly how a not-yet-decoded register block (e.g. compressor
-            // frequency) shows up. Catalog it and skip the whole frame.
-            portENTER_CRITICAL(&s_mux);
-            s_stats.frames_ok++;
-            s_stats.resp_frames++;
-            s_stats.last_frame_ms = now_ms();
-            portEXIT_CRITICAL(&s_mux);
-            if (pf.dir == tuya_codec::DIR_RESPONSE) {
-                arctic::recordObservedWindow(pf.field_a, pf.field_b, 0,
-                                             pf.payload, pf.payload_len);
-            }
-            ESP_LOGW(TAG, "UNKNOWN window addr=%u count=%u (cataloged)",
-                     (unsigned)pf.field_a, (unsigned)pf.field_b);
-            consumed += pf.frame_len;
-        } else if (r == tuya_codec::ParseResult::TRUNCATED) {
-            // Wait for more bytes before this frame can be parsed.
-            break;
-        } else {
-            // Header looked valid but checksum (or length) failed. Skip past
-            // the magic and resync.
-            if (r == tuya_codec::ParseResult::BAD_CHECKSUM) {
-                portENTER_CRITICAL(&s_mux);
-                s_stats.checksum_err++;
-                portEXIT_CRITICAL(&s_mux);
-            }
-            consumed += 2;
-        }
-    }
-    return consumed;
-}
-
 // ---------------------------------------------------------------------------
 // Receive task
 // ---------------------------------------------------------------------------
-
+//
+// Reads raw bytes and hands them to the library decoder. The library owns the
+// frame accumulator, resync state machine, statistics, and register ingest.
+//
 static void rx_task(void *param)
 {
-    static uint8_t acc[ACC_SIZE];
-    size_t         acc_len       = 0;
+    static uint8_t buf[READ_CHUNK];
     uint32_t       last_idle_log = now_ms();
     uint32_t       frames_at_log = 0;
 
@@ -183,28 +61,9 @@ static void rx_task(void *param)
              TUYA_BAUD, arctic::RS485_RX_PIN, arctic::RS485_DIR_PIN);
 
     for (;;) {
-        int n = uart_read_bytes(UART_PORT, acc + acc_len, ACC_SIZE - acc_len,
-                                pdMS_TO_TICKS(50));
+        int n = uart_read_bytes(UART_PORT, buf, sizeof(buf), pdMS_TO_TICKS(50));
         if (n > 0) {
-            acc_len += (size_t)n;
-            portENTER_CRITICAL(&s_mux);
-            s_stats.bytes_rx += (uint32_t)n;
-            portEXIT_CRITICAL(&s_mux);
-
-            size_t consumed = drain(acc, acc_len);
-            if (consumed > 0 && consumed <= acc_len) {
-                memmove(acc, acc + consumed, acc_len - consumed);
-                acc_len -= consumed;
-            }
-            // Safety valve: if the accumulator is full and nothing drained,
-            // the stream is garbage -> reset.
-            if (acc_len == ACC_SIZE) {
-                ESP_LOGW(TAG, "Accumulator full with no frame; resetting");
-                acc_len = 0;
-                portENTER_CRITICAL(&s_mux);
-                s_stats.resync++;
-                portEXIT_CRITICAL(&s_mux);
-            }
+            arctic::feedListenerBytes(buf, (size_t)n);
         }
 
         // Heartbeat every 5s so we can confirm the task is alive on the bench
@@ -301,11 +160,18 @@ void listener_start()
 
 ListenerStats listener_get_stats()
 {
-    ListenerStats snap;
-    portENTER_CRITICAL(&s_mux);
-    snap = s_stats;
-    portEXIT_CRITICAL(&s_mux);
-    return snap;
+    // Delegate to the library-owned statistics; the controller carries no
+    // frame-decode state of its own.
+    const arctic::MaconListenerStats s = arctic::getListenerStats();
+    ListenerStats out;
+    out.bytes_rx      = s.bytes_rx;
+    out.frames_ok     = s.frames_ok;
+    out.req_frames    = s.req_frames;
+    out.resp_frames   = s.resp_frames;
+    out.checksum_err  = s.checksum_err;
+    out.resync        = s.resync;
+    out.last_frame_ms = s.last_frame_ms;
+    return out;
 }
 
 }  // namespace tuya

--- a/tests/api/test_opaque_macon_controller.py
+++ b/tests/api/test_opaque_macon_controller.py
@@ -1,15 +1,19 @@
 """Guard the opaque-Macon boundary in the controller (main/).
 
 The controller must carry ZERO Tuya/Macon protocol knowledge: no register-map
-header, no REG_* register symbols, and no OEM fault-code string literals. All of
-that lives behind the arctic-macon library's typed/opaque APIs.
+header, no REG_* register symbols, no OEM fault-code string literals, no wire
+register numbers, and no raw-register/frame plumbing. All of that lives behind
+the arctic-macon library's typed/opaque APIs — including the passive listener,
+the active bus-master engine, and the observed-window catalog (#123).
 
 Scope of the gate is the controller sources under ``main/`` only, excluding:
-  * ``main/tuya/`` — the Macon master transport shim (relocated into the library
-    in a later phase; not part of the opaque-consumer contract yet).
   * ``advanced_params.{cpp,h}`` — the advanced-parameters *quarantine wrapper*.
     It is the sole controller file allowed to touch raw AP registers/wire codes,
     translating the library's opaque option ids into wire writes (#118).
+
+Note: ``main/tuya/`` (the RS485 transport + master/listener shims) is now IN
+scope — after #123 relocated all frame/register/window decoding into the
+library, those files are pure platform glue and carry no wire knowledge.
 """
 
 import re
@@ -26,7 +30,7 @@ THIS_FILE = Path(__file__).resolve()
 SOURCE_SUFFIXES = {".cpp", ".h", ".hpp", ".c", ".cc"}
 
 # Directories (relative to main/) that are out of scope for the gate.
-EXCLUDED_DIR_PARTS = {"tuya"}
+EXCLUDED_DIR_PARTS = set()
 # Individual files (relative to main/) that are out of scope for the gate.
 EXCLUDED_FILES = {"advanced_params.cpp", "advanced_params.h"}
 # Generated font / image blobs — huge and never contain protocol knowledge.
@@ -62,6 +66,14 @@ INCLUDE_RE = re.compile(r'#\s*include\s*[<"]\s*([A-Za-z0-9_./]+)\s*[>"]')
 # sole excluded consumer (see EXCLUDED_FILES) — it owns the id<->wire mapping.
 FORBIDDEN_ADV_WIRE_META = re.compile(
     r"\benum_vals\b|\benum_count\b|(?:->|\.)wire\b|(?:->|\.)reg\b|\bADV_REG_UNKNOWN\b"
+)
+
+# Raw-register/frame plumbing that #123 relocated into the library. The
+# controller feeds opaque bytes (feedListenerBytes) or drives the library sink
+# (liveIngestSink); it must never name a register base, a per-window register
+# feed, or the observed-window recorder — those all imply wire knowledge.
+FORBIDDEN_RAW_REGISTER_PLUMBING = re.compile(
+    r"\bfeedRegisterWindow\b|\brecordObservedWindow\b|\breg_base\b"
 )
 
 # The arctic-macon library's public headers.
@@ -135,6 +147,17 @@ def test_controller_has_no_advanced_param_wire_metadata():
         "semantic accessors (advanced_param_reg_known, advanced_register_address) "
         "instead (#118). The advanced_params.{cpp,h} quarantine wrapper is the "
         "only file allowed to touch these:\n" + "\n".join(violations)
+    )
+
+
+def test_controller_has_no_raw_register_plumbing():
+    violations = _scan(FORBIDDEN_RAW_REGISTER_PLUMBING)
+    assert not violations, (
+        "main/ must not carry raw-register/frame plumbing (feedRegisterWindow, "
+        "recordObservedWindow, reg_base). Feed opaque bytes via "
+        "feedListenerBytes() or drive the library sink via liveIngestSink(); the "
+        "arctic-macon library owns all register/window decoding (#123):\n"
+        + "\n".join(violations)
     )
 
 


### PR DESCRIPTION
Relocates the **last** of the Macon wire logic out of the arctic-controller and behind opaque library APIs. After this, `main/` (including `main/tuya/`) carries **zero** frame/register/window knowledge — it is pure platform glue.

Depends on library **sslivins/arctic-macon#26** (merged; submodule bumped to `1c8faff`).

## Library (via submodule bump)
- **`MaconListener`** — portable passive-listen frame decoder (drain/resync state machine), ingests decoded windows into the opaque `MaconImage` and catalogs observed windows; `feed_bytes()` returns only semantic `MaconCoverage`.
- **`MaconObservedCatalog`** — shared observed-window store.
- **`MaconImageSink`** — active-master `MaconWindowSink` that ingests internally, so the master path also never sees `reg_base`.

## Controller
- `heatpump_controller`: `feedRegisterWindow()` → **`feedListenerBytes()`** (opaque bytes in, semantic coverage out). Owns `s_listener` + `s_observed` + `s_live_sink`; exposes `liveIngestSink()` / `liveIngestBeginCycle()` / `liveIngestEndCycle()` for the active master. `getObservedWindows()` now returns `MaconObservedWindow`; adds `getListenerStats()`. Removes the controller-side `ObservedWindow` struct + `recordObservedWindow()`.
- `main/tuya/tuya_listener`: strips the drain/log/hex/stats state machine — the RX task just pumps UART bytes into `feedListenerBytes()`; stats delegate to the library.
- `main/tuya/macon_master`: drops `ControllerSink`; feeds `arctic::liveIngestSink()` to `MaconMaster` and brackets each poll cycle with begin/end; removes the `reg 2000/2093` comments.
- `api_server`: `/windows` uses `MaconObservedWindow`.

## Opacity gate
- Removes the `"tuya"` directory exclusion (`main/tuya` is now in scope and clean).
- Adds `test_controller_has_no_raw_register_plumbing` (forbids `feedRegisterWindow`, `recordObservedWindow`, `reg_base`).

## Validation
- Opacity gate **7/7**.
- Both library native suites green (incl. new `MaconListener` + `MaconImageSink` cases).
- Full **esp32p4 `idf.py build` green**.

Closes #123. Part of #124.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
