### PR TITLE
fix(ci): pin jsonschema-rs<0.50 to unbreak schema contract tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,13 @@ requests>=2.28
 aiohttp>=3.11
 cryptography>=42
 schemathesis>=3.0
+# Pin jsonschema-rs below 0.50: 0.50.0 (released 2026-08-20) removed the
+# CanonicalSchema.is_satisfiable API that schemathesis's transitive
+# hypothesis-jsonschema (0.23.1) depends on, which breaks schema collection
+# in tests/api/test_api_schema.py with:
+#   AttributeError: 'builtins.CanonicalSchema' object has no attribute 'is_satisfiable'
+# Remove this pin once schemathesis/hypothesis-jsonschema support jsonschema-rs 0.50+.
+jsonschema-rs<0.50
 pyyaml>=6.0
 esptool>=4.0
 pyserial>=3.5


### PR DESCRIPTION
## Pin `jsonschema-rs<0.50` to unbreak schema contract tests

### Problem

Every `host-tests` and `device-tests` run on `main` started failing at
**collection time** for `tests/api/test_api_schema.py`:

```
ERROR collecting tests/api/test_api_schema.py
AttributeError: 'builtins.CanonicalSchema' object has no attribute 'is_satisfiable'
```

### Root cause — upstream dependency break (not a code regression)

`jsonschema-rs 0.50.0` was published to PyPI on **2026-08-20 17:27 UTC** and
removed/renamed the `CanonicalSchema.is_satisfiable` API. Schemathesis pulls in
`hypothesis-jsonschema 0.23.1` (unchanged since 2024), which calls that API
during schema canonicalization. Because `tests/requirements.txt` left
`jsonschema-rs` unpinned (transitively via `schemathesis>=3.0`), CI began
resolving `0.50.0` and broke.

Timeline confirms it's purely the dependency, not any source change:
- Last green `main` Host Tests: `223d714` at **05:19 UTC** (jsonschema-rs 0.49.9)
- `jsonschema-rs 0.50.0` published at **17:27 UTC**
- First failure: next `main` run at **17:49 UTC** (jsonschema-rs 0.50.0)

The failing hypothesis reproduce buffer (`b'AA=='`, empty input) confirms the
error fires at canonicalization regardless of schema content.

### Fix

Pin `jsonschema-rs<0.50` in `tests/requirements.txt`. Verified locally that
schemathesis 4.24.3 + jsonschema-rs 0.49.9 collects all 73 tests cleanly.
Remove the pin once schemathesis / hypothesis-jsonschema support the new
jsonschema-rs 0.50 API.
