### PR TITLE
feat(web): notification bell + fix OTA progress stall

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -539,6 +539,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/notifications:
+    get:
+      tags:
+        - Status
+      summary: Active status-bar notifications
+      description: |
+        Returns the notifications currently shown on the on-device status-bar
+        bell (firmware update available, unstable WiFi, low battery). The web
+        dashboard uses this to mirror the device notification bell.
+      operationId: getNotifications
+      security:
+        - apiKey: []
+        - sessionCookie: []
+      responses:
+        '200':
+          description: Active notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of active notifications
+                    example: 1
+                  notifications:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: integer
+                          description: Numeric notification type (0=firmware, 1=wifi, 2=battery)
+                          example: 0
+                        key:
+                          type: string
+                          enum: [firmware_update, wifi_unstable, low_battery, unknown]
+                          description: Stable, language-independent notification key
+                          example: firmware_update
+                        message:
+                          type: string
+                          description: Human-readable notification message
+                          example: Firmware v2.11.13 available
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /api/ota/status:
     get:
       tags:

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -28,6 +28,7 @@
 #include "advanced_params.h"  // advanced_param_write() AP guardrail
 #include "heatpump_errors.h"
 #include "history_storage.h"
+#include "status_bar.h"        // status_bar_get_notifications() for /api/notifications
 #include "event_log.h"
 #include "factory_reset.h"
 #include "boot_stats.h"
@@ -158,6 +159,7 @@ static esp_err_t heatpump_demo_patch_handler(httpd_req_t* req);
 #endif
 static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req);
 static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req);
+static esp_err_t notifications_get_handler(httpd_req_t* req);
 static esp_err_t events_get_handler(httpd_req_t* req);
 static esp_err_t events_clear_handler(httpd_req_t* req);
 static esp_err_t brownout_clear_handler(httpd_req_t* req);
@@ -948,6 +950,15 @@ bool api_server_start(void)
         .user_ctx = NULL
     };
     REGISTER_URI(heatpump_temperature_history_uri);
+
+    // GET /api/notifications - Active status-bar notifications (mirrors the device bell)
+    httpd_uri_t notifications_uri = {
+        .uri = "/api/notifications",
+        .method = HTTP_GET,
+        .handler = notifications_get_handler,
+        .user_ctx = NULL
+    };
+    REGISTER_URI(notifications_uri);
     
     // GET /api/heatpump/diagnostic - Download diagnostic CSV dump
     httpd_uri_t heatpump_diagnostic_uri = {
@@ -4178,6 +4189,55 @@ static esp_err_t heatpump_diagnostic_get_handler(httpd_req_t* req)
 
     // Terminate chunked response
     httpd_resp_sendstr_chunk(req, NULL);
+    return ESP_OK;
+}
+
+// Stable, language-independent key for each notification type so the web bell
+// can pick an icon / navigation target without parsing the message text.
+static const char* notify_type_key(status_bar_notify_type_t type)
+{
+    switch (type) {
+        case STATUS_BAR_NOTIFY_FIRMWARE_UPDATE: return "firmware_update";
+        case STATUS_BAR_NOTIFY_WIFI_UNSTABLE:   return "wifi_unstable";
+        case STATUS_BAR_NOTIFY_LOW_BATTERY:     return "low_battery";
+        default:                                return "unknown";
+    }
+}
+
+// GET /api/notifications - Active status-bar notifications (mirrors the device bell)
+static esp_err_t notifications_get_handler(httpd_req_t* req)
+{
+    if (!check_api_auth(req)) {
+        send_json_error(req, "401 Unauthorized", "API key required");
+        return ESP_OK;
+    }
+
+    set_json_content_type(req);
+
+    status_bar_notification_snapshot_t items[STATUS_BAR_NOTIFY_MAX];
+    bsp_display_lock(0);
+    uint8_t count = status_bar_get_notifications(items, STATUS_BAR_NOTIFY_MAX);
+    bsp_display_unlock();
+
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "count", count);
+    cJSON* arr = cJSON_AddArrayToObject(root, "notifications");
+    for (uint8_t i = 0; i < count; i++) {
+        cJSON* n = cJSON_CreateObject();
+        cJSON_AddNumberToObject(n, "type", (double)items[i].type);
+        cJSON_AddStringToObject(n, "key", notify_type_key(items[i].type));
+        cJSON_AddStringToObject(n, "message", items[i].message);
+        cJSON_AddItemToArray(arr, n);
+    }
+
+    char* json = cJSON_PrintUnformatted(root);
+    if (json) {
+        httpd_resp_sendstr(req, json);
+        free(json);
+    } else {
+        httpd_resp_sendstr(req, "{\"count\":0,\"notifications\":[]}");
+    }
+    cJSON_Delete(root);
     return ESP_OK;
 }
 

