### PR TITLE
fix: register OTA endpoints on integration server for HA updates

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -544,8 +544,17 @@ paths:
       tags:
         - OTA
       summary: OTA update status
-      description: Returns current OTA update status, progress, and partition information.
+      description: |
+        Returns current OTA update status, progress, and partition information.
+
+        Also served on the Home Assistant integration server (port 8443); the
+        integration bearer token is accepted in addition to the API key or
+        session cookie.
       operationId: getOtaStatus
+      security:
+        - apiKey: []
+        - sessionCookie: []
+        - integrationBearer: []
       responses:
         '200':
           description: OTA status
@@ -615,10 +624,16 @@ paths:
       description: |
         Queries the controller's configured GitHub releases feed and compares the
         latest release with the currently running firmware.
+
+        Also served on the Home Assistant integration server (port 8443); the
+        integration bearer token is accepted in addition to the API key or
+        session cookie. This is the endpoint the Home Assistant `update` entity
+        polls to detect available firmware.
       operationId: getOtaReleases
       security:
         - apiKey: []
         - sessionCookie: []
+        - integrationBearer: []
       responses:
         '200':
           description: Latest release information
@@ -661,10 +676,16 @@ paths:
       description: |
         Starts an OTA update using the release discovered by
         `GET /api/ota/releases`. Poll `/api/ota/status` for progress.
+
+        Also served on the Home Assistant integration server (port 8443); the
+        integration bearer token is accepted in addition to the API key or
+        session cookie. This is the endpoint the Home Assistant `update` entity
+        calls to install firmware.
       operationId: startGithubOtaUpdate
       security:
         - apiKey: []
         - sessionCookie: []
+        - integrationBearer: []
       responses:
         '200':
           description: GitHub OTA update started

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -514,7 +514,10 @@ bool api_server_start(void)
         httpd_ssl_config_t integration_config = HTTPD_SSL_CONFIG_DEFAULT();
         integration_config.port_secure = 8443;
         integration_config.httpd.ctrl_port = 32771;
-        integration_config.httpd.max_uri_handlers = 8;
+        // 8 core HA handlers (pair, capabilities, state, events/WSS, power,
+        // mode, setpoint + WSS worker) plus the 3 OTA control endpoints the
+        // integration drives (status, releases, github) plus headroom.
+        integration_config.httpd.max_uri_handlers = 12;
         integration_config.httpd.max_open_sockets = 5;
         integration_config.httpd.stack_size = 12288;
         // Reject surplus connections instead of evicting established WSS
@@ -1208,6 +1211,60 @@ bool api_server_start(void)
             api_server_stop();
             return false;
         }
+
+        // OTA control endpoints on the integration server. The Home Assistant
+        // integration connects ONLY to port 8443 with its integration token,
+        // so the firmware "update" entity's check/status/install calls land
+        // here, not on the main server where the OTA routes also live. These
+        // handlers accept the integration Bearer token via
+        // check_api_or_integration_auth. Registered independently of the WPS
+        // websocket since OTA does not depend on it. The raw upload endpoint
+        // (/api/ota/update) is intentionally NOT exposed here.
+        httpd_uri_t ha_ota_status_uri = {
+            .uri = "/api/ota/status",
+            .method = HTTP_GET,
+            .handler = ota_status_get_handler,
+            .user_ctx = NULL
+        };
+        ret = httpd_register_uri_handler(
+            server_integration, &ha_ota_status_uri);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to register HA OTA status: %s",
+                     esp_err_to_name(ret));
+            api_server_stop();
+            return false;
+        }
+
+        httpd_uri_t ha_ota_releases_uri = {
+            .uri = "/api/ota/releases",
+            .method = HTTP_GET,
+            .handler = ota_releases_get_handler,
+            .user_ctx = NULL
+        };
+        ret = httpd_register_uri_handler(
+            server_integration, &ha_ota_releases_uri);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to register HA OTA releases: %s",
+                     esp_err_to_name(ret));
+            api_server_stop();
+            return false;
+        }
+
+        httpd_uri_t ha_ota_github_uri = {
+            .uri = "/api/ota/github",
+            .method = HTTP_POST,
+            .handler = ota_github_update_post_handler,
+            .user_ctx = NULL
+        };
+        ret = httpd_register_uri_handler(
+            server_integration, &ha_ota_github_uri);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to register HA OTA github: %s",
+                     esp_err_to_name(ret));
+            api_server_stop();
+            return false;
+        }
+
         if (!ha_websocket_start(server_integration)) {
             ESP_LOGE(TAG, "Home Assistant WebSocket push unavailable");
             httpd_ssl_stop(server_integration);


### PR DESCRIPTION
## Problem

Home Assistant (hass-macon) never detected available firmware, even when the device itself knew an update existed. With the 0.4.1 logging fix in place, HA surfaced the real error:

```
Macon update check failed: GET /api/ota/releases failed with HTTP 404: Nothing matches the given URI
```

### Root cause

The device runs a **dedicated integration HTTPS server on port 8443**, separate from the main server (80/443). `pymacon` connects **only** to port 8443 with its integration Bearer token for every request — including OTA.

But the OTA routes (`/api/ota/status`, `/api/ota/releases`, `/api/ota/github`) were registered **only on the main server**. So HA's update entity hit 8443 → **404**.

The earlier auth fix (#137, accept integration token on OTA handlers) was necessary but insufficient — the routes simply didn't exist on the server HA talks to.

## Fix

Register the three OTA control handlers on `server_integration` as well:

| Route | Method | Handler |
|---|---|---|
| `/api/ota/status` | GET | `ota_status_get_handler` |
| `/api/ota/releases` | GET | `ota_releases_get_handler` |
| `/api/ota/github` | POST | `ota_github_update_post_handler` |

These already accept the integration Bearer token via `check_api_or_integration_auth` (#137). The raw upload endpoint (`/api/ota/update`) is intentionally **not** exposed on the integration server. Bumped the integration server's `max_uri_handlers` from 8 → 12 to fit the new routes with headroom.

## Testing

- ESP-IDF build (esp32p4) passes.
- After this ships in firmware and is installed once via the web UI, HA will detect and install all future updates over port 8443.
