### PR TITLE
refactor: library-owned bus params + test-only register map in api_server

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -18,8 +18,13 @@
 #include "heatpump_types.h"
 #include "macon_master_iface.h"
 #include "macon_state.h"  // arctic::setpoint_limits / SetpointKind
-#include "macon_image.h"   // arctic::MaconField / macon_field_address (opaque address lookup)
+#ifdef CONFIG_TEST_ENDPOINTS
+// Register-map headers are pulled in for the debug/test diagnostic export only
+// (the register-address column + raw fault-register rows). A production image
+// never includes them, so it carries no Macon register map at all.
+#include "macon_image.h"   // arctic::MaconField / macon_field_address
 #include "macon_faults.h"  // arctic::MACON_FAULT_REGS (fault-register addresses)
+#endif
 #include "advanced_params.h"  // advanced_param_write() AP guardrail
 #include "heatpump_errors.h"
 #include "event_log.h"
@@ -3921,17 +3926,18 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
 
     // Register-address column. Real register addresses are emitted only in
     // debug/test builds; a production image ships an opaque CSV with the
-    // address column left blank so the Macon register map is never surfaced.
+    // address column left blank and references no Macon field enum at all, so
+    // the register map is never surfaced (nor even compiled in).
+#ifdef CONFIG_TEST_ENDPOINTS
     char addr[12];
     auto addr_col = [&addr](arctic::MaconField f) -> const char* {
-#ifdef CONFIG_TEST_ENDPOINTS
         snprintf(addr, sizeof(addr), "%u", (unsigned)arctic::macon_field_address(f));
-#else
-        (void)f;
-        addr[0] = '\0';
-#endif
         return addr;
     };
+    #define DIAG_ADDR(field) addr_col(arctic::MaconField::field)
+#else
+    #define DIAG_ADDR(field) ""
+#endif
 
     // UTF-8 BOM so Excel interprets the file correctly (degree signs, accents, etc.)
     httpd_resp_send_chunk(req, "\xEF\xBB\xBF", 3);
@@ -3955,47 +3961,48 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
     httpd_resp_sendstr_chunk(req, line);
 
     // --- Temperatures (whole °C, already decoded by the macon library) ---
-    // Addresses come from the library's opaque field->address lookup; the
-    // consumer never hardcodes a wire address.
+    // The address column is populated only in debug/test builds; in production
+    // the field name never appears (DIAG_ADDR expands to "").
     #define DIAG_TEMP(name_str, field, macon_field) \
         snprintf(line, sizeof(line), "Temperature,%s,,%s,%d,°C\r\n", name_str, \
-                 addr_col(macon_field), (int)(field)); \
+                 DIAG_ADDR(macon_field), (int)(field)); \
         httpd_resp_sendstr_chunk(req, line);
 
-    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       arctic::MaconField::WaterTankTemp)
-    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     arctic::MaconField::OutletWaterTemp)
-    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      arctic::MaconField::InletWaterTemp)
-    DIAG_TEMP("Discharge",        hp.discharge_temp,        arctic::MaconField::DischargeTemp)
-    DIAG_TEMP("Suction",          hp.suction_temp,          arctic::MaconField::SuctionTemp)
-    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     arctic::MaconField::OutdoorCoilTemp)
-    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      arctic::MaconField::IndoorCoilTemp)
-    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  arctic::MaconField::OutdoorAmbientTemp)
-    DIAG_TEMP("IPM Module",       hp.ipm_temp,              arctic::MaconField::IpmTemp)
+    DIAG_TEMP("Water Tank",       hp.water_tank_temp,       WaterTankTemp)
+    DIAG_TEMP("Outlet Water",     hp.outlet_water_temp,     OutletWaterTemp)
+    DIAG_TEMP("Inlet Water",      hp.inlet_water_temp,      InletWaterTemp)
+    DIAG_TEMP("Discharge",        hp.discharge_temp,        DischargeTemp)
+    DIAG_TEMP("Suction",          hp.suction_temp,          SuctionTemp)
+    DIAG_TEMP("Outdoor Coil",     hp.outdoor_coil_temp,     OutdoorCoilTemp)
+    DIAG_TEMP("Indoor Coil",      hp.indoor_coil_temp,      IndoorCoilTemp)
+    DIAG_TEMP("Outdoor Ambient",  hp.outdoor_ambient_temp,  OutdoorAmbientTemp)
+    DIAG_TEMP("IPM Module",       hp.ipm_temp,              IpmTemp)
     #undef DIAG_TEMP
 
     // --- Setpoints (whole °C) ---
