### PR TITLE
feat: report network identity (IP + .local hostname) in HA capabilities

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2609,8 +2609,9 @@ paths:
       summary: Home Assistant integration capabilities
       description: |
         Returns the stable device identity, protocol version, supported
-        transports, read/control capabilities, and setpoint limits. Production
-        firmware exposes this endpoint only over HTTPS.
+        transports, read/control capabilities, setpoint limits, and network
+        identity (IP address and mDNS hostname). Production firmware exposes
+        this endpoint only over HTTPS.
       operationId: getHomeAssistantCapabilities
       security:
         - integrationBearer: []
@@ -2956,6 +2957,23 @@ components:
                   type: boolean
         setpoint_limits_c:
           type: object
+        network:
+          type: object
+          description: |
+            Network identity so Home Assistant can show how it reaches the
+            controller. Present on firmware that supports it; served on the
+            integration server (port 8443).
+          required: [ip_address, local_hostname]
+          properties:
+            ip_address:
+              type: string
+              nullable: true
+              description: Current IPv4 address, or null when WiFi is down.
+              example: "192.168.1.21"
+            local_hostname:
+              type: string
+              description: Stable mDNS hostname (ends in .local).
+              example: "arctic-e540.local"
 
     HomeAssistantCommandAccepted:
       type: object

--- a/main/ha_integration.cpp
+++ b/main/ha_integration.cpp
@@ -2,7 +2,7 @@
  * Home Assistant integration identity and versioned state serialization.
  */
 #include "ha_integration.h"
-
+#include "api_server.h"
 #include "heatpump_controller.h"
 #include "heatpump_errors.h"
 #include "macon_state.h"
@@ -304,6 +304,24 @@ cJSON* createCapabilities()
 
     cJSON* limits = cJSON_AddObjectToObject(root, "setpoint_limits_c");
     addSetpointLimits(limits);
+
+    // Network identity so Home Assistant can surface how it reaches the
+    // controller. Served on the integration server (port 8443), which is the
+    // only server the HA integration talks to. ip_address reflects the current
+    // DHCP lease (null when WiFi is down); local_hostname is the stable mDNS
+    // name (e.g. "arctic-e540.local").
+    cJSON* network = cJSON_AddObjectToObject(root, "network");
+    char ip[16];
+    if (wifi_mgr_get_ip_addr(ip, sizeof(ip))) {
+        cJSON_AddStringToObject(network, "ip_address", ip);
+    } else {
+        cJSON_AddNullToObject(network, "ip_address");
+    }
+    char local_hostname[40];
+    snprintf(local_hostname, sizeof(local_hostname), "%s.local",
+             api_server_get_hostname());
+    cJSON_AddStringToObject(network, "local_hostname", local_hostname);
+
     return root;
 }
 

--- a/tests/api/test_home_assistant_api.py
+++ b/tests/api/test_home_assistant_api.py
@@ -190,7 +190,23 @@ def test_capabilities_exclude_advanced_and_raw_controls():
     assert data["capabilities"]["raw_registers"] is False
 
 
-def test_state_identity_and_revision_are_ordered():
+def test_capabilities_report_network_identity():
+    token = _issue_test_token()
+    response = _session.get(
+        f"{HA_URL}/api/v1/capabilities",
+        headers=_headers(token),
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    network = data["network"]
+    assert set(network) == {"ip_address", "local_hostname"}
+    assert network["local_hostname"].endswith(".local")
+    assert network["local_hostname"].startswith("arctic-")
+    assert network["ip_address"] is None or (
+        isinstance(network["ip_address"], str) and network["ip_address"]
+    )
     token = _issue_test_token()
     first = _session.get(
         f"{HA_URL}/api/v1/state",


### PR DESCRIPTION
## Problem

The Home Assistant integration connects **only** to the controller's integration server on port 8443. That server exposes device identity via `/api/v1/capabilities`, but nothing about **how HA reaches the device** — its IP address or mDNS hostname. Users asked to see both in Home Assistant (as diagnostic entities).

## Fix

Add a `network` object to the `/api/v1/capabilities` response:

```json
"network": {
  "ip_address": "192.168.1.21",
  "local_hostname": "arctic-e540.local"
}
```

- `ip_address` — current IPv4 lease, or `null` when WiFi is down.
- `local_hostname` — the stable mDNS name (`arctic-<xxxx>.local`).

Sourced from the existing `wifi_mgr_get_ip_addr()` and `api_server_get_hostname()` helpers, added in `createCapabilities()` (which already runs in the `main/` module alongside those helpers). Because pymacon and HA already fetch capabilities on connect, no new endpoint or round-trip is needed — the integration just reads the extra fields.

## Downstream

- `pymacon` will parse `network` into `ControllerCapabilities.ip_address` / `.local_hostname`.
- `hass-macon` will add two `EntityCategory.DIAGNOSTIC` sensors for them.

## Testing

- ESP-IDF build (esp32p4) passes.
- OpenAPI schema (`HomeAssistantCapabilities`) updated; `test_openapi_coverage.py` passes.
- Added device-side contract test `test_capabilities_report_network_identity` asserting the `network` object shape (`local_hostname` ends in `.local`, `ip_address` is a non-empty string or null).
