### PR TITLE
feat: surface brownout resets in the notification bell

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -575,7 +575,7 @@ paths:
                           example: 0
                         key:
                           type: string
-                          enum: [firmware_update, wifi_unstable, low_battery, unknown]
+                          enum: [firmware_update, wifi_unstable, low_battery, brownout, unknown]
                           description: Stable, language-independent notification key
                           example: firmware_update
                         message:

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -4200,6 +4200,7 @@ static const char* notify_type_key(status_bar_notify_type_t type)
         case STATUS_BAR_NOTIFY_FIRMWARE_UPDATE: return "firmware_update";
         case STATUS_BAR_NOTIFY_WIFI_UNSTABLE:   return "wifi_unstable";
         case STATUS_BAR_NOTIFY_LOW_BATTERY:     return "low_battery";
+        case STATUS_BAR_NOTIFY_BROWNOUT:        return "brownout";
         default:                                return "unknown";
     }
 }
@@ -4609,6 +4610,11 @@ static esp_err_t brownout_clear_handler(httpd_req_t* req)
     set_json_content_type(req);
     
     boot_stats_clear();
+    // Also clear the brownout notification badge so acknowledging the counter
+    // from the web/API dismisses the bell everywhere.
+    bsp_display_lock(0);
+    status_bar_clear_notification(STATUS_BAR_NOTIFY_BROWNOUT);
+    bsp_display_unlock();
     httpd_resp_sendstr(req, "{\"success\":true}");
     return ESP_OK;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -467,6 +467,18 @@ void create_ui(void)
     if (wifi_init_complete && wifi_mgr_get_state() == WIFI_MGR_STATE_CONNECTED) {
         status_bar_set_wifi_state(true, wifi_mgr_get_connected_ssid());
     }
+
+    // Surface a brownout warning in the notification bell. The brownout counter
+    // is persisted in NVS (boot_stats), so a supply sag survives the reboot it
+    // causes and stays visible until the user acknowledges it (which clears the
+    // counter). Called with the display lock already held by the caller.
+    uint32_t brownouts = boot_stats_brownout_count();
+    if (brownouts > 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "Brownout detected (%lu) - check power supply",
+                 (unsigned long)brownouts);
+        status_bar_add_notification(STATUS_BAR_NOTIFY_BROWNOUT, msg);
+    }
 }
 
 // ============================================================================
@@ -776,7 +788,14 @@ static void on_status_bar_notify_item_click(status_bar_notify_type_t type)
         case STATUS_BAR_NOTIFY_LOW_BATTERY:
             // Just clear (already done above) - no additional action
             break;
-        
+
+        case STATUS_BAR_NOTIFY_BROWNOUT:
+            // Acknowledge the power warning: clear the persistent brownout
+            // counter so it does not re-raise on the next boot. (RAM
+            // notification already cleared above.)
+            boot_stats_clear();
+            break;
+
         default:
             mclog::tagWarn(TAG, "Unknown notification type: {}", (int)type);
             break;

--- a/main/status_bar.cpp
+++ b/main/status_bar.cpp
@@ -610,6 +610,7 @@ static void show_dropdown(void)
             case STATUS_BAR_NOTIFY_FIRMWARE_UPDATE: item_tag = "notify_item_firmware"; break;
             case STATUS_BAR_NOTIFY_WIFI_UNSTABLE:   item_tag = "notify_item_wifi";     break;
             case STATUS_BAR_NOTIFY_LOW_BATTERY:     item_tag = "notify_item_battery";  break;
+            case STATUS_BAR_NOTIFY_BROWNOUT:        item_tag = "notify_item_brownout"; break;
             default: break;
         }
         lv_obj_set_user_data(item, (void*)item_tag);
@@ -625,6 +626,9 @@ static void show_dropdown(void)
                 break;
             case STATUS_BAR_NOTIFY_LOW_BATTERY:
                 icon_text = LV_SYMBOL_BATTERY_EMPTY;
+                break;
+            case STATUS_BAR_NOTIFY_BROWNOUT:
+                icon_text = LV_SYMBOL_CHARGE;
                 break;
             default:
                 break;
@@ -648,6 +652,9 @@ static void show_dropdown(void)
                     break;
                 case STATUS_BAR_NOTIFY_LOW_BATTERY:
                     msg = "Low battery warning";
+                    break;
+                case STATUS_BAR_NOTIFY_BROWNOUT:
+                    msg = "Brownout detected - check power supply";
                     break;
                 default:
                     msg = "Notification";