-    snprintf(line, sizeof(line), "Setpoint,Cooling,,%s,%d,°C\r\n", addr_col(arctic::MaconField::CoolingSetpoint), hp.cooling_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Cooling,,%s,%d,°C\r\n", DIAG_ADDR(CoolingSetpoint), hp.cooling_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Heating,,%s,%d,°C\r\n", addr_col(arctic::MaconField::HeatingSetpoint), hp.heating_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Heating,,%s,%d,°C\r\n", DIAG_ADDR(HeatingSetpoint), hp.heating_setpoint);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Setpoint,Hot Water,,%s,%d,°C\r\n", addr_col(arctic::MaconField::HotWaterSetpoint), hp.hot_water_setpoint);
+    snprintf(line, sizeof(line), "Setpoint,Hot Water,,%s,%d,°C\r\n", DIAG_ADDR(HotWaterSetpoint), hp.hot_water_setpoint);
     httpd_resp_sendstr_chunk(req, line);
 
     // --- System Readings (already decoded to whole units by the macon library) ---
-    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,%s,%u,Hz\r\n", addr_col(arctic::MaconField::CompressorFreq), hp.compressor_freq);
+    snprintf(line, sizeof(line), "Reading,Compressor Frequency,,%s,%u,Hz\r\n", DIAG_ADDR(CompressorFreq), hp.compressor_freq);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Fan Speed,,%s,%u,RPM\r\n", addr_col(arctic::MaconField::FanLevel), hp.fan_speed);
+    snprintf(line, sizeof(line), "Reading,Fan Speed,,%s,%u,RPM\r\n", DIAG_ADDR(FanLevel), hp.fan_speed);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Voltage,,%s,%u,V\r\n", addr_col(arctic::MaconField::AcVoltage), hp.ac_voltage);
+    snprintf(line, sizeof(line), "Reading,AC Voltage,,%s,%u,V\r\n", DIAG_ADDR(AcVoltage), hp.ac_voltage);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,AC Current,,%s,%u,A\r\n", addr_col(arctic::MaconField::AcCurrent), hp.ac_current);
+    snprintf(line, sizeof(line), "Reading,AC Current,,%s,%u,A\r\n", DIAG_ADDR(AcCurrent), hp.ac_current);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,DC Voltage,,%s,%.1f,V\r\n", addr_col(arctic::MaconField::DcVoltage), hp.getDcVoltageV());
+    snprintf(line, sizeof(line), "Reading,DC Voltage,,%s,%.1f,V\r\n", DIAG_ADDR(DcVoltage), hp.getDcVoltageV());
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,%s,%u,steps\r\n", addr_col(arctic::MaconField::PrimaryEev), hp.primary_eev_opening);
+    snprintf(line, sizeof(line), "Reading,Primary EEV Opening,,%s,%u,steps\r\n", DIAG_ADDR(PrimaryEev), hp.primary_eev_opening);
     httpd_resp_sendstr_chunk(req, line);
-    snprintf(line, sizeof(line), "Reading,Power Consumption,,%s,%lu,W\r\n", addr_col(arctic::MaconField::RealtimePower), (unsigned long)hp.realtime_power_w);
+    snprintf(line, sizeof(line), "Reading,Power Consumption,,%s,%lu,W\r\n", DIAG_ADDR(RealtimePower), (unsigned long)hp.realtime_power_w);
     httpd_resp_sendstr_chunk(req, line);
