### PR TITLE
fix(esp_hosted): backport transport_pserial_send double-free fix + expose C6 FW version

### DIFF
--- a/components/espressif__esp_hosted/LOCAL_PATCHES.md
+++ b/components/espressif__esp_hosted/LOCAL_PATCHES.md
@@ -1,0 +1,77 @@
+# Local patches to the vendored `esp_hosted` component
+
+This component is **vendored** (checked into the repo) and wired in via
+`override_path` in [`main/idf_component.yml`](../../../main/idf_component.yml):
+
+```yaml
+espressif/esp_hosted:
+  version: "1.4.0"
+  override_path: "../components/espressif__esp_hosted"
+```
+
+It is **not** pristine upstream — it carries the local modifications listed
+below. The patches are applied **in place** (edited directly in the checked-in
+source); the `.patch` files under [`patches/`](patches/) are kept as
+**reference/documentation only** and are **not** applied by the build.
+
+## Base version
+
+| | |
+|---|---|
+| Upstream component | `espressif/esp_hosted` |
+| Base version | **1.4.0** (Espressif component registry) |
+| Base zip | https://components-file.espressif.com/components/espressif/esp_hosted/1.4.0/espressif__esp_hosted-v1.4.0.zip |
+
+## Why we patch instead of upgrading
+
+The Tab5's ESP32-C6 radio runs ESP-Hosted **1.4.1** (confirmed at runtime via
+`esp_hosted_get_coprocessor_fwversion()`, surfaced as `wifi_module_fw_version`
+in `GET /api/info`). ESP-Hosted requires the host and slave to match on
+**major.minor**, so the host driver is locked to the **1.4.x** line until the
+C6 is bench-reflashed. Both fixes below exist upstream only in **2.x+**, so they
+must be **backported** into 1.4.0 rather than picked up via an upgrade.
+
+## The patches
+
+| # | File | Purpose | Upstream origin |
+|---|------|---------|-----------------|
+| 0001 | `host/port/include/os_wrapper.h` | `MEM_ALLOC` prefers PSRAM (`MALLOC_CAP_SPIRAM`) with fallback to internal DMA SRAM, so the streaming SDIO RX buffer doesn't exhaust internal DMA SRAM during an OTA download (fixes `sdio_rx_get_buffer:670` OOM assert). | esp-hosted-mcu 2.12.8 `MEMPOOL_PREFER_SPIRAM` |
+| 0002 | `host/drivers/virtual_serial_if/serial_if.c` | `transport_pserial_send` no longer double-frees `write_buf` after `serial_drv_write()` consumes it (ownership passes to `esp_hosted_tx()`, which frees it on the `!transport_up` branch). Fixes `tlsf_free` "block already marked as free" panic when the C6 link is down. | esp-hosted-mcu `main` `free_bufs1`/`free_bufs2` split |
+
+## Removal criteria (important)
+
+**Both patches are a stopgap for the 1.4.x lockstep.** ESP-Hosted **2.12.12**
+contains *both* fixes natively (the double-free fix and `MEMPOOL_PREFER_SPIRAM`).
+Once the C6 is reflashed to 2.12.x (see the
+[`arctic-c6-slave`](https://github.com/sslivins/arctic-c6-slave) build repo) and
+the host is bumped to a matching 2.12.x, the correct action is:
+
+1. Delete this vendored component directory.
+2. Remove the `override_path` from `main/idf_component.yml` and bump
+   `espressif/esp_hosted` to the matching registry version.
+3. Delete this file and `patches/`.
+
+i.e. the goal is to carry **zero** local patches, not to maintain this fork.
+
+## Verifying / re-applying the patches
+
+To confirm the vendored tree still equals `upstream 1.4.0 + these patches`
+(useful when reviewing, or to re-derive after a version bump):
+
+```bash
+# 1. Fetch pristine 1.4.0 into a scratch dir
+curl -L -o esp_hosted-1.4.0.zip \
+  https://components-file.espressif.com/components/espressif/esp_hosted/1.4.0/espressif__esp_hosted-v1.4.0.zip
+unzip esp_hosted-1.4.0.zip -d pristine
+
+# 2. Apply the reference patches from the component root
+cd pristine
+git apply -p1 ../patches/0001-mempool-prefer-spiram.patch
+git apply -p1 ../patches/0002-serial_if-double-free.patch
+
+# 3. Diff the result against the vendored copy -- expect NO differences
+diff -ru pristine <this component dir>
+```
+
+If that diff is non-empty, the vendored source has drifted from
+`upstream + patches` and either the code or these patch files need updating.

--- a/components/espressif__esp_hosted/host/drivers/virtual_serial_if/serial_if.c
+++ b/components/espressif__esp_hosted/host/drivers/virtual_serial_if/serial_if.c
@@ -185,30 +185,38 @@ int transport_pserial_send(uint8_t* data, uint16_t data_length)
 	buf_len = SIZE_OF_TYPE + SIZE_OF_LENGTH + strlen(ep_name) +
 		SIZE_OF_TYPE + SIZE_OF_LENGTH + data_length;
 
-	HOSTED_CALLOC(uint8_t,write_buf,buf_len,free_bufs);
+	HOSTED_CALLOC(uint8_t,write_buf,buf_len,free_bufs2);
 
 	if (!serial_handle) {
 		ESP_LOGE(TAG, "Serial connection closed?\n");
-		goto free_bufs;
+		goto free_bufs1;
 	}
 
 	count = compose_tlv(write_buf, data, data_length);
 	if (!count) {
 		ESP_LOGE(TAG, "Failed to compose TX data\n");
-		goto free_bufs;
+		goto free_bufs1;
 	}
 
 	ret = serial_drv_write(serial_handle, write_buf, count, &count);
 	if (ret != SUCCESS) {
 		ESP_LOGE(TAG, "Failed to write TX data\n");
-		goto free_bufs;
+		/* Local backport of the upstream esp-hosted-mcu free_bufs1/free_bufs2
+		 * split. Once write_buf is handed to serial_drv_write() its ownership
+		 * passes to esp_hosted_tx(), which frees it on every path -- including
+		 * the !transport_up error branch (sdio_drv.c). Freeing it again here
+		 * double-frees the same block -> tlsf_free "block already marked as
+		 * free" assert -> panic/crash-loop when the C6 link is down. So on a
+		 * write failure we must NOT free write_buf. */
+		goto free_bufs2;
 	}
 	return SUCCESS;
-free_bufs:
+free_bufs1:
 	if (write_buf) {
 		g_h.funcs->_h_free(write_buf);
 	}
-
+free_bufs2:
+	/* write_buf is supposed to be freed by serial_drv_write() */
 	return FAILURE;
 }
 

--- a/components/espressif__esp_hosted/patches/.gitattributes
+++ b/components/espressif__esp_hosted/patches/.gitattributes
@@ -1,0 +1,4 @@
+# Reference patch files must keep LF endings so `git apply` works on any
+# platform. Without this, autocrlf would rewrite them to CRLF on checkout and
+# the patches would fail to apply.
+*.patch -text

--- a/components/espressif__esp_hosted/patches/0001-mempool-prefer-spiram.patch
+++ b/components/espressif__esp_hosted/patches/0001-mempool-prefer-spiram.patch
@@ -1,0 +1,41 @@
+diff --git a/host/port/include/os_wrapper.h b/host/port/include/os_wrapper.h
+index 19d5fe2..fb14fdf 100644
+--- a/host/port/include/os_wrapper.h
++++ b/host/port/include/os_wrapper.h
+@@ -101,17 +101,29 @@ enum {
+ /* without alignment */
+ #define MALLOC(x)                        malloc(x)
+ 
+-/* This is [malloc + aligned DMA] */
++/* This is [malloc + aligned DMA].
++ * ESP32-P4 GDMA can DMA to/from PSRAM through the cache path, so prefer PSRAM
++ * (MALLOC_CAP_SPIRAM) and fall back to internal DMA-capable SRAM. This keeps the
++ * dynamically-grown streaming SDIO RX buffer (up to ~32KB under sustained inbound,
++ * e.g. a ~2MB OTA download) OFF the scarce internal DMA SRAM pool. Under OTA heap
++ * pressure that pool otherwise fails to satisfy the contiguous DMA allocation,
++ * esp_dma_capable_malloc returns "Not enough heap", MEM_ALLOC yields NULL and the
++ * streaming path trips assert(*buf) in sdio_rx_get_buffer (sdio_drv.c:670) -> panic.
++ * Host-side backport of esp-hosted-mcu 2.12.8 (MEMPOOL_PREFER_SPIRAM); no C6 reflash. */
+ #define MEM_ALLOC(x)       ({                                       \
++	void *tmp_buf = NULL;                                           \
++	size_t actual_size = 0;                                         \
+ 	esp_dma_mem_info_t dma_mem_info = {                             \
+-		.extra_heap_caps = 0,                                       \
++		.extra_heap_caps = MALLOC_CAP_SPIRAM,                       \
+ 		.dma_alignment_bytes = 64,                                  \
+ 	};                                                              \
+-	void *tmp_buf = NULL;                                           \
+-	size_t actual_size = 0;                                         \
+-	esp_err_t err = ESP_OK;                                         \
+-	err = esp_dma_capable_malloc((x), &dma_mem_info, &tmp_buf, &actual_size);\
+-	if (err) tmp_buf = NULL;                                        \
++	if (esp_dma_capable_malloc((x), &dma_mem_info, &tmp_buf, &actual_size) != ESP_OK) \
++		tmp_buf = NULL;                                             \
++	if (!tmp_buf) {                                                 \
++		dma_mem_info.extra_heap_caps = 0;                          \
++		if (esp_dma_capable_malloc((x), &dma_mem_info, &tmp_buf, &actual_size) != ESP_OK) \
++			tmp_buf = NULL;                                         \
++	}                                                               \
+ 	tmp_buf;})
+ 
+ #define FREE(x)                          free(x);