--- a/main/status_bar.h
+++ b/main/status_bar.h
@@ -32,6 +32,7 @@ typedef enum {
     STATUS_BAR_NOTIFY_FIRMWARE_UPDATE = 0,  // Firmware update available
     STATUS_BAR_NOTIFY_WIFI_UNSTABLE,        // WiFi connection is unstable
     STATUS_BAR_NOTIFY_LOW_BATTERY,          // Low battery warning
+    STATUS_BAR_NOTIFY_BROWNOUT,             // Brownout reset detected (power sag)
     STATUS_BAR_NOTIFY_MAX
 } status_bar_notify_type_t;
 

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -532,6 +532,7 @@
       firmware_update: { icon: "⬇️", route: ["settings", "firmware"] },
       wifi_unstable:   { icon: "📶", route: ["settings", "wifi"] },
       low_battery:     { icon: "🔋", route: null },
+      brownout:        { icon: "⚡", route: ["events", null] },
       unknown:         { icon: "🔔", route: null },
     };
     function notifBell() {
@@ -1345,6 +1346,12 @@
       if (action === "notif-open") {
         const n = state.notifications[parseInt(el.dataset.index, 10)];
         state.notifOpen = false;
+        if (n && n.key === "brownout") {
+          // Acknowledge the power warning: clear the persistent counter so it
+          // does not re-raise, and drop it from the current list immediately.
+          await api("/api/brownout/clear", { method: "POST" }).catch(() => {});
+          state.notifications = state.notifications.filter(x => x.key !== "brownout");
+        }
         const meta = n && (NOTIF_META[n.key] || NOTIF_META.unknown);
         if (meta && meta.route) await navigate(meta.route[0], meta.route[1]);
         else render();

--- a/tests/web/test_notifications.py
+++ b/tests/web/test_notifications.py
@@ -79,3 +79,32 @@ class TestNotificationBellWeb:
             ).to_be_visible()
         finally:
             _reset_notifications(base_url)
+
+    def test_brownout_notification_reported_and_acknowledged(self, dashboard_page: Page, base_url: str):
+        _reset_notifications(base_url)
+        try:
+            # Type 3 == STATUS_BAR_NOTIFY_BROWNOUT.
+            _add_notification(base_url, ntype=3, message="Brownout detected (2) - check power supply")
+
+            data = dashboard_page.evaluate(
+                "() => fetch('/api/notifications').then(r => r.json())"
+            )
+            keys = [n["key"] for n in data["notifications"]]
+            assert "brownout" in keys
+
+            # Reload so the bell reflects the seeded brownout, then acknowledge it.
+            dashboard_page.reload(wait_until="domcontentloaded")
+            dashboard_page.wait_for_selector(".rail", timeout=10000)
+            dashboard_page.locator(".notif-btn").click()
+            dashboard_page.locator(".notif-item", has_text="Brownout").click()
+
+            # Tapping a brownout notification navigates to the Events log...
+            expect(dashboard_page.locator("#event-search")).to_be_visible()
+
+            # ...and acknowledges it: /api/brownout/clear cleared the badge.
+            after = dashboard_page.evaluate(
+                "() => fetch('/api/notifications').then(r => r.json())"
+            )
+            assert "brownout" not in [n["key"] for n in after["notifications"]]
+        finally:
+            _reset_notifications(base_url)


### PR DESCRIPTION
## Summary

Closes #149. Surfaces **brownout resets** in the notification bell (both on-device and web), following the notification-bell work in #148.

Brownouts are already tracked persistently in NVS (`boot_stats`) and logged as `brownout_reset` events, but they never appeared in the bell — so a supply sag (e.g. the Tab5 running off the heat-pump RS485 rail) was easy to miss.

## Behaviour (persistent until acknowledged)

- **Raised at boot** when `boot_stats_brownout_count() > 0`, in `create_ui()` right after the status bar is created. Because the counter is in NVS, the notification survives the reboot the brownout causes and stays until acknowledged. Message includes the count: `"Brownout detected (N) - check power supply"`.
- **Rendered** in the status-bar dropdown with a ⚡ (`LV_SYMBOL_CHARGE`) icon and a `notify_item_brownout` test tag.
- **Exposed** via `GET /api/notifications` (key `brownout`) so the web bell shows it too; enum documented in `openapi.yaml`.
- **Acknowledging clears it everywhere:**
  - On device, tapping the notification calls `boot_stats_clear()` so it doesn't re-raise next boot.
  - `POST /api/brownout/clear` (the existing endpoint) now also clears the status-bar notification badge.
  - The web bell routes a brownout tap to the **Events** log (where `brownout_reset` entries live) *after* acknowledging via `/api/brownout/clear`.

## Tests

Adds a Playwright case in `tests/web/test_notifications.py`: seeds a brownout (type 3), asserts `/api/notifications` reports `brownout`, then taps it and verifies it navigates to Events and the badge is cleared.

Firmware builds clean (esp32p4, 47% free); JS syntax-checked; openapi YAML validated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
