### PR TITLE
chore(deps): bump mooncake_log to v1.5.0 (dependency sweep)

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -7,7 +7,7 @@
     {
         "url": "https://github.com/Forairaaaaa/mooncake_log.git",
         "path": "dependencies/mooncake_log",
-        "branch": "v1.0.0"
+        "branch": "v1.5.0"
     },
     {
         "url": "https://github.com/lvgl/lvgl.git",


### PR DESCRIPTION
## Dependency upgrade sweep — outcome

Follow-up to the esp_hosted crash-fix PR #142. Goal was "upgrade everything we can" that isn't coupled to the C6 ESP-Hosted lock.

### Shipped here
- **mooncake_log v1.0.0 -> v1.5.0** — standalone logging lib (used in main.cpp). Clean esp32p4 build.

### No action needed (auto-upgraded on CI)
 + "dependencies.lock is **gitignored**, so CI resolves latest-in-range on every fresh build. Registry deps (esp_codec_dev -> 1.6.2, esp_lcd_touch_gt911 -> 1.2.1, etc.) already float to newest in-range automatically — nothing to pin." + @"

### Held (breaking / risky — deferred)
- **smooth_ui_toolkit v2.0.0 -> v2.14.0**: breaking restructure (umbrella header `.h` -> `.hpp`, `core/lvgl/uitk/widget` layout, `lvgl_cpp` namespace change). Would require rewriting `startup_anim.cpp` + on-device UI validation. Coupled **mooncake** held with it.
- **git lvgl v9.2.2**: dual-copy with registry lvgl 9.5.0 — untangle separately.
- **esp_lcd_st7703 1.x -> 2.x**: major, behind BSP `^1.0.1` constraint; needs BSP API compat check.

### C6-locked (must not upgrade)
- **esp_hosted 1.4.0** + coupled **esp_wifi_remote 0.8.5** — pinned to match the C6's ESP-Hosted 1.4.1 until the C6 is reflashed.