--- a/components/espressif__esp_hosted/patches/0002-serial_if-double-free.patch
+++ b/components/espressif__esp_hosted/patches/0002-serial_if-double-free.patch
@@ -1,0 +1,49 @@
+diff --git a/host/drivers/virtual_serial_if/serial_if.c b/host/drivers/virtual_serial_if/serial_if.c
+index 569b099..17d77f5 100644
+--- a/host/drivers/virtual_serial_if/serial_if.c
++++ b/host/drivers/virtual_serial_if/serial_if.c
+@@ -185,30 +185,38 @@ int transport_pserial_send(uint8_t* data, uint16_t data_length)
+ 	buf_len = SIZE_OF_TYPE + SIZE_OF_LENGTH + strlen(ep_name) +
+ 		SIZE_OF_TYPE + SIZE_OF_LENGTH + data_length;
+ 
+-	HOSTED_CALLOC(uint8_t,write_buf,buf_len,free_bufs);
++	HOSTED_CALLOC(uint8_t,write_buf,buf_len,free_bufs2);
+ 
+ 	if (!serial_handle) {
+ 		ESP_LOGE(TAG, "Serial connection closed?\n");
+-		goto free_bufs;
++		goto free_bufs1;
+ 	}
+ 
+ 	count = compose_tlv(write_buf, data, data_length);
+ 	if (!count) {
+ 		ESP_LOGE(TAG, "Failed to compose TX data\n");
+-		goto free_bufs;
++		goto free_bufs1;
+ 	}
+ 
+ 	ret = serial_drv_write(serial_handle, write_buf, count, &count);
+ 	if (ret != SUCCESS) {
+ 		ESP_LOGE(TAG, "Failed to write TX data\n");
+-		goto free_bufs;
++		/* Local backport of the upstream esp-hosted-mcu free_bufs1/free_bufs2
++		 * split. Once write_buf is handed to serial_drv_write() its ownership
++		 * passes to esp_hosted_tx(), which frees it on every path -- including
++		 * the !transport_up error branch (sdio_drv.c). Freeing it again here
++		 * double-frees the same block -> tlsf_free "block already marked as
++		 * free" assert -> panic/crash-loop when the C6 link is down. So on a
++		 * write failure we must NOT free write_buf. */
++		goto free_bufs2;
+ 	}
+ 	return SUCCESS;
+-free_bufs:
++free_bufs1:
+ 	if (write_buf) {
+ 		g_h.funcs->_h_free(write_buf);
+ 	}
+-
++free_bufs2:
++	/* write_buf is supposed to be freed by serial_drv_write() */
+ 	return FAILURE;
+ }
+ 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -108,6 +108,7 @@ idf_component_register(
         smooth_ui_toolkit
         esp_wifi
         esp_event
+        esp_hosted
         nvs_flash
         esp_netif
         mdns

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -2623,6 +2623,15 @@ static esp_err_t info_get_handler(httpd_req_t* req)
     cJSON_AddStringToObject(root, "hostname", hostname);
     cJSON_AddStringToObject(root, "platform", "ESP32-P4");
     cJSON_AddStringToObject(root, "wifi_module", "ESP32-C6");
+
+    // ESP32-C6 co-processor ESP-Hosted firmware version (read at init over RPC).
+    uint32_t c6_maj = 0, c6_min = 0, c6_pat = 0;
+    if (wifi_mgr_get_coprocessor_version(&c6_maj, &c6_min, &c6_pat)) {
+        char c6_ver_str[24];
+        snprintf(c6_ver_str, sizeof(c6_ver_str), "%u.%u.%u",
+                 (unsigned)c6_maj, (unsigned)c6_min, (unsigned)c6_pat);
+        cJSON_AddStringToObject(root, "wifi_module_fw_version", c6_ver_str);
+    }
     
     // Get version from app description
     const esp_app_desc_t* app_desc = esp_app_get_description();

--- a/main/wifi_manager.cpp
+++ b/main/wifi_manager.cpp
@@ -15,6 +15,7 @@
 #include <freertos/event_groups.h>
 #include <freertos/task.h>
 #include <bsp/m5stack_tab5.h>
+#include <esp_hosted.h>
 
 static const char* TAG = "wifi_mgr";
 
@@ -44,7 +45,13 @@ static struct {
     
     // Connection state callback
     wifi_mgr_state_cb_t state_callback;
-    
+
+    // ESP32-C6 co-processor ESP-Hosted firmware version, read once at init.
+    bool coproc_ver_valid;
+    uint32_t coproc_ver_major;
+    uint32_t coproc_ver_minor;
+    uint32_t coproc_ver_patch;
+
 } wifi_state = {};
 
 static TaskHandle_t api_start_task_handle = NULL;
@@ -168,7 +175,25 @@ bool wifi_mgr_init(void)
     // The co-processor needs time to complete internal initialization
     ESP_LOGI(TAG, "WiFi STA started, waiting for RPC to stabilize...");
     vTaskDelay(pdMS_TO_TICKS(1500));
-    
+
+    // Read the ESP32-C6 co-processor's ESP-Hosted firmware version once, now that
+    // the RPC link is up. Exposed via GET /api/info (wifi_module_fw_version) so the
+    // host/slave ESP-Hosted version compatibility can be checked across the fleet.
+    esp_hosted_coprocessor_fwver_t c6_ver = {};
+    esp_err_t c6_ver_err = esp_hosted_get_coprocessor_fwversion(&c6_ver);
+    if (c6_ver_err == ESP_OK) {
+        wifi_state.coproc_ver_valid = true;
+        wifi_state.coproc_ver_major = c6_ver.major1;
+        wifi_state.coproc_ver_minor = c6_ver.minor1;
+        wifi_state.coproc_ver_patch = c6_ver.patch1;
+        ESP_LOGI(TAG, "ESP32-C6 ESP-Hosted co-processor FW version: %u.%u.%u",
+                 (unsigned)c6_ver.major1, (unsigned)c6_ver.minor1, (unsigned)c6_ver.patch1);
+    } else {
+        wifi_state.coproc_ver_valid = false;
+        ESP_LOGW(TAG, "Could not read ESP32-C6 co-processor FW version: %s",
+                 esp_err_to_name(c6_ver_err));
+    }
+
     wifi_state.initialized = true;
     wifi_state.state = WIFI_MGR_STATE_DISCONNECTED;
     
@@ -596,4 +621,15 @@ bool wifi_mgr_get_mac_addr(uint8_t* mac)
     // For now, return the station MAC
     esp_err_t err = esp_wifi_get_mac(WIFI_IF_STA, mac);
     return (err == ESP_OK);
+}
+
+bool wifi_mgr_get_coprocessor_version(uint32_t* major, uint32_t* minor, uint32_t* patch)
+{
+    if (!wifi_state.coproc_ver_valid) {
+        return false;
+    }
+    if (major) *major = wifi_state.coproc_ver_major;
+    if (minor) *minor = wifi_state.coproc_ver_minor;
+    if (patch) *patch = wifi_state.coproc_ver_patch;
+    return true;
 }

