### PR TITLE
feat(history): round graph x-axis to whole hours + add web history view

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1881,6 +1881,102 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/heatpump/temperature-history:
+    get:
+      tags:
+        - HeatPump
+      summary: Get temperature history timeline
+      description: |
+        Returns up to an eight-hour window of telemetry samples (inlet, outlet,
+        and setpoint temperatures plus operating mode and compressor state),
+        mirroring the on-device history graph. Samples are captured every 30
+        seconds and retained for 14 days.
+
+        Temperatures are raw deci-Celsius integers (tenths of a degree), or null
+        when the reading was invalid at capture time; clients convert to the
+        preferred unit. The window ends at `end` (or "now" when omitted) and the
+        axis on the device/web chart is rounded to whole hours for readability.
+        All timestamps are Unix epoch seconds.
+      operationId: getTemperatureHistory
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      parameters:
+        - name: end
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: |
+            Unix epoch seconds for the end of the window. Defaults to the latest
+            aligned sample. Clamped to [window_seconds, latest_end].
+      responses:
+        '200':
+          description: Telemetry timeline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  start:
+                    type: integer
+                    description: Window start (Unix epoch seconds)
+                  end:
+                    type: integer
+                    description: Window end (Unix epoch seconds)
+                  latest_end:
+                    type: integer
+                    description: Most recent aligned sample timestamp
+                  earliest:
+                    type: integer
+                    description: Oldest timestamp still within retention
+                  window_seconds:
+                    type: integer
+                    description: Window length in seconds (28800 = 8 hours)
+                  sample_interval_sec:
+                    type: integer
+                    description: Seconds between samples (30)
+                  retention_days:
+                    type: integer
+                    description: Days of history retained (14)
+                  samples:
+                    type: array
+                    description: Samples in ascending time order
+                    items:
+                      type: object
+                      properties:
+                        t:
+                          type: integer
+                          description: Sample timestamp (Unix epoch seconds)
+                        in:
+                          type: integer
+                          nullable: true
+                          description: Inlet water temperature (deci-Celsius) or null
+                        out:
+                          type: integer
+                          nullable: true
+                          description: Outlet water temperature (deci-Celsius) or null
+                        set:
+                          type: integer
+                          nullable: true
+                          description: Active setpoint (deci-Celsius) or null
+                        mode:
+                          type: integer
+                          enum: [0, 1, 2, 3]
+                          description: '0=unknown, 1=heating, 2=cooling, 3=hot water'
+                        run:
+                          type: boolean
+                          description: Whether the compressor was running
+                        conn:
+                          type: boolean
+                          description: Whether the heat pump was connected
+        '401':
+          description: API key required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /api/heatpump/errors:
     get:
       tags:

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -27,6 +27,7 @@
 #endif
 #include "advanced_params.h"  // advanced_param_write() AP guardrail
 #include "heatpump_errors.h"
+#include "history_storage.h"
 #include "event_log.h"
 #include "factory_reset.h"
 #include "boot_stats.h"
@@ -156,6 +157,7 @@ static esp_err_t heatpump_errors_clear_handler(httpd_req_t* req);
 static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req);
 #endif
 static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req);
+static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req);
 static esp_err_t events_get_handler(httpd_req_t* req);
 static esp_err_t events_clear_handler(httpd_req_t* req);
 static esp_err_t brownout_clear_handler(httpd_req_t* req);
@@ -937,6 +939,15 @@ bool api_server_start(void)
         .user_ctx = NULL
     };
     REGISTER_URI(heatpump_errors_clear_uri);
+    
+    // GET /api/heatpump/temperature-history - Telemetry timeline for the web chart
+    httpd_uri_t heatpump_temperature_history_uri = {
+        .uri = "/api/heatpump/temperature-history",
+        .method = HTTP_GET,
+        .handler = heatpump_temperature_history_get_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(heatpump_temperature_history_uri);
     
     // GET /api/heatpump/diagnostic - Download diagnostic CSV dump
     httpd_uri_t heatpump_diagnostic_uri = {
@@ -4329,6 +4340,127 @@ static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req)
     return ESP_OK;
 }
 #endif  // CONFIG_DEMO_MODE
