### PR TITLE
Accept integration Bearer token on OTA control endpoints

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -278,6 +278,16 @@ static bool check_integration_auth(
         authorization + BEARER_PREFIX_LEN, generation_out);
 }
 
+// Accepts either programmatic API-key/session auth (check_api_auth) or a valid
+// integration Bearer token (check_integration_auth). Used by the OTA control
+// endpoints so the Home Assistant integration — already trusted to command the
+// heat pump over /api/v1 — can also check for and start firmware updates with
+// its integration token, not just the X-API-Key/web-session credential.
+static bool check_api_or_integration_auth(httpd_req_t* req)
+{
+    return check_api_auth(req) || check_integration_auth(req);
+}
+
 static void set_session_cookie(httpd_req_t* req, const char* token)
 {
     char cookie[160];
@@ -2598,7 +2608,7 @@ static const char* ota_state_to_string(ota_state_t state)
 
 static esp_err_t ota_status_get_handler(httpd_req_t* req)
 {
-    if (!check_api_auth(req)) {
+    if (!check_api_or_integration_auth(req)) {
         send_json_error(req, "401 Unauthorized", "API key required");
         return ESP_OK;
     }
@@ -2846,7 +2856,7 @@ static esp_err_t ota_reboot_post_handler(httpd_req_t* req)
 
 static esp_err_t ota_releases_get_handler(httpd_req_t* req)
 {
-    if (!check_api_auth(req)) {
+    if (!check_api_or_integration_auth(req)) {
         send_json_error(req, "401 Unauthorized", "API key required");
         return ESP_OK;
     }
@@ -2888,7 +2898,7 @@ static esp_err_t ota_releases_get_handler(httpd_req_t* req)
 
 static esp_err_t ota_github_update_post_handler(httpd_req_t* req)
 {
-    if (!check_api_auth(req)) {
+    if (!check_api_or_integration_auth(req)) {
         send_json_error(req, "401 Unauthorized", "API key required");
         return ESP_OK;
     }


### PR DESCRIPTION
## Problem

The new Home Assistant `update` entity (hass-macon 0.4.0) never detected an available firmware update, even when the device's own web UI showed a newer release. HA always reported the device as up to date.

## Root cause

The HA integration (pymacon) authenticates with its **integration Bearer token** (`Authorization: Bearer <token>`), validated by `check_integration_auth`. But the OTA control endpoints only accepted the `X-API-Key` header or a web session cookie via `check_api_auth`:

- `GET /api/ota/status`
- `GET /api/ota/releases`
- `POST /api/ota/github`

So every firmware check from HA got a `401`. The entity swallows the error and falls back to reporting `latest_version == installed_version`, i.e. "up to date."

Reproduced on a bench device:
- `Authorization: Bearer <key>` on `/api/ota/releases` → `{"error":"API key required"}`
- `X-API-Key: <key>` on `/api/ota/releases` → `update_available: true, latest_version: "v2.11.7"`

## Fix

Add `check_api_or_integration_auth()` (`check_api_auth || check_integration_auth`) and apply it to the three OTA **control** endpoints the integration uses. The integration is already trusted to command the heat pump over `/api/v1`, so letting it check for and start firmware updates is consistent.

The raw firmware-upload endpoint (`POST /api/ota/update`) is intentionally left API-key/session only — it's a higher-privilege operation.

## Notes

- Bootstraps once: the office E540 device must install this fixed firmware (2.11.8) once via the web UI; after that HA detects and installs all future updates automatically.
- Builds clean for esp32p4 (49% app partition free).
