### PR TITLE
feat(fan): fan speed as RPM + library-provided full-scale for bars

### DIFF
--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -467,6 +467,7 @@ static void applyMaconMapping() {
     s_state.working_mode    = to_working_mode(ms);
     s_state.operation       = to_operation(ms);
     s_state.fan_speed       = ms.fan_level;
+    s_state.fan_speed_max   = ms.fan_speed_max;
 
     // Electrical readings.
     s_state.ac_current          = ms.ac_current;

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -291,7 +291,7 @@ void initDemoState() {
     s_image.set_value(MaconField::AcCurrent, 5);        // A
     s_image.set_value(MaconField::AcVoltage, 230);      // V
     s_image.set_value(MaconField::DcVoltage, 380);      // V
-    s_image.set_value(MaconField::FanLevel, 400);      // RPM (raw DC motor level ×10)
+    s_image.set_value(MaconField::FanLevel, 400);      // RPM
     s_image.set_value(MaconField::PrimaryEev, 200);     // EEV steps
     s_image.set_value(MaconField::CompressorFreq, 60);  // Hz
     s_image.set_value(MaconField::RealtimePower, 1200); // W

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -291,7 +291,7 @@ void initDemoState() {
     s_image.set_value(MaconField::AcCurrent, 5);        // A
     s_image.set_value(MaconField::AcVoltage, 230);      // V
     s_image.set_value(MaconField::DcVoltage, 380);      // V
-    s_image.set_value(MaconField::FanLevel, 40);        // raw DC motor level
+    s_image.set_value(MaconField::FanLevel, 400);      // RPM (raw DC motor level ×10)
     s_image.set_value(MaconField::PrimaryEev, 200);     // EEV steps
     s_image.set_value(MaconField::CompressorFreq, 60);  // Hz
     s_image.set_value(MaconField::RealtimePower, 1200); // W

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -47,7 +47,7 @@ struct HeatPumpState {
     
     // System readings (decoded by the macon library from the real Tuya window)
     uint16_t compressor_freq = 0;    // Hz
-    uint16_t fan_speed = 0;          // raw DC fan-motor level (0..~72), owned by macon lib
+    uint16_t fan_speed = 0;          // fan speed in RPM (raw DC motor level ×10, ~0..720), owned by macon lib
     uint16_t ac_voltage = 0;         // V
     uint16_t ac_current = 0;         // A
     uint16_t dc_voltage = 0;         // V (volts; unit conversion owned by macon lib)
@@ -92,13 +92,13 @@ struct HeatPumpState {
     // DC bus voltage in volts (already converted by the macon library).
     float getDcVoltageV() const { return static_cast<float>(dc_voltage); }
 
-    // Fan UI level (0=off..3=high) bucketed from the raw fan-motor level.
+    // Fan UI level (0=off..3=high) bucketed from the fan RPM (raw level ×10).
     // TODO(fan-rework): replace with bars = round(fan_speed/fan_speed_max*N)
     // once the library exposes fan_speed + fan_speed_max.
     int getFanSpeedLevel() const {
         if (!fan_running || fan_speed == 0) return 0;
-        if (fan_speed >= 60) return 3;
-        if (fan_speed >= 30) return 2;
+        if (fan_speed >= 600) return 3;
+        if (fan_speed >= 300) return 2;
         return 1;
     }
 };

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -30,7 +30,7 @@ struct HeatPumpState {
     bool unit_on = false;
     WorkingMode working_mode = WorkingMode::COOLING;
     HeatPumpOperation operation = HeatPumpOperation::UNKNOWN;
-    int16_t cooling_setpoint = 0;    // °C (raw value, may need /10)
+    int16_t cooling_setpoint = 0;    // °C
     int16_t heating_setpoint = 0;    // °C
     int16_t hot_water_setpoint = 0;  // °C
     
@@ -47,7 +47,7 @@ struct HeatPumpState {
     
     // System readings (decoded by the macon library from the real Tuya window)
     uint16_t compressor_freq = 0;    // Hz
-    uint16_t fan_speed = 0;          // fan speed in RPM (raw DC motor level ×10, ~0..720), owned by macon lib
+    uint16_t fan_speed = 0;          // fan speed in RPM (decoded by the macon library)
     uint16_t fan_speed_max = 0;      // full-scale fan speed in RPM (from macon lib); 0 until first read
     uint16_t ac_voltage = 0;         // V
     uint16_t ac_current = 0;         // A
@@ -205,7 +205,7 @@ bool setDemoField(const char* field, int32_t value);
 // controller — the arctic-macon library owns the code namespace).
 // Delegates the code -> (register, bit) mapping to the arctic-macon library so
 // no bit positions are hardcoded here. Returns the number of register-bit sites
-// written (a code such as E28/E05 maps to two sites), or 0 if the code is
+// written (some codes map to two register-bit sites), or 0 if the code is
 // unknown. Demo mode only; re-decodes the register cache before returning.
 int injectDemoFault(const char* code, bool active);
 

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -48,6 +48,7 @@ struct HeatPumpState {
     // System readings (decoded by the macon library from the real Tuya window)
     uint16_t compressor_freq = 0;    // Hz
     uint16_t fan_speed = 0;          // fan speed in RPM (raw DC motor level ×10, ~0..720), owned by macon lib
+    uint16_t fan_speed_max = 0;      // full-scale fan speed in RPM (from macon lib); 0 until first read
     uint16_t ac_voltage = 0;         // V
     uint16_t ac_current = 0;         // A
     uint16_t dc_voltage = 0;         // V (volts; unit conversion owned by macon lib)
@@ -92,14 +93,16 @@ struct HeatPumpState {
     // DC bus voltage in volts (already converted by the macon library).
     float getDcVoltageV() const { return static_cast<float>(dc_voltage); }
 
-    // Fan UI level (0=off..3=high) bucketed from the fan RPM (raw level ×10).
-    // TODO(fan-rework): replace with bars = round(fan_speed/fan_speed_max*N)
-    // once the library exposes fan_speed + fan_speed_max.
+    // Fan UI level (0=off..3=high) as a percentage of the library-provided
+    // full-scale fan speed (fan_speed_max). The controller no longer encodes
+    // the fan register's range or maximum — that assumption lives entirely in
+    // arctic-macon (MACON_FAN_SPEED_MAX_RPM); only the bar banding is UI policy.
     int getFanSpeedLevel() const {
-        if (!fan_running || fan_speed == 0) return 0;
-        if (fan_speed >= 600) return 3;
-        if (fan_speed >= 300) return 2;
-        return 1;
+        if (!fan_running || fan_speed == 0 || fan_speed_max == 0) return 0;
+        const uint32_t pct = static_cast<uint32_t>(fan_speed) * 100u / fan_speed_max;
+        if (pct >= 66) return 3;   // top third
+        if (pct >= 33) return 2;   // middle third
+        return 1;                  // bottom third
     }
 };
 

--- a/main/heatpump_screen.cpp
+++ b/main/heatpump_screen.cpp
@@ -32,7 +32,7 @@ static void format_error_card_text(char* buf, size_t buf_size, const lv_font_t* 
         return;
     }
     
-    // Build first error: "P02: High pressure protection"
+    // Build first error: "<code>: <description>" (both library-provided)
     char first[128];
     snprintf(first, sizeof(first), "\xEF\x81\xB1 %s: %s", errors[0].code, errors[0].description);
     

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -263,14 +263,14 @@ class TestDemoModeInjection:
         assert temps["outdoor"] == 22
 
     def test_inject_compressor_readings(self):
-        """Inject compressor freq and fan level and verify in readings."""
-        # fan_speed is now the Macon byte-level fan value (reg2003), reported
-        # as fan_rpm; it is not an actual RPM. 45 falls in the "medium" bucket.
-        _inject_demo({"compressor_freq": 75, "fan_speed": 45})
+        """Inject compressor freq and fan speed and verify in readings."""
+        # fan_speed is the fan RPM (reg2003 raw ×10). 450 RPM falls in the
+        # "medium" bucket (300..599 => 2 bars).
+        _inject_demo({"compressor_freq": 75, "fan_speed": 450})
         time.sleep(1.0)
         data = _get("/api/heatpump/status").json()
         assert data["readings"]["compressor_freq"] == 75
-        assert data["readings"]["fan_rpm"] == 45
+        assert data["readings"]["fan_rpm"] == 450
 
     def test_inject_electrical_readings(self):
         """Inject voltage/current and verify they are reflected in status."""
@@ -426,9 +426,9 @@ class TestDemoFaultControlViaDemoEndpoint:
 #   aux_heater -> not currently mapped from any Tuya register (always false)
 # We drive each via the named demo fields so tests never touch raw bit layout.
 
-# fan_speed (reg2003) byte-level thresholds -> UI level (getFanSpeedLevel):
-#   0 -> 0, 1..29 -> 1, 30..59 -> 2, >=60 -> 3
-_FAN_OFF, _FAN_LOW, _FAN_MED, _FAN_HIGH = 0, 20, 45, 80
+# fan_speed is the fan RPM (reg2003 raw ×10) -> UI level (getFanSpeedLevel):
+#   0 -> 0, 1..299 -> 1, 300..599 -> 2, >=600 -> 3
+_FAN_OFF, _FAN_LOW, _FAN_MED, _FAN_HIGH = 0, 200, 450, 700
 
 
 class TestComponentStateManipulation:

--- a/tests/api/test_heatpump_api.py
+++ b/tests/api/test_heatpump_api.py
@@ -426,8 +426,9 @@ class TestDemoFaultControlViaDemoEndpoint:
 #   aux_heater -> not currently mapped from any Tuya register (always false)
 # We drive each via the named demo fields so tests never touch raw bit layout.
 
-# fan_speed is the fan RPM (reg2003 raw ×10) -> UI level (getFanSpeedLevel):
-#   0 -> 0, 1..299 -> 1, 300..599 -> 2, >=600 -> 3
+# fan_speed is the fan RPM (reg2003 raw ×10). getFanSpeedLevel buckets it as a
+# percentage of the library-provided max (fan_speed_max = 1000 RPM):
+#   0 -> 0, <33% -> 1, 33..65% -> 2, >=66% -> 3. Demo values below are RPM.
 _FAN_OFF, _FAN_LOW, _FAN_MED, _FAN_HIGH = 0, 200, 450, 700
 
 

--- a/tests/device/test_localization.py
+++ b/tests/device/test_localization.py
@@ -21,7 +21,7 @@ from device_client import DeviceClient
 # there is no fictional "status1" bitfield. Faults are injected by their Macon
 # code so the library owns the code->register,bit mapping.
 # ---------------------------------------------------------------------------
-FAN_MED = 45  # fan_speed byte level -> 2 bars
+FAN_MED = 450  # fan RPM (reg2003 raw ×10) -> 2 bars
 
 # Default demo fault (matches initDemoState()).
 DEMO_FAULT = "P02"

--- a/tests/device/test_main_screen.py
+++ b/tests/device/test_main_screen.py
@@ -21,8 +21,9 @@ import pytest
 from device_client import DeviceClient
 
 # ---------------------------------------------------------------------------
-# fan_speed is the fan RPM (reg2003 raw ×10) -> UI fan level (getFanSpeedLevel):
-#   0 -> 0 bars, 1..299 -> 1 bar, 300..599 -> 2 bars, >=600 -> 3 bars
+# fan_speed is the fan RPM (reg2003 raw ×10). getFanSpeedLevel buckets it as a
+# percentage of the library-provided max (fan_speed_max = 1000 RPM):
+#   0 -> 0 bars, <33% -> 1 bar, 33..65% -> 2 bars, >=66% -> 3 bars
 # ---------------------------------------------------------------------------
 FAN_OFF, FAN_LOW, FAN_MED, FAN_HIGH = 0, 200, 450, 700
 

--- a/tests/device/test_main_screen.py
+++ b/tests/device/test_main_screen.py
@@ -8,7 +8,7 @@ Component/run state is decoded natively by arctic-macon from the real Tuya
 registers, so there is no fictional "status1" bitfield. Tests drive named
 demo fields instead of raw register bits:
   compressor -> compressor_freq (>0 = running)
-  fan bars   -> fan_speed byte level (getFanSpeedLevel buckets)
+  fan bars   -> fan_speed RPM (reg2003 raw ×10; getFanSpeedLevel buckets)
   fan dot    -> fan_on
   pump       -> pump_on
 Faults are injected by their Macon code via inject_fault()/clear_all_faults().
@@ -21,10 +21,10 @@ import pytest
 from device_client import DeviceClient
 
 # ---------------------------------------------------------------------------
-# fan_speed (reg2003) byte-level values -> UI fan level (getFanSpeedLevel):
-#   0 -> 0 bars, 1..29 -> 1 bar, 30..59 -> 2 bars, >=60 -> 3 bars
+# fan_speed is the fan RPM (reg2003 raw ×10) -> UI fan level (getFanSpeedLevel):
+#   0 -> 0 bars, 1..299 -> 1 bar, 300..599 -> 2 bars, >=600 -> 3 bars
 # ---------------------------------------------------------------------------
-FAN_OFF, FAN_LOW, FAN_MED, FAN_HIGH = 0, 20, 45, 80
+FAN_OFF, FAN_LOW, FAN_MED, FAN_HIGH = 0, 200, 450, 700
 
 # Working modes
 MODE_COOLING       = 0
@@ -292,18 +292,17 @@ class TestPerformanceStrip:
     """Verify performance strip values update from demo state."""
 
     def test_fan_rpm_displayed(self, device: DeviceClient):
-        """Fan speed should show its value when the fan is running.
+        """Fan speed should show its RPM value when the fan is running.
 
-        NOTE: fan_speed is now the Macon byte-level fan value (reg2003), not a
-        true RPM; the label still reads "<value> RPM" pending the fan-level
-        rework (see sun-peaks TODO).
+        fan_speed is the fan RPM (reg2003 raw ×10); the label reads
+        "<value> RPM".
         """
         device.clear_all_faults()
-        _running(device, fan_speed=45)
+        _running(device, fan_speed=450)
         _wait_for_update()
         fan = device.find_widget(tag="perf_fan")
         assert fan is not None, "perf_fan widget not found"
-        assert "45" in fan.text, f"Expected '45' in fan text, got '{fan.text}'"
+        assert "450" in fan.text, f"Expected '450' in fan text, got '{fan.text}'"
         assert "RPM" in fan.text, f"Expected 'RPM' in fan text, got '{fan.text}'"
 
     def test_fan_rpm_dashes_when_stopped(self, device: DeviceClient):


### PR DESCRIPTION
Makes the fan-speed reading an honest **RPM** value and removes the last fan-register range assumption from the controller (opacity #122). Bumps arctic-macon twice: #27 (decode reg2003 A10 as `raw ×10` => RPM) and #28 (expose `fan_speed_max` = assumed 1000 RPM).

### Changes
- Bump `components/arctic-macon` to the merged fan-RPM + fan_speed_max commit.
- `HeatPumpState` carries `fan_speed` (RPM) and `fan_speed_max` (from the library).
- `getFanSpeedLevel()` now buckets fan RPM as a **percentage of the library max** (`<33%`->1, `33-65%`->2, `>=66%`->3) instead of hardcoded RPM/byte thresholds. The controller no longer encodes the fan register's range or maximum — that lives entirely in arctic-macon; only the bar banding is UI policy.
- Demo seed = 400 RPM; fan device/API tests inject RPM (LOW/MED/HIGH = 200/450/700).
- Existing `fan_rpm` API field and `<n> RPM` UI labels become honest (no display-code changes needed).

### Scale caveat
Both the `×10` factor and the `1000` RPM max are **assumed** (raw reg2003 observed only up to ~72 => ~720 RPM), **not tachometer-verified**. Both are now single-point revisions in arctic-macon once a live fan measurement exists. This closes the controller-side portion of #122 (no more magic thresholds in the controller); the library max remains a placeholder.

Firmware builds clean (esp32p4); all arctic-macon native suites pass.