+
+// ============================================================================
+// Temperature history API
+// ============================================================================
+
+// GET /api/heatpump/temperature-history[?end=<unix_seconds>]
+// Returns up to an 8-hour window of telemetry samples ending at `end`
+// (default: now), mirroring the on-device history screen. Temperatures are raw
+// deci-Celsius (or null when the reading is invalid); the client converts to
+// the user's preferred unit. The JSON is streamed in chunks so we never build
+// a multi-hundred-KB buffer in RAM for ~960 samples.
+static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+
+    constexpr uint32_t kWindowSeconds = 8 * 60 * 60;
+    constexpr uint32_t kRetentionSeconds =
+        (uint32_t)HISTORY_TELEMETRY_RETENTION_DAYS * 24 * 60 * 60;
+
+    // Latest sample-aligned timestamp ("now" snapped to the sample grid), so
+    // the web window lines up with the on-device chart.
+    uint32_t latest_end = 0;
+    time_t now = 0;
+    time(&now);
+    if (time_mgr_is_synced() && now > 0) {
+        latest_end = ((uint32_t)now + HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC - 1) /
+                     HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC *
+                     HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC;
+    } else {
+        history_storage_latest_telemetry_timestamp(&latest_end);
+        if (latest_end > 0) latest_end += HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC;
+    }
+    if (latest_end == 0) latest_end = kWindowSeconds;
+
+    // Resolve the requested window end, clamped to [kWindowSeconds, latest_end].
+    uint32_t end = latest_end;
+    char query[64];
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+        char param[16];
+        if (httpd_query_key_value(query, "end", param, sizeof(param)) == ESP_OK) {
+            long requested = atol(param);
+            if (requested > 0) end = (uint32_t)requested;
+        }
+    }
+    if (end > latest_end) end = latest_end;
+    if (end < kWindowSeconds) end = kWindowSeconds;
+    uint32_t start = end - kWindowSeconds;
+    uint32_t earliest =
+        latest_end > kRetentionSeconds ? latest_end - kRetentionSeconds : 0;
+
+    history_telemetry_sample_t* samples =
+        (history_telemetry_sample_t*)heap_caps_malloc(
+            sizeof(history_telemetry_sample_t) * HISTORY_TELEMETRY_PAGE_CAPACITY,
+            MALLOC_CAP_SPIRAM);
+    if (!samples) {
+        samples = (history_telemetry_sample_t*)malloc(
+            sizeof(history_telemetry_sample_t) * HISTORY_TELEMETRY_PAGE_CAPACITY);
+    }
+    if (!samples) {
+        send_json_error(req, "500 Internal Server Error", "Out of memory");
+        return ESP_OK;
+    }
+
+    size_t count = 0;
+    esp_err_t err = history_storage_query_telemetry(
+        start, end, samples, HISTORY_TELEMETRY_PAGE_CAPACITY, &count);
+    if (err != ESP_OK) {
+        free(samples);
+        send_json_error(req, "500 Internal Server Error",
+                        "Failed to query telemetry history");
+        return ESP_OK;
+    }
+
+    set_json_content_type(req);
+
+    char line[256];
+    snprintf(line, sizeof(line),
+             "{\"start\":%u,\"end\":%u,\"latest_end\":%u,\"earliest\":%u,"
+             "\"window_seconds\":%u,\"sample_interval_sec\":%u,"
+             "\"retention_days\":%u,\"samples\":[",
+             (unsigned)start, (unsigned)end, (unsigned)latest_end,
+             (unsigned)earliest, (unsigned)kWindowSeconds,
+             (unsigned)HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC,
+             (unsigned)HISTORY_TELEMETRY_RETENTION_DAYS);
+    httpd_resp_sendstr_chunk(req, line);
+
+    for (size_t i = 0; i < count; i++) {
+        const history_telemetry_sample_t& s = samples[i];
+        char in_buf[12], out_buf[12], set_buf[12];
+        if (s.flags & HISTORY_TELEMETRY_INLET_VALID)
+            snprintf(in_buf, sizeof(in_buf), "%d", (int)s.inlet_deci_c);
+        else
+            strcpy(in_buf, "null");
+        if (s.flags & HISTORY_TELEMETRY_OUTLET_VALID)
+            snprintf(out_buf, sizeof(out_buf), "%d", (int)s.outlet_deci_c);
+        else
+            strcpy(out_buf, "null");
+        if (s.flags & HISTORY_TELEMETRY_SETPOINT_VALID)
+            snprintf(set_buf, sizeof(set_buf), "%d", (int)s.setpoint_deci_c);
+        else
+            strcpy(set_buf, "null");
+        bool running = (s.flags & HISTORY_TELEMETRY_COMPRESSOR_VALID) &&
+                       (s.flags & HISTORY_TELEMETRY_COMPRESSOR_RUNNING);
+        bool conn = (s.flags & HISTORY_TELEMETRY_CONNECTED) != 0;
+        snprintf(line, sizeof(line),
+                 "%s{\"t\":%u,\"in\":%s,\"out\":%s,\"set\":%s,"
+                 "\"mode\":%u,\"run\":%s,\"conn\":%s}",
+                 i == 0 ? "" : ",", (unsigned)s.timestamp, in_buf, out_buf,
+                 set_buf, (unsigned)s.mode, running ? "true" : "false",
+                 conn ? "true" : "false");
+        httpd_resp_sendstr_chunk(req, line);
+    }
+    free(samples);
+
+    httpd_resp_sendstr_chunk(req, "]}");
+    httpd_resp_send_chunk(req, NULL, 0);
+    return ESP_OK;
+}
 
 // ============================================================================
 // Events API

