### PR TITLE
fix: close notification dropdown when the display turns off

### DIFF
--- a/main/display_idle.cpp
+++ b/main/display_idle.cpp
@@ -1,6 +1,7 @@
 #include "display_idle.h"
 #include "app_navigation.h"
 #include "settings/settings_display_screen.h"
+#include "status_bar.h"
 #include <bsp/display.h>
 #include <esp_log.h>
 #include <lvgl.h>
@@ -75,6 +76,9 @@ void display_idle_force_dim(void)
 
 void display_idle_force_off(void)
 {
+    // Dismiss any expanded notification dropdown so the user does not wake the
+    // screen to a stale open panel.
+    status_bar_close_notifications();
     app_navigation_return_home();
     esp_err_t err = bsp_display_brightness_set(0);
     if (err == ESP_OK) {

--- a/main/status_bar.cpp
+++ b/main/status_bar.cpp
@@ -513,6 +513,11 @@ static void close_dropdown(void)
     }
 }
 
+void status_bar_close_notifications(void)
+{
+    close_dropdown();
+}
+
 static void show_dropdown(void)
 {
     // Close if already open (toggle behavior)
@@ -535,6 +540,7 @@ static void show_dropdown(void)
     
     // Create overlay container that fills the screen (for click-outside-to-close)
     bar_state.notify_dropdown = lv_obj_create(screen);
+    lv_obj_set_user_data(bar_state.notify_dropdown, (void*)"notification_dropdown");
     lv_obj_set_size(bar_state.notify_dropdown, LV_PCT(100), LV_PCT(100));
     lv_obj_set_pos(bar_state.notify_dropdown, 0, 0);
     lv_obj_set_style_bg_opa(bar_state.notify_dropdown, LV_OPA_50, LV_PART_MAIN);

--- a/main/status_bar.h
+++ b/main/status_bar.h
@@ -110,6 +110,15 @@ uint8_t status_bar_get_notify_count(void);
 void status_bar_update_time(void);
 
 /**
+ * @brief Close the notification dropdown if it is open
+ *
+ * Safe to call when the dropdown is already closed. Used to dismiss the
+ * expanded notification panel when the display turns off, so the user does
+ * not wake the screen to a stale open dropdown.
+ */
+void status_bar_close_notifications(void);
+
+/**
  * @brief Delete the status bar and stop its timer
  */
 void status_bar_delete(void);

--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -138,7 +138,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`device_client.py`](device_client.py) | Python HTTP client wrapping all 19 test endpoints + production API |
 | [`openapi-test.yaml`](openapi-test.yaml) | OpenAPI 3.0 spec for the test instrumentation API |
 
-### Test Files (266 UI tests + 9 screenshot API tests + 10 HTTPS tests + 286 REST API tests + 55 web tests + API contract tests)
+### Test Files (267 UI tests + 9 screenshot API tests + 10 HTTPS tests + 286 REST API tests + 55 web tests + API contract tests)
 
 | File | Tests | Description |
 |------|-------|-------------|

--- a/tests/device/test_display_idle.py
+++ b/tests/device/test_display_idle.py
@@ -54,3 +54,29 @@ def test_turning_off_returns_home_from_settings_modal(device: DeviceClient):
     wake = device.click(tag="settings")
     assert wake["consumed"] is True
     assert device.screen == "main"
+
+
+def test_turning_off_closes_notification_dropdown(device: DeviceClient):
+    """The expanded notification dropdown is dismissed when the display turns
+    off, so waking the screen never shows a stale open dropdown."""
+    device.wait_for_screen("main", timeout=5.0)
+
+    # Create a notification and open the dropdown from the status-bar bell.
+    device.notification_mock(0, "Firmware update available")
+    try:
+        device.click(tag="notifications")
+        assert device.wait_for_widget(tag="notification_dropdown", timeout=3.0), \
+            "Notification dropdown should open when the bell is tapped"
+
+        # Turning the display off must dismiss the dropdown.
+        off = device.set_display_idle("off")
+        assert off["off"] is True
+        assert device.find_widget(tag="notification_dropdown") is None, \
+            "Notification dropdown should be closed after the display turns off"
+
+        # The first touch only wakes the screen; the dropdown stays closed.
+        wake = device.click(tag="notifications")
+        assert wake["consumed"] is True
+        assert device.find_widget(tag="notification_dropdown") is None
+    finally:
+        device.notification_mock_reset()


### PR DESCRIPTION
## Problem

When a notification (e.g. a firmware-update alert) is expanded from the status-bar bell and left open, the display idle timer dims and then turns the screen off with the dropdown still open. Waking the screen shows the **stale expanded dropdown** instead of the home screen.

## Fix

`display_idle_force_off()` already calls `app_navigation_return_home()`, but the notification dropdown is a separate full-screen overlay that was never torn down. This PR:

- Adds `status_bar_close_notifications()` (a public wrapper over the existing `close_dropdown()`), safe to call when nothing is open.
- Calls it from `display_idle_force_off()` so the overlay is dismissed alongside the return-home — the same way modals are abandoned on display-off.
- Tags the dropdown overlay `notification_dropdown` for test addressability.

## Test

Adds a device regression test (`test_turning_off_closes_notification_dropdown`) that:
1. Injects a firmware notification and opens the dropdown from the bell.
2. Asserts the dropdown overlay is present.
3. Forces the display off and asserts the overlay is gone.
4. Confirms the first wake-touch doesn't re-open it.

## Notes

- Only triggers on display **off** (black), not dim — matching the reported behavior.
- Builds clean for esp32p4 (49% app partition free).
- Batched as a single PR since device tests take ~55 min in CI.