+    #undef DIAG_ADDR
     if (hp.cop_valid) {
         snprintf(line, sizeof(line), "Reading,Heat Output (est),,,%ld,W\r\n", (long)hp.thermal_w);
         httpd_resp_sendstr_chunk(req, line);

--- a/main/tuya/macon_uart_params.h
+++ b/main/tuya/macon_uart_params.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Maps the arctic-macon library's protocol-owned bus parameters
+// (arctic::MACON_BUS_PARAMS — baud + character framing) onto an ESP-IDF
+// uart_config_t. The *value* of the wire settings lives in the library (it is a
+// property of the Macon protocol, not this board); only the *mechanism* of
+// applying them to a UART driver lives here, so the transport never hardcodes a
+// magic baud/parity of its own.
+
+#include "driver/uart.h"
+#include "macon_bus.h"
+
+namespace arctic {
+
+inline uart_word_length_t macon_uart_data_bits() {
+    switch (MACON_BUS_PARAMS.data_bits) {
+        case 5:  return UART_DATA_5_BITS;
+        case 6:  return UART_DATA_6_BITS;
+        case 7:  return UART_DATA_7_BITS;
+        default: return UART_DATA_8_BITS;
+    }
+}
+
+inline uart_parity_t macon_uart_parity() {
+    switch (MACON_BUS_PARAMS.parity) {
+        case MaconParity::Even: return UART_PARITY_EVEN;
+        case MaconParity::Odd:  return UART_PARITY_ODD;
+        default:                return UART_PARITY_DISABLE;
+    }
+}
+
+inline uart_stop_bits_t macon_uart_stop_bits() {
+    return (MACON_BUS_PARAMS.stop_bits == 2) ? UART_STOP_BITS_2 : UART_STOP_BITS_1;
+}
+
+// Fully-populated uart_config_t for the Macon bus (flow control off, default
+// source clock). Callers may override individual fields afterwards if needed.
+inline uart_config_t macon_uart_config() {
+    uart_config_t cfg = {};
+    cfg.baud_rate  = (int)MACON_BUS_PARAMS.baud;
+    cfg.data_bits  = macon_uart_data_bits();
+    cfg.parity     = macon_uart_parity();
+    cfg.stop_bits  = macon_uart_stop_bits();
+    cfg.flow_ctrl  = UART_HW_FLOWCTRL_DISABLE;
+    cfg.source_clk = UART_SCLK_DEFAULT;
+    return cfg;
+}
+
+}  // namespace arctic

--- a/main/tuya/macon_uart_transport.cpp
+++ b/main/tuya/macon_uart_transport.cpp
@@ -10,6 +10,7 @@
 #include "esp_log.h"
 
 #include "macon_bus_config.h"
+#include "macon_uart_params.h"
 
 static const char *TAG = "macon_tx";
 
@@ -18,7 +19,6 @@ namespace tuya {
 // Master shares the passive listener's port and wire settings. Only one of the
 // two runs (the bus mode is a Kconfig choice), so there is no UART1 conflict.
 static constexpr uart_port_t UART_PORT   = UART_NUM_1;
-static constexpr int         TUYA_BAUD   = 4800;
 static constexpr size_t      RX_BUF_SIZE = 2048;
 static constexpr size_t      TX_BUF_SIZE = 512;
 
@@ -47,13 +47,7 @@ esp_err_t MaconUartTransport::init()
     }
     gpio_set_level((gpio_num_t)arctic::RS485_DIR_PIN, 0);
 
-    uart_config_t cfg = {};
-    cfg.baud_rate  = TUYA_BAUD;
-    cfg.data_bits  = UART_DATA_8_BITS;
-    cfg.parity     = UART_PARITY_EVEN;
-    cfg.stop_bits  = UART_STOP_BITS_1;
-    cfg.flow_ctrl  = UART_HW_FLOWCTRL_DISABLE;
-    cfg.source_clk = UART_SCLK_DEFAULT;
+    uart_config_t cfg = arctic::macon_uart_config();
 
     err = uart_driver_install(UART_PORT, RX_BUF_SIZE, TX_BUF_SIZE, 0, nullptr, 0);
     if (err != ESP_OK) {
@@ -85,7 +79,7 @@ esp_err_t MaconUartTransport::init()
     initialized_ = true;
     ESP_LOGI(TAG,
              "RS485 half-duplex master UART ready (%d 8E1, TX=GPIO%d RX=GPIO%d DE=GPIO%d)",
-             TUYA_BAUD, arctic::RS485_TX_PIN, arctic::RS485_RX_PIN,
+             (int)arctic::MACON_BUS_PARAMS.baud, arctic::RS485_TX_PIN, arctic::RS485_RX_PIN,
              arctic::RS485_DIR_PIN);
     return ESP_OK;
 }

--- a/main/tuya/tuya_listener.cpp
+++ b/main/tuya/tuya_listener.cpp
@@ -16,6 +16,7 @@
 #include "driver/gpio.h"
 
 #include "macon_bus_config.h"
+#include "macon_uart_params.h"
 #include "heatpump_controller.h"  // arctic::feedListenerBytes / getListenerStats
 
 static const char *TAG = "tuya_listen";
@@ -26,9 +27,9 @@ namespace tuya {
 // Wire configuration
 // ---------------------------------------------------------------------------
 //
-// The real Arctic RS485 bus runs at 4800 baud 8-E-1.
+// The real Arctic RS485 bus runs at the library-owned Macon wire settings
+// (arctic::MACON_BUS_PARAMS — 4800 8-E-1).
 static constexpr uart_port_t UART_PORT   = UART_NUM_1;
-static constexpr int         TUYA_BAUD   = 4800;
 static constexpr size_t      RX_BUF_SIZE = 2048;   // driver ring buffer
 static constexpr size_t      READ_CHUNK  = 256;    // per read_bytes slice
 
@@ -58,7 +59,7 @@ static void rx_task(void *param)
     uint32_t       frames_at_log = 0;
 
     ESP_LOGI(TAG, "Listener task started (RX-only, %d baud 8E1, RX=GPIO%d, DIR=GPIO%d held low)",
-             TUYA_BAUD, arctic::RS485_RX_PIN, arctic::RS485_DIR_PIN);
+             (int)arctic::MACON_BUS_PARAMS.baud, arctic::RS485_RX_PIN, arctic::RS485_DIR_PIN);
 
     for (;;) {
         int n = uart_read_bytes(UART_PORT, buf, sizeof(buf), pdMS_TO_TICKS(50));
@@ -113,13 +114,7 @@ esp_err_t listener_init()
     }
     gpio_set_level((gpio_num_t)arctic::RS485_DIR_PIN, 0);
 
-    uart_config_t cfg = {};
-    cfg.baud_rate = TUYA_BAUD;
-    cfg.data_bits = UART_DATA_8_BITS;
-    cfg.parity    = UART_PARITY_EVEN;
-    cfg.stop_bits = UART_STOP_BITS_1;
-    cfg.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
-    cfg.source_clk = UART_SCLK_DEFAULT;
+    uart_config_t cfg = arctic::macon_uart_config();
 
     err = uart_driver_install(UART_PORT, RX_BUF_SIZE, 0 /*tx*/, 0, nullptr, 0);
     if (err != ESP_OK) {
@@ -144,7 +139,7 @@ esp_err_t listener_init()
 
     s_initialized = true;
     ESP_LOGI(TAG, "Passive Tuya listener initialized (%d baud 8E1, RX=GPIO%d)",
-             TUYA_BAUD, arctic::RS485_RX_PIN);
+             (int)arctic::MACON_BUS_PARAMS.baud, arctic::RS485_RX_PIN);
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Summary

Two follow-up opacity refactors so the **production controller build carries zero Macon wire/register knowledge**. Builds on the just-merged #128.

### Epic B — UART bus parameters as library data
- Bumps `arctic-macon` submodule to `37d1862` (adds `macon_bus.h`: `MaconBusParams` + `MACON_BUS_PARAMS = {4800, 8, Even, 1}`).
- New `main/tuya/macon_uart_params.h` maps the library's protocol-owned `MACON_BUS_PARAMS` onto an ESP-IDF `uart_config_t`. The **value** of the wire settings now lives in the library (a property of the Macon protocol); only the **mechanism** of applying them to a UART driver stays in the controller.
- `tuya_listener.cpp` / `macon_uart_transport.cpp` consume `arctic::macon_uart_config()`; the hardcoded `TUYA_BAUD=4800` constant and hand-populated `uart_config_t` are gone.

### Epic A — api_server register map is compile-time test-only
- `macon_image.h` / `macon_faults.h` includes are now wrapped in `#ifdef CONFIG_TEST_ENDPOINTS` — a **production image includes no Macon register-map header at all**.
- The diagnostic CSV address column uses a `DIAG_ADDR(field)` macro that expands to `addr_col(arctic::MaconField::field)` in test builds and to `""` in production, so `MaconField` never appears in the production translation unit.

## Validation
- ✅ Production build (esp32p4, 48% free)
- ✅ `CONFIG_TEST_ENDPOINTS=y` build
- ✅ Opacity gate 7/7 (`tests/api/test_opaque_macon_controller.py`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