--- a/main/wifi_manager.h
+++ b/main/wifi_manager.h
@@ -149,6 +149,20 @@ void wifi_mgr_clear_credentials(void);
  */
 bool wifi_mgr_get_mac_addr(uint8_t* mac);
 
+/**
+ * @brief Get the ESP32-C6 co-processor's ESP-Hosted firmware version.
+ *
+ * The version is read once from the co-processor over the ESP-Hosted RPC link
+ * during wifi_mgr_init(). Useful for confirming host/slave ESP-Hosted version
+ * compatibility.
+ *
+ * @param major Out: major version (may be NULL)
+ * @param minor Out: minor version (may be NULL)
+ * @param patch Out: patch version (may be NULL)
+ * @return true if a version was successfully read, false otherwise
+ */
+bool wifi_mgr_get_coprocessor_version(uint32_t* major, uint32_t* minor, uint32_t* patch);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes the nightly Device-Tests heap **double-free crash** in the vendored ESP-Hosted host driver, and adds a permanent diagnostic exposing the C6 co-processor firmware version.

## The crash (fix)

In `transport_pserial_send` (`serial_if.c`), once `write_buf` is handed to `serial_drv_write()` its ownership passes to `esp_hosted_tx()`, which frees it on **every** path — including the `!transport_up` error branch (`sdio_drv.c`). The old single `free_bufs:` label freed `write_buf` **again** on write failure, double-freeing the same block:

```
tlsf_free: "block already marked as free" assert -> panic
```

This fired whenever the C6 link was down (e.g. the ~15 min `REBOOT_AFTER_MS` supervisor cycle with no connectivity), which is what we saw in the nightly device-test failures.

**Fix:** backport the upstream esp-hosted-mcu `free_bufs1` / `free_bufs2` split — pre-write failures free `write_buf` (`free_bufs1`), post-write failures do **not** (`free_bufs2`).

### Why a backport (not an upgrade)

The C6 radio is locked at **ESP-Hosted 1.4.1** (empirically confirmed — see the new diagnostic). ESP-Hosted requires host/slave to match on major.minor, so the host must stay on the 1.4.x line. This fix exists in **no** 1.4.x release (verified up to 1.4.7) — only in 2.x+/main — so backporting into our vendored 1.4.0 is the only C6-compatible option. (Reflashing the C6 to 2.12.12 is tracked separately in the new `arctic-c6-slave` repo.)

## Diagnostic (feat)

Reads the C6 firmware version at startup via `esp_hosted_get_coprocessor_fwversion()` and exposes it as **`wifi_module_fw_version`** in `GET /api/info`. This is how we confirmed the C6 = 1.4.1 lockstep constraint, and makes it permanently observable.

## Testing

- ✅ Builds clean (`idf.py build`, esp32p4, IDF v5.5.2) — app 0x20abb0, 49% free.
- Device tests on CI validate runtime behavior. Note: a red device-test caused by C6-unreachable/rig connectivity is a **hardware-rig** issue, separate from validating this crash fix.

## Note on vendoring

`esp_hosted` is vendored via `override_path`; this is now the **second** in-place local patch (alongside `MEMPOOL_PREFER_SPIRAM` in `os_wrapper.h`). Both are documented via inline/idf_component.yml comments.