--- a/main/heatpump_history_screen.cpp
+++ b/main/heatpump_history_screen.cpp
@@ -227,14 +227,35 @@ static void chart_draw_cb(lv_event_t* event) {
         draw_label(layer, label_area, label, UI_COLOR_TEXT_DIM,
                    LV_TEXT_ALIGN_RIGHT);
     }
-    for (int tick = 0; tick <= 4; tick++) {
-        uint32_t timestamp =
-            state.window_start + (WINDOW_SECONDS * tick / 4);
-        int32_t x = map_x(timestamp, plot);
+    // X-axis gridlines/labels are anchored to whole-hour boundaries in local
+    // time (rounded up to the next even-hour multiple) rather than to the
+    // ragged window edges, so the axis always reads in clean hours
+    // (e.g. 08:00, 10:00, 12:00) regardless of the current minute. The data
+    // window itself still ends at "now" so the last 8 hours stay visible.
+    static constexpr int TICK_STEP_HOURS = 2;
+    time_t tick_time;
+    {
+        time_t start = state.window_start;
+        struct tm t0 = {};
+        localtime_r(&start, &t0);
+        if (t0.tm_min != 0 || t0.tm_sec != 0) {
+            t0.tm_hour += 1;
+        }
+        t0.tm_min = 0;
+        t0.tm_sec = 0;
+        // Snap up to the next multiple of TICK_STEP_HOURS for even spacing.
+        t0.tm_hour +=
+            (TICK_STEP_HOURS - (t0.tm_hour % TICK_STEP_HOURS)) % TICK_STEP_HOURS;
+        t0.tm_isdst = -1;
+        tick_time = mktime(&t0);
+    }
+    for (; tick_time > 0 && (uint32_t)tick_time <= state.window_end;
+         tick_time += TICK_STEP_HOURS * 3600) {
+        if ((uint32_t)tick_time < state.window_start) continue;
+        int32_t x = map_x((uint32_t)tick_time, plot);
         draw_line(layer, {x, plot.y1}, {x, plot.y2}, COLOR_GRID, 1);
-        time_t local_timestamp = timestamp;
         struct tm local = {};
-        localtime_r(&local_timestamp, &local);
+        localtime_r(&tick_time, &local);
         char label[12];
         strftime(label, sizeof(label), "%H:%M", &local);
         lv_area_t label_area = {x - 40, plot.y2 + 10, x + 40, coords.y2};

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -205,6 +205,16 @@
     .btn.danger { color: var(--cp-danger); border-color: var(--cp-danger); }
     .btn:disabled { opacity: .5; cursor: not-allowed; }
     .btn-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+    .hist-muted { color: var(--cp-text-muted); margin: 8px 0; }
+    .hist-toolbar { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+    .hist-range { font-weight: 600; }
+    .hist-legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 13px; color: var(--cp-text-muted); }
+    .hist-legend span { display: inline-flex; align-items: center; gap: 6px; }
+    .hist-legend i { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
+    .hist-chart-wrap { width: 100%; }
+    .hist-chart { width: 100%; height: auto; display: block; }
+    .hist-axis { fill: var(--cp-text-muted); font-size: 12px; font-family: inherit; }
+    .hist-nav { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
     .field { display: grid; gap: 6px; margin-bottom: 14px; }
     .field label { color: var(--cp-text-muted); font-size: 13px; font-weight: 600; }
     input, select, textarea {
@@ -394,7 +404,8 @@
       ["UTC", "UTC0"]
     ];
     const nav = [
-      ["home", "⌂", "Home"], ["status", "▥", "Status"], ["control", "◉", "Control"], ["events", "≡", "Events"]
+      ["home", "⌂", "Home"], ["status", "▥", "Status"], ["control", "◉", "Control"],
+      ["history", "📈", "History"], ["events", "≡", "Events"]
     ];
     const settingsNav = [
       ["wifi", "WiFi"], ["firmware", "Firmware"], ["time", "Time"], ["display", "Display"],
@@ -411,6 +422,7 @@
       },
       preferences: { temp_unit: "celsius", language_code: "en", brightness: 80 },
       errors: { active: [], history: [] }, params: {}, events: [], eventTotal: 0,
+      tempHistory: { loading: false, error: "", data: null, end: null },
       currentBootId: 0, eventOffset: 0, eventFilters: { search: "", category: "all", time: "all" },
       ota: {}, release: null, timeConfig: {}, security: {}, tls: {}, networks: [],
       ha: {}, haTimer: null,
@@ -858,6 +870,143 @@
         <div class="field"><label>Confirm password</label><input name="confirm_password" type="password" minlength="12" autocomplete="new-password" required></div>
         <button class="btn primary" type="submit">Save credentials</button></form></div>`;
     }
+    function fmtHistClock(epoch, withDate) {
+      const d = new Date(epoch * 1000);
+      const hh = String(d.getHours()).padStart(2, "0");
+      const mm = String(d.getMinutes()).padStart(2, "0");
+      if (!withDate) return `${hh}:${mm}`;
+      const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      return `${months[d.getMonth()]} ${d.getDate()}, ${hh}:${mm}`;
+    }
+    // Convert raw deci-Celsius to tenths of the user's preferred unit.
+    function histDeciToDisplay(deciC) {
+      return state.preferences.temp_unit === "fahrenheit" ? (deciC * 9 / 5 + 320) : deciC;
+    }
+    async function loadHistory() {
+      state.tempHistory.loading = true; state.tempHistory.error = "";
+      try {
+        const q = state.tempHistory.end ? `?end=${state.tempHistory.end}` : "";
+        state.tempHistory.data = await api(`/api/heatpump/temperature-history${q}`);
+      } catch (error) {
+        state.tempHistory.error = error.message || "Failed to load temperature history";
+      } finally {
+        state.tempHistory.loading = false;
+      }
+    }
+    function historyChartSvg(data) {
+      const samples = data.samples || [];
+      const W = 960, H = 360, L = 58, R = 16, T = 16, B = 34;
+      const plotL = L, plotR = W - R, plotT = T, plotB = H - B;
+      const plotW = plotR - plotL, plotH = plotB - plotT;
+      const start = data.start, end = data.end, span = Math.max(1, end - start);
+      const mapX = t => plotL + (Math.min(Math.max(t, start), end) - start) / span * plotW;
+
+      let lo = Infinity, hi = -Infinity;
+      for (const s of samples) {
+        for (const v of [s.in, s.out, s.set]) {
+          if (v === null || v === undefined) continue;
+          if (v < lo) lo = v;
+          if (v > hi) hi = v;
+        }
+      }
+      if (!isFinite(lo)) { lo = 0; hi = 400; }
+      if (hi - lo < 20) { const mid = (hi + lo) / 2; lo = mid - 10; hi = mid + 10; }
+      const pad = (hi - lo) * 0.08; lo -= pad; hi += pad;
+      const mapY = v => plotB - (v - lo) / (hi - lo) * plotH;
+
+      let svg = `<svg class="hist-chart" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="Temperature history chart">`;
+
+      // Mode bands: contiguous running periods tinted by operating mode.
+      const bandColor = { 1: "#ef4444", 2: "#3b82f6", 3: "#fbbf24" };
+      const interval = data.sample_interval_sec || 30;
+      let i = 0;
+      while (i < samples.length) {
+        const s = samples[i];
+        if (!s.run || !(s.mode >= 1 && s.mode <= 3)) { i++; continue; }
+        let j = i + 1;
+        while (j < samples.length && samples[j].run && samples[j].mode === s.mode) j++;
+        const x1 = mapX(s.t), x2 = mapX(samples[j - 1].t + interval);
+        svg += `<rect x="${x1.toFixed(1)}" y="${plotT}" width="${Math.max(1, x2 - x1).toFixed(1)}" height="${plotH}" fill="${bandColor[s.mode]}" opacity="0.13"/>`;
+        i = j;
+      }
+
+      // Horizontal gridlines + y-axis temperature labels.
+      for (let g = 0; g <= 5; g++) {
+        const y = plotB - g / 5 * plotH;
+        svg += `<line x1="${plotL}" y1="${y.toFixed(1)}" x2="${plotR}" y2="${y.toFixed(1)}" stroke="var(--cp-border)" stroke-width="1" opacity="0.7"/>`;
+        const val = lo + g / 5 * (hi - lo);
+        svg += `<text x="${plotL - 8}" y="${(y + 4).toFixed(1)}" text-anchor="end" class="hist-axis">${(histDeciToDisplay(val) / 10).toFixed(1)}°</text>`;
+      }
+
+      // Vertical gridlines snapped to whole even-hour marks (matches device).
+      const startDate = new Date(start * 1000);
+      const tick = new Date(startDate);
+      tick.setMinutes(0, 0, 0);
+      if (startDate.getMinutes() !== 0 || startDate.getSeconds() !== 0) tick.setHours(tick.getHours() + 1);
+      while (tick.getHours() % 2 !== 0) tick.setHours(tick.getHours() + 1);
+      for (let ts = Math.floor(tick.getTime() / 1000); ts <= end; ts += 2 * 3600) {
+        if (ts < start) continue;
+        const x = mapX(ts);
+        svg += `<line x1="${x.toFixed(1)}" y1="${plotT}" x2="${x.toFixed(1)}" y2="${plotB}" stroke="var(--cp-border)" stroke-width="1" opacity="0.7"/>`;
+        svg += `<text x="${x.toFixed(1)}" y="${plotB + 20}" text-anchor="middle" class="hist-axis">${fmtHistClock(ts, false)}</text>`;
+      }
+
+      // Series paths (setpoint is a step line, temps are smooth polylines).
+      const line = (key, color, step) => {
+        let d = "", pen = false;
+        for (const s of samples) {
+          const v = s[key];
+          if (v === null || v === undefined) { pen = false; continue; }
+          const x = mapX(s.t), y = mapY(v);
+          if (!pen) { d += `M${x.toFixed(1)} ${y.toFixed(1)}`; pen = true; }
+          else if (step) { d += `H${x.toFixed(1)}V${y.toFixed(1)}`; }
+          else { d += `L${x.toFixed(1)} ${y.toFixed(1)}`; }
+        }
+        return d ? `<path d="${d}" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>` : "";
+      };
+      svg += line("set", "#4ade80", true);
+      svg += line("out", "#fb7185", false);
+      svg += line("in", "#38bdf8", false);
+
+      svg += `</svg>`;
+      return svg;
+    }
+    function historyPage() {
+      const th = state.tempHistory, data = th.data;
+      let body;
+      if (th.loading && !data) {
+        body = `<section class="card"><div class="login" style="min-height:320px"><div class="spinner"></div></div></section>`;
+      } else if (th.error && !data) {
+        body = `<section class="card"><p class="hist-muted">${esc(th.error)}</p></section>`;
+      } else if (!data || !(data.samples && data.samples.length)) {
+        const interval = data ? data.sample_interval_sec : 30;
+        body = `<section class="card"><p class="hist-muted">No temperature history recorded yet. Samples are captured every ${interval}s while the heat pump is connected.</p></section>`;
+      } else {
+        const atLatest = data.end >= data.latest_end;
+        const atOldest = data.start <= data.earliest;
+        const rangeText = `${fmtHistClock(data.start, true)} — ${fmtHistClock(data.end, true)}`;
+        body = `<section class="card">
+          <div class="hist-toolbar">
+            <div class="hist-range">${esc(rangeText)}</div>
+            <div class="hist-legend">
+              <span><i style="background:#38bdf8"></i>Inlet</span>
+              <span><i style="background:#fb7185"></i>Outlet</span>
+              <span><i style="background:#4ade80"></i>Setpoint</span>
+            </div>
+          </div>
+          <div class="hist-chart-wrap">${historyChartSvg(data)}</div>
+          <div class="hist-nav">
+            <button class="btn" data-action="history-prev" ${atOldest ? "disabled" : ""}>‹ Earlier</button>
+            <button class="btn" data-action="history-latest" ${atLatest ? "disabled" : ""}>Latest</button>
+            <button class="btn" data-action="history-next" ${atLatest ? "disabled" : ""}>Later ›</button>
+          </div>
+        </section>`;
+      }
+      return `<div class="page">
+        ${pageHead("Temperature history", "Inlet, outlet, and setpoint over the last 8 hours.", `<button class="btn" data-action="history-refresh">Refresh</button>`)}
+        ${body}
+      </div>`;
+    }
     function render() {
       if (!state.auth.checked) {
         $("#app").innerHTML = `<div class="login"><div class="spinner"></div></div>`;
@@ -870,7 +1019,7 @@
         $("#app").innerHTML = credentialChangePage(); return;
       }
       const pages = { home: homePage, status: statusPage, control: controlPage, events: eventsPage,
-        errors: errorsPage, settings: settingsPage };
+        history: historyPage, errors: errorsPage, settings: settingsPage };
       $("#app").innerHTML = shell((pages[state.route] || homePage)());
       if (state.settingsPage === "diagnostics") {
         const logs = $("#log-container"); if (logs) logs.scrollTop = logs.scrollHeight;
@@ -961,11 +1110,13 @@
       stopHaPolling();
       state.route = route;
       if (settingsPage) state.settingsPage = settingsPage;
+      if (route === "history" && !state.tempHistory.data) state.tempHistory.loading = true;
       const targetHash = route === "settings" ? `#/settings/${state.settingsPage}` : `#/${route}`;
       if (location.hash !== targetHash) history.pushState(null, "", targetHash);
       render();
       try {
         if (route === "control" && !Object.keys(state.params).length) await loadParams();
+        if (route === "history") await loadHistory();
         if (route === "events" && !state.events.length) await loadEvents(true);
         if (route === "settings") {
           await ensureSettings();
@@ -1075,6 +1226,20 @@
         state.hp.mode = data.mode || el.dataset.value; render();
       }
       if (action === "reload-params") { await loadParams(); render(); }
+      if (action === "history-refresh") { await loadHistory(); render(); }
+      if (action === "history-latest") { state.tempHistory.end = null; await loadHistory(); render(); }
+      if (action === "history-prev") {
+        const d = state.tempHistory.data;
+        if (d) { state.tempHistory.end = d.start; await loadHistory(); render(); }
+      }
+      if (action === "history-next") {
+        const d = state.tempHistory.data;
+        if (d) {
+          const next = d.end + d.window_seconds;
+          state.tempHistory.end = next >= d.latest_end ? null : next;
+          await loadHistory(); render();
+        }
+      }
       if (action === "load-more-events") { await loadEvents(false); render(); }
       if (action === "clear-events" && confirm("Clear all operational events?")) {
         await mutate("/api/events", { method: "DELETE" }, "Events cleared"); await loadEvents(true); render();
@@ -1224,6 +1389,7 @@
           render();
           await loadCore();
           if (state.route === "control") await loadParams();
+          if (state.route === "history") await loadHistory();
           if (state.route === "events") await loadEvents(true);
           if (state.route === "settings") await ensureSettings();
         }

--- a/tests/api/test_temperature_history.py
+++ b/tests/api/test_temperature_history.py
@@ -79,3 +79,30 @@ def test_temperature_history_strings_exist_in_all_languages():
         "STR_HISTORY_NO_DATA",
     ):
         assert len(re.findall(rf"\[{name}\]\s*=", source)) == 3
+
+
+def test_web_api_exposes_temperature_history_endpoint():
+    source = (MAIN / "api_server.cpp").read_text(encoding="utf-8")
+    assert '"/api/heatpump/temperature-history"' in source
+    assert "heatpump_temperature_history_get_handler" in source
+    # Serves the data straight from the persistent telemetry store.
+    assert "history_storage_query_telemetry" in source
+    # Streamed in chunks so ~960 samples never build a huge in-RAM buffer.
+    assert "httpd_resp_sendstr_chunk" in source
+    # Guarded by the same API auth as the rest of the heatpump API.
+    assert "check_api_auth" in source
+
+
+def test_web_dashboard_has_temperature_history_view():
+    web = (MAIN / "web" / "index.html").read_text(encoding="utf-8")
+    # Registered as a first-class nav route and page.
+    assert '["history", ' in web
+    assert "history: historyPage" in web
+    assert "function historyPage" in web
+    assert "function loadHistory" in web
+    assert "function historyChartSvg" in web
+    # Fetches from the streaming endpoint above.
+    assert "/api/heatpump/temperature-history" in web
+    # Same 8-hour window / whole-hour axis rounding as the device chart.
+    assert "getHours() % 2 !== 0" in web
+

--- a/tests/web/test_temperature_history.py
+++ b/tests/web/test_temperature_history.py
@@ -45,8 +45,10 @@ class TestTemperatureHistoryWeb:
         _seed_history(base_url)
         _open_history(dashboard_page)
 
-        labels = dashboard_page.locator(".hist-chart text.hist-axis").all_inner_texts()
-        clock_labels = [t for t in labels if ":" in t]
+        # SVG <text> nodes support textContent (not innerText), so use
+        # all_text_contents() which reads textContent.
+        labels = dashboard_page.locator(".hist-chart text.hist-axis").all_text_contents()
+        clock_labels = [t for t in labels if t and ":" in t]
         assert clock_labels, "expected time labels on the x-axis"
         # Every x-axis time label is rounded to a whole hour (:00).
         assert all(t.endswith(":00") for t in clock_labels)

--- a/tests/web/test_temperature_history.py
+++ b/tests/web/test_temperature_history.py
@@ -1,0 +1,72 @@
+"""Web dashboard tests for the temperature history view."""
+
+import requests
+import urllib3
+from playwright.sync_api import Page, expect
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _seed_history(base_url: str) -> dict:
+    """Replace telemetry history with the deterministic 8-hour fixture."""
+    r = requests.post(
+        f"{base_url}/api/test/populate-temperature-history",
+        timeout=30,
+        verify=False,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _open_history(page: Page) -> None:
+    page.locator(".rail .nav-link", has_text="History").click()
+    page.wait_for_selector(".hist-chart", timeout=10000)
+
+
+class TestTemperatureHistoryWeb:
+    def test_history_view_renders_chart(self, dashboard_page: Page, base_url: str):
+        _seed_history(base_url)
+        _open_history(dashboard_page)
+
+        expect(
+            dashboard_page.get_by_role("heading", name="Temperature history")
+        ).to_be_visible()
+
+        # Inlet, outlet, and setpoint each draw a path.
+        assert dashboard_page.locator(".hist-chart path").count() >= 3
+        expect(
+            dashboard_page.locator(".hist-legend", has_text="Inlet")
+        ).to_be_visible()
+        expect(
+            dashboard_page.locator(".hist-legend", has_text="Setpoint")
+        ).to_be_visible()
+
+    def test_axis_labels_are_whole_hours(self, dashboard_page: Page, base_url: str):
+        _seed_history(base_url)
+        _open_history(dashboard_page)
+
+        labels = dashboard_page.locator(".hist-chart text.hist-axis").all_inner_texts()
+        clock_labels = [t for t in labels if ":" in t]
+        assert clock_labels, "expected time labels on the x-axis"
+        # Every x-axis time label is rounded to a whole hour (:00).
+        assert all(t.endswith(":00") for t in clock_labels)
+
+    def test_history_navigation_shifts_window(
+        self, dashboard_page: Page, base_url: str
+    ):
+        _seed_history(base_url)
+        _open_history(dashboard_page)
+
+        # At the most recent window, Later/Latest are disabled.
+        expect(dashboard_page.locator('[data-action="history-latest"]')).to_be_disabled()
+
+        range_before = dashboard_page.locator(".hist-range").inner_text()
+        dashboard_page.locator('[data-action="history-prev"]').click()
+        dashboard_page.wait_for_function(
+            "prev => document.querySelector('.hist-range')?.innerText !== prev",
+            arg=range_before,
+            timeout=10000,
+        )
+
+        # Having stepped back, returning to the latest window is now possible.
+        expect(dashboard_page.locator('[data-action="history-latest"]')).to_be_enabled()


### PR DESCRIPTION
## What

Two temperature-history improvements requested by @sslivins.

### 1. Round the graph x-axis to whole hours (device)
The 8-hour history graph labelled its x-axis at the ragged window edges (e.g. `14:37`, `16:37`) because the window ends exactly at "now". The gridlines/labels are now anchored to whole **even-hour** marks in local time, while the data window still ends at now — so the axis reads in clean hours (`08:00`, `10:00`, `12:00`…) without dropping any recent data.

### 2. Temperature history on the web UI (feature)
- **New endpoint** `GET /api/heatpump/temperature-history[?end=<epoch>]` returning up to an 8-hour window of telemetry samples as **streamed** JSON (auth-guarded; temps are raw deci-Celsius or `null` per reading). Documented in `docs/openapi.yaml`.
- **New "History" nav view** in the dashboard rendering an SVG chart (inlet / outlet / setpoint series + mode bands + the same whole-hour axis) with **Earlier / Later / Latest** navigation, mirroring the on-device screen.

## Tests
- Host-side static guards for the endpoint wiring + web view (`tests/api/test_temperature_history.py`).
- Playwright web tests seeding the fixture and asserting the chart renders, x-axis labels are whole hours, and window navigation works (`tests/web/test_temperature_history.py`).
- Full firmware build passes (47% app partition free); host-side API suite green locally.

## Notes
- JSON is streamed in chunks so ~960 samples never build a large in-RAM buffer.
- Web chart uses inline SVG (no chart library) and CSS theme vars so it adapts to light/dark.