--- a/main/status_bar.cpp
+++ b/main/status_bar.cpp
@@ -390,6 +390,24 @@ uint8_t status_bar_get_notify_count(void)
     return count_active_notifications();
 }
 
+uint8_t status_bar_get_notifications(status_bar_notification_snapshot_t* out, uint8_t max)
+{
+    uint8_t written = 0;
+    for (int i = 0; i < STATUS_BAR_NOTIFY_MAX; i++) {
+        if (!bar_state.notifications[i].active) {
+            continue;
+        }
+        if (out && written < max) {
+            out[written].type = (status_bar_notify_type_t)i;
+            strncpy(out[written].message, bar_state.notifications[i].message,
+                    sizeof(out[written].message) - 1);
+            out[written].message[sizeof(out[written].message) - 1] = '\0';
+            written++;
+        }
+    }
+    return written;
+}
+
 void status_bar_set_wifi_connecting(bool connecting)
 {
     if (connecting == bar_state.wifi_connecting) {

--- a/main/status_bar.h
+++ b/main/status_bar.h
@@ -104,6 +104,25 @@ bool status_bar_has_notification(status_bar_notify_type_t type);
 uint8_t status_bar_get_notify_count(void);
 
 /**
+ * @brief A snapshot of one active notification (for the web API / diagnostics).
+ */
+typedef struct {
+    status_bar_notify_type_t type;  // Notification type
+    char message[64];               // Human-readable message
+} status_bar_notification_snapshot_t;
+
+/**
+ * @brief Copy the currently-active notifications into caller-provided storage.
+ *
+ * Lets non-UI code (e.g. the web API) mirror the on-device notification bell.
+ *
+ * @param out Destination array (may be NULL when @p max is 0)
+ * @param max Capacity of @p out
+ * @return Number of active notifications written into @p out (<= max)
+ */
+uint8_t status_bar_get_notifications(status_bar_notification_snapshot_t* out, uint8_t max);
+
+/**
  * @brief Update time display
  *        Call this periodically or it will auto-update via timer
  */

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -137,6 +137,31 @@
       border-radius: 10px; background: var(--cp-surface); color: var(--cp-text);
       display: grid; place-items: center; text-decoration: none;
     }
+    .notif-wrap { position: relative; }
+    .notif-btn { position: relative; cursor: pointer; font-size: 17px; }
+    .notif-badge {
+      position: absolute; top: -6px; right: -6px; min-width: 18px; height: 18px;
+      padding: 0 5px; border-radius: 9px; background: var(--cp-danger); color: #fff;
+      font-size: 11px; font-weight: 700; line-height: 18px; text-align: center;
+    }
+    .notif-panel {
+      position: absolute; top: 46px; right: 0; width: 320px; max-width: 82vw; z-index: 50;
+      background: var(--cp-surface); border: 1px solid var(--cp-border); border-radius: 12px;
+      box-shadow: 0 12px 32px rgba(0,0,0,.35); overflow: hidden;
+    }
+    .notif-panel h3 { margin: 0; padding: 12px 14px; font-size: 13px; border-bottom: 1px solid var(--cp-border); color: var(--cp-text-muted); }
+    .notif-item {
+      display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+      padding: 12px 14px; border: 0; border-bottom: 1px solid var(--cp-border);
+      background: transparent; color: var(--cp-text); font-size: 14px; cursor: pointer;
+    }
+    .notif-item:last-child { border-bottom: 0; }
+    .notif-item:hover { background: var(--cp-surface-soft); }
+    .notif-item .ni-icon { font-size: 18px; flex: 0 0 auto; }
+    .notif-empty { padding: 18px 14px; color: var(--cp-text-muted); font-size: 13px; text-align: center; }
+    .ota-indeterminate { margin: 12px 0 6px; height: 6px; border-radius: 3px; background: var(--cp-border); overflow: hidden; }
+    .ota-indeterminate-bar { width: 40%; height: 100%; border-radius: 3px; background: var(--cp-accent, #2f81f7); animation: ota-slide 1.3s ease-in-out infinite; }
+    @keyframes ota-slide { 0% { transform: translateX(-100%); } 100% { transform: translateX(320%); } }
     .layout { display: grid; grid-template-columns: 216px minmax(0, 1fr); min-height: calc(100vh - 64px); }
     .rail {
       position: sticky; top: 64px; align-self: start; height: calc(100vh - 64px);
@@ -425,6 +450,7 @@
       tempHistory: { loading: false, error: "", data: null, end: null },
       currentBootId: 0, eventOffset: 0, eventFilters: { search: "", category: "all", time: "all" },
       ota: {}, release: null, timeConfig: {}, security: {}, tls: {}, networks: [],
+      notifications: [], notifOpen: false,
       ha: {}, haTimer: null,
       settingsLoaded: false, settingsPromise: null,
       logs: [], logSeq: 0, logLevel: "V", logTimer: null, pollTimer: null,
@@ -502,6 +528,28 @@
       if (state.route === "settings") state.settingsPage = parts[1] || "wifi";
       if (![...nav.map(n => n[0]), "settings", "errors"].includes(state.route)) state.route = "home";
     }
+    const NOTIF_META = {
+      firmware_update: { icon: "⬇️", route: ["settings", "firmware"] },
+      wifi_unstable:   { icon: "📶", route: ["settings", "wifi"] },
+      low_battery:     { icon: "🔋", route: null },
+      unknown:         { icon: "🔔", route: null },
+    };
+    function notifBell() {
+      const items = state.notifications || [];
+      const badge = items.length ? `<span class="notif-badge">${items.length}</span>` : "";
+      const panel = state.notifOpen ? `
+        <div class="notif-panel" data-notif-panel>
+          <h3>Notifications</h3>
+          ${items.length ? items.map((n, i) => {
+            const meta = NOTIF_META[n.key] || NOTIF_META.unknown;
+            return `<button class="notif-item" data-action="notif-open" data-index="${i}">
+              <span class="ni-icon">${meta.icon}</span><span>${esc(n.message || n.key)}</span></button>`;
+          }).join("") : `<div class="notif-empty">No notifications</div>`}
+        </div>` : "";
+      return `<div class="notif-wrap">
+        <button class="icon-btn notif-btn" data-action="notif-toggle" aria-label="Notifications">🔔${badge}</button>
+        ${panel}</div>`;
+    }
     function shell(content) {
       const connected = !!state.hp.connected;
       return `<div class="app">
@@ -511,6 +559,7 @@
             <span class="status-item"><span class="dot ${connected ? "good" : "bad"}"></span>${connected ? "Heat pump online" : "Heat pump offline"}</span>
             <span class="status-item">${esc(state.wifi.ssid || "WiFi disconnected")}</span>
             <span class="status-item">${esc(state.status.time?.local || "--:--")}</span>
+            ${notifBell()}
             <button class="icon-btn" data-route="settings" aria-label="Settings">⚙</button>
             ${state.auth.required ? `<button class="btn" data-action="logout" style="padding:6px 12px;font-size:13px" aria-label="Sign out">Sign out</button>` : ""}
           </div>
@@ -741,20 +790,31 @@
           <p><button class="btn primary" type="submit">Save and connect</button></p></form></section>`;
     }
     function firmwareSettings() {
-      const otaActive = ["downloading", "verifying"].includes(state.ota.state);
-      const showProgress = otaActive || (state.ota.progress != null && state.ota.progress > 0);
+      const inst = state.otaInstall;
+      const installing = inst && inst.active;
+      const installDone = inst && !inst.active && inst.phase === "done";
+      const installFailed = inst && !inst.active && (inst.phase === "failed" || inst.phase === "timeout");
+      const indeterminate = installing && ["starting", "applying", "rebooting"].includes(inst.phase);
+      const otaActive = installing || ["downloading", "verifying"].includes(state.ota.state);
+      const showProgress = !inst && (["downloading", "verifying"].includes(state.ota.state) || (state.ota.progress != null && state.ota.progress > 0));
       return `<section class="card"><h2>Firmware</h2>
-        <div class="kv"><span>Current version</span><strong>${esc(state.ota.current_version || state.info.version || "--")}</strong></div>
-        <div class="kv"><span>Update status</span><strong>${esc(titleCase(state.ota.state || "idle"))}</strong></div>
+        <div class="kv"><span>Current version</span><strong>${esc((installDone && inst.newVersion) || state.ota.current_version || state.info.version || "--")}</strong></div>
+        <div class="kv"><span>Update status</span><strong>${esc(inst ? OTA_PHASE_LABEL[inst.phase] : titleCase(state.ota.state || "idle"))}</strong></div>
+        ${installing && inst.phase === "downloading" ? `<div class="kv"><span>Progress</span><strong>${inst.progress || 0}%</strong></div>` : ""}
+        ${indeterminate ? `<div class="ota-indeterminate"><div class="ota-indeterminate-bar"></div></div>
+          <div class="metric-sub">The controller is writing the new firmware and will reboot. This can take a couple of minutes and the connection will drop briefly — that's expected.</div>` : ""}
         ${showProgress ? `<div class="kv"><span>Progress</span><strong>${state.ota.progress || 0}%</strong></div>` : ""}
-        ${state.ota.error ? `<div class="notice bad" style="margin-top:16px">Update failed: ${esc(state.ota.error)}</div>` : ""}
+        ${installDone ? `<div class="notice good" style="margin-top:16px">Updated to ${esc(inst.newVersion || inst.target || "the latest version")} ✓</div>` : ""}
+        ${installFailed ? `<div class="notice bad" style="margin-top:16px">${inst.phase === "timeout" ? "The device is taking longer than expected. Reload the page to check its status." : "Update failed: " + esc(inst.error || "unknown error")}</div>` : ""}
+        ${!inst && state.ota.error ? `<div class="notice bad" style="margin-top:16px">Update failed: ${esc(state.ota.error)}</div>` : ""}
         <div class="btn-row" style="margin-top:16px">
-          ${otaActive
-            ? `<button class="btn" disabled>Installing…</button>`
+          ${installing
+            ? `<button class="btn" disabled>${indeterminate ? "Applying…" : "Installing…"}</button>`
             : `<button class="btn" data-action="check-update">Check for updates</button>
-               ${state.release?.update_available && state.release?.download_ready ? `<button class="btn primary" data-action="install-update">Install ${esc(state.release.latest_version)}</button>` : ""}`}
-          ${state.ota.state === "ready_to_reboot" ? `<button class="btn primary" data-action="reboot">Reboot now</button>` : ""}</div>
-        ${!otaActive && state.release ? `<div class="notice" style="margin-top:16px">${state.release.update_available ? `Version ${esc(state.release.latest_version)} is available.` : "The controller is up to date."}</div>` : ""}
+               ${state.release?.update_available && state.release?.download_ready ? `<button class="btn primary" data-action="install-update">Install ${esc(state.release.latest_version)}</button>` : ""}
+               ${(installDone || installFailed) ? `<button class="btn" data-action="ota-dismiss">Dismiss</button>` : ""}`}
+          ${!installing && state.ota.state === "ready_to_reboot" ? `<button class="btn primary" data-action="reboot">Reboot now</button>` : ""}</div>
+        ${!otaActive && !inst && state.release ? `<div class="notice" style="margin-top:16px">${state.release.update_available ? `Version ${esc(state.release.latest_version)} is available.` : "The controller is up to date."}</div>` : ""}
         <h3 style="margin-top:28px">Upload firmware</h3><form data-form="firmware"><div class="field"><label>ESP-IDF application image (.bin)</label>
           <input type="file" name="firmware" accept=".bin,application/octet-stream"></div><button class="btn" type="submit">Upload and install</button></form>
       </section>`;
@@ -1029,10 +1089,11 @@
     async function loadCore() {
       const results = await Promise.allSettled([
         api("/api/info"), api("/api/status"), api("/api/wifi"), api("/api/heatpump/status"),
-        api("/api/preferences"), api("/api/heatpump/errors"), api("/api/ota/status")
+        api("/api/preferences"), api("/api/heatpump/errors"), api("/api/ota/status"), api("/api/notifications")
       ]);
       const values = results.map(r => r.status === "fulfilled" ? r.value : {});
       [state.info, state.status, state.wifi, state.hp, state.preferences, state.errors, state.ota] = values;
+      state.notifications = values[7].notifications || [];
     }
     async function loadParams() { const data = await api("/api/heatpump/advanced"); state.params = data.params || {}; }
     async function loadEvents(reset = false) {
@@ -1220,7 +1281,75 @@
         xhr.send(file);
       }
     }
+    const OTA_PHASE_LABEL = {
+      starting: "Starting update…",
+      downloading: "Downloading firmware…",
+      applying: "Applying update & rebooting…",
+      rebooting: "Applying update & rebooting…",
+      done: "Update complete",
+      failed: "Update failed",
+      timeout: "Still finishing…",
+    };
+
+    // Drives the OTA install UI through its full lifecycle. The device stops its
+    // web server before erasing/writing flash (to avoid a C6 SDIO wedge), so the
+    // browser loses connection mid-install — we treat that loss as "applying &
+    // rebooting" and wait for the device to come back on the new version.
+    async function startInstallWatch() {
+      const startVersion = state.ota.current_version || state.info.version || "";
+      state.otaInstall = {
+        active: true, phase: "starting", startVersion,
+        target: state.release?.latest_version || "", progress: 0,
+        error: "", newVersion: "", started: Date.now(),
+      };
+      render();
+      const TIMEOUT_MS = 5 * 60 * 1000;
+      const tick = async () => {
+        const inst = state.otaInstall;
+        if (!inst || !inst.active) return;
+        if (Date.now() - inst.started > TIMEOUT_MS) {
+          inst.phase = "timeout"; inst.active = false; render(); return;
+        }
+        let ota = null;
+        try { ota = await api("/api/ota/status"); } catch (_) { ota = null; }
+        if (ota) {
+          state.ota = ota;
+          if (ota.state === "downloading") {
+            inst.phase = "downloading"; inst.progress = ota.progress || 0;
+          } else if (ota.state === "verifying") {
+            inst.phase = "applying"; inst.progress = 100;
+          } else if (ota.state === "ready_to_reboot") {
+            inst.phase = "rebooting"; inst.progress = 100;
+          } else if (ota.state === "failed") {
+            inst.phase = "failed"; inst.error = ota.error || "Update failed";
+            inst.active = false; render(); return;
+          } else if (ota.state === "idle") {
+            const advanced = ota.current_version && ota.current_version !== inst.startVersion;
+            if (advanced || ["applying", "rebooting"].includes(inst.phase)) {
+              inst.phase = "done"; inst.active = false;
+              inst.newVersion = ota.current_version || inst.target; render(); return;
+            }
+          }
+        } else if (["starting", "downloading", "applying", "rebooting"].includes(inst.phase)) {
+          // Server unreachable: expected while the device flashes and reboots.
+          inst.phase = "rebooting";
+        }
+        render();
+        setTimeout(tick, 2000);
+      };
+      setTimeout(tick, 1500);
+    }
+
     async function handleAction(action, el) {
+      if (action === "notif-toggle") { state.notifOpen = !state.notifOpen; render(); return; }
+      if (action === "notif-open") {
+        const n = state.notifications[parseInt(el.dataset.index, 10)];
+        state.notifOpen = false;
+        const meta = n && (NOTIF_META[n.key] || NOTIF_META.unknown);
+        if (meta && meta.route) await navigate(meta.route[0], meta.route[1]);
+        else render();
+        return;
+      }
       if (action === "mode") {
         const data = await mutate("/api/heatpump/mode", jsonOptions("PUT", { mode: el.dataset.value }), "Mode changed");
         state.hp.mode = data.mode || el.dataset.value; render();
@@ -1260,8 +1389,9 @@
       if (action === "check-update") { state.release = await mutate("/api/ota/releases", {}, "Update check complete"); render(); }
       if (action === "install-update" && confirm("Download and install this update?")) {
         await mutate("/api/ota/github", { method: "POST" }, "Update started");
-        state.ota = await api("/api/ota/status").catch(() => state.ota); render();
+        startInstallWatch();
       }
+      if (action === "ota-dismiss") { state.otaInstall = null; render(); }
       if (action === "reboot" && confirm("Restart the controller now?")) await mutate("/api/ota/reboot", { method: "POST" }, "Controller restarting");
       if (action === "copy-key") { await navigator.clipboard.writeText(state.security.api_key || ""); toast("API key copied", "good"); }
       if (action === "regenerate-key" && confirm("Regenerate the API key? Existing integrations will stop working.")) {
@@ -1318,6 +1448,11 @@
     }
 
     document.addEventListener("click", async event => {
+      // Close the notification panel when clicking outside it (but still let the
+      // click perform its normal action below).
+      if (state.notifOpen && !event.target.closest(".notif-wrap")) {
+        state.notifOpen = false; render();
+      }
       const route = event.target.closest("[data-route]");
       if (route) { event.preventDefault(); await navigate(route.dataset.route); return; }
       const settings = event.target.closest("[data-settings]");
@@ -1408,16 +1543,19 @@
       state.pollTimer = setInterval(async () => {
         if (!state.auth.loggedIn || state.auth.changeRequired) return;
         try {
-          const [status, hp, wifi, ota, errors] = await Promise.all([
-            api("/api/status"), api("/api/heatpump/status"), api("/api/wifi"), api("/api/ota/status"), api("/api/heatpump/errors")
+          const [status, hp, wifi, ota, errors, notif] = await Promise.all([
+            api("/api/status"), api("/api/heatpump/status"), api("/api/wifi"), api("/api/ota/status"), api("/api/heatpump/errors"), api("/api/notifications")
           ]);
           Object.assign(state, { status, hp, wifi, ota, errors });
+          const prevNotifCount = (state.notifications || []).length;
+          state.notifications = notif.notifications || [];
           if (state.route === "events") {
             const searchFocused = document.activeElement?.id === "event-search";
             await loadEvents(true);
             if (searchFocused) refreshEventResults();
             else render();
           } else if (["home", "status", "errors"].includes(state.route)) render();
+          else if (state.notifications.length !== prevNotifCount) render();
           else if (state.route === "settings" && state.settingsPage === "firmware"
                    && ota && ota.state && ota.state !== "idle") render();
         } catch (_) {}

--- a/tests/web/test_notifications.py
+++ b/tests/web/test_notifications.py
@@ -1,0 +1,79 @@
+"""Web dashboard tests for the notification bell (mirrors the on-device bell)."""
+
+import requests
+import urllib3
+from playwright.sync_api import Page, expect
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _add_notification(base_url: str, ntype: int = 0, message: str = "Firmware v99.0.0 available"):
+    r = requests.post(
+        f"{base_url}/api/test/notification-mock",
+        json={"type": ntype, "message": message},
+        timeout=10,
+        verify=False,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _reset_notifications(base_url: str):
+    requests.post(
+        f"{base_url}/api/test/notification-mock-reset",
+        json={},
+        timeout=10,
+        verify=False,
+    )
+
+
+class TestNotificationBellWeb:
+    def test_notifications_endpoint_reports_active(self, base_url: str):
+        _reset_notifications(base_url)
+        try:
+            _add_notification(base_url)
+            r = requests.get(f"{base_url}/api/notifications", timeout=10, verify=False)
+            r.raise_for_status()
+            data = r.json()
+            assert data["count"] >= 1
+            keys = [n["key"] for n in data["notifications"]]
+            assert "firmware_update" in keys
+        finally:
+            _reset_notifications(base_url)
+
+    def test_bell_shows_badge_and_panel(self, dashboard_page: Page, base_url: str):
+        _reset_notifications(base_url)
+        try:
+            _add_notification(base_url)
+            # Reload so loadCore() picks up the seeded notification.
+            dashboard_page.reload(wait_until="domcontentloaded")
+            dashboard_page.wait_for_selector(".rail", timeout=10000)
+
+            # Badge shows the active count.
+            expect(dashboard_page.locator(".notif-badge")).to_be_visible()
+
+            # Opening the bell reveals the notification item.
+            dashboard_page.locator(".notif-btn").click()
+            expect(dashboard_page.locator(".notif-panel")).to_be_visible()
+            expect(
+                dashboard_page.locator(".notif-item", has_text="Firmware v99.0.0 available")
+            ).to_be_visible()
+        finally:
+            _reset_notifications(base_url)
+
+    def test_firmware_notification_navigates_to_firmware(self, dashboard_page: Page, base_url: str):
+        _reset_notifications(base_url)
+        try:
+            _add_notification(base_url)
+            dashboard_page.reload(wait_until="domcontentloaded")
+            dashboard_page.wait_for_selector(".rail", timeout=10000)
+
+            dashboard_page.locator(".notif-btn").click()
+            dashboard_page.locator(".notif-item", has_text="Firmware").click()
+
+            # Firmware settings page renders its heading.
+            expect(
+                dashboard_page.get_by_role("heading", name="Firmware")
+            ).to_be_visible()
+        finally:
+            _reset_notifications(base_url)

--- a/tests/web/test_notifications.py
+++ b/tests/web/test_notifications.py
@@ -28,13 +28,15 @@ def _reset_notifications(base_url: str):
 
 
 class TestNotificationBellWeb:
-    def test_notifications_endpoint_reports_active(self, base_url: str):
+    def test_notifications_endpoint_reports_active(self, dashboard_page: Page, base_url: str):
         _reset_notifications(base_url)
         try:
             _add_notification(base_url)
-            r = requests.get(f"{base_url}/api/notifications", timeout=10, verify=False)
-            r.raise_for_status()
-            data = r.json()
+            # Fetch through the browser's own authenticated context (same path
+            # the dashboard uses), so the auth-guarded endpoint is reachable.
+            data = dashboard_page.evaluate(
+                "() => fetch('/api/notifications').then(r => r.json())"
+            )
             assert data["count"] >= 1
             keys = [n["key"] for n in data["notifications"]]
             assert "firmware_update" in keys
@@ -71,9 +73,9 @@ class TestNotificationBellWeb:
             dashboard_page.locator(".notif-btn").click()
             dashboard_page.locator(".notif-item", has_text="Firmware").click()
 
-            # Firmware settings page renders its heading.
+            # Firmware settings page renders its unique "Check for updates" control.
             expect(
-                dashboard_page.get_by_role("heading", name="Firmware")
+                dashboard_page.get_by_role("button", name="Check for updates")
             ).to_be_visible()
         finally:
             _reset_notifications(base_url)


### PR DESCRIPTION
## Summary

Two web-dashboard UX nits, batched into one PR:

1. **Notification bell on the web dashboard** — mirrors the on-device status-bar bell.
2. **Fix web firmware-update progress freezing at ~87%** — the device flashes and reboots fine, it was purely a status/UX issue.

## Notification bell

- New `GET /api/notifications` endpoint returning the active status-bar notifications (`firmware_update` / `wifi_unstable` / `low_battery`), auth-guarded and documented in `docs/openapi.yaml`.
- `status_bar_get_notifications()` accessor snapshots the active in-memory notifications for the HTTP thread (under the display lock).
- Web bell UI: a 🔔 button in the topbar with an active-count badge and a dropdown panel. Items are click-to-navigate (firmware → Firmware settings, wifi → WiFi settings). Outside-click closes the panel. Data is loaded in `loadCore()` and refreshed by the existing 5 s poller (re-renders when the count changes).

## OTA progress fix

The device intentionally calls `api_server_stop()` + `mdns_free()` **before** erasing/writing flash (to avoid a C6 SDIO-RX starvation wedge during the long erase). So once the image finishes downloading, the web server is dead — the browser can never observe `verifying`/`ready_to_reboot`, and its last successful poll (mid-download, ~87%) just froze.

The fix is client-side: the install action now drives a lifecycle that tracks the download %, then switches to an indeterminate **"Applying update & rebooting…"** state once the device becomes unreachable (or reaches `verifying`). It records the pre-update version and, when the device returns, reports **"Updated to vX.Y.Z ✓"** (version advanced) or a failure/timeout message.

## Tests

- Adds `tests/web/test_notifications.py` (Playwright): asserts `/api/notifications` reports seeded notifications, the bell badge + panel render, and a firmware notification navigates to Firmware settings.
- openapi coverage test passes with the new documented route.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
