### PR TITLE
feat(ui): show 'Notifications' heading in device notification dropdown

### DIFF
--- a/main/i18n/i18n.cpp
+++ b/main/i18n/i18n.cpp
@@ -88,6 +88,7 @@ static const char* strings_en[STR_COUNT] = {
     [STR_LANG_RESTART_REQUIRED] = "Restart may be required for full effect",
     
     // Status Bar / Notifications
+    [STR_NOTIFY_TITLE] = "Notifications",
     [STR_NOTIFY_UPDATE_AVAILABLE] = "Update available",
     [STR_NOTIFY_WIFI_UNSTABLE] = "WiFi connection unstable",
     [STR_NOTIFY_LOW_BATTERY] = "Low battery",
@@ -476,6 +477,7 @@ static const char* strings_fr[STR_COUNT] = {
     [STR_LANG_RESTART_REQUIRED] = "Un redémarrage peut être nécessaire",
     
     // Status Bar / Notifications
+    [STR_NOTIFY_TITLE] = "Notifications",
     [STR_NOTIFY_UPDATE_AVAILABLE] = "Mise à jour disponible",
     [STR_NOTIFY_WIFI_UNSTABLE] = "Connexion WiFi instable",
     [STR_NOTIFY_LOW_BATTERY] = "Batterie faible",
@@ -864,6 +866,7 @@ static const char* strings_es[STR_COUNT] = {
     [STR_LANG_RESTART_REQUIRED] = "Puede ser necesario reiniciar",
     
     // Status Bar / Notifications
+    [STR_NOTIFY_TITLE] = "Notificaciones",
     [STR_NOTIFY_UPDATE_AVAILABLE] = "Actualización disponible",
     [STR_NOTIFY_WIFI_UNSTABLE] = "Conexión WiFi inestable",
     [STR_NOTIFY_LOW_BATTERY] = "Batería baja",

--- a/main/i18n/strings.h
+++ b/main/i18n/strings.h
@@ -95,6 +95,7 @@ typedef enum {
     // ========================================================================
     // Status Bar / Notifications
     // ========================================================================
+    STR_NOTIFY_TITLE,
     STR_NOTIFY_UPDATE_AVAILABLE,
     STR_NOTIFY_WIFI_UNSTABLE,
     STR_NOTIFY_LOW_BATTERY,

--- a/main/status_bar.cpp
+++ b/main/status_bar.cpp
@@ -6,6 +6,7 @@
 #include "time_manager.h"
 #include "settings/settings_time_screen.h"
 #include "wifi_manager.h"
+#include "i18n/i18n.h"
 #include <esp_log.h>
 #include <string.h>
 
@@ -570,7 +571,7 @@ static void show_dropdown(void)
     
     // Create the dropdown panel inside the overlay
     lv_obj_t* panel = lv_obj_create(bar_state.notify_dropdown);
-    lv_obj_set_size(panel, 500, count * 90 + 30);  // 90px per item + padding
+    lv_obj_set_size(panel, 500, count * 90 + 30 + 44);  // heading + 90px per item + padding
     lv_obj_align(panel, LV_ALIGN_TOP_RIGHT, -25, STATUS_BAR_HEIGHT + 10);
     lv_obj_set_style_bg_color(panel, lv_color_hex(COLOR_DROPDOWN_BG), LV_PART_MAIN);
     lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, LV_PART_MAIN);
@@ -586,7 +587,21 @@ static void show_dropdown(void)
     lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
     // Stop click events from propagating to overlay
     lv_obj_add_flag(panel, LV_OBJ_FLAG_CLICKABLE);
-    
+
+    // Panel heading ("Notifications"), mirroring the web dashboard bell panel.
+    lv_obj_t* title = lv_label_create(panel);
+    lv_obj_set_user_data(title, (void*)"notify_title");
+    lv_label_set_text(title, i18n_get(STR_NOTIFY_TITLE));
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_text_font(title, FONT_DROPDOWN_TEXT, LV_PART_MAIN);
+    lv_obj_set_style_text_color(title, lv_color_hex(0x8b949e), LV_PART_MAIN);
+    lv_obj_set_style_pad_left(title, 6, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(title, 2, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(title, 8, LV_PART_MAIN);
+    lv_obj_set_style_border_side(title, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN);
+    lv_obj_set_style_border_width(title, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_color(title, lv_color_hex(0x30363d), LV_PART_MAIN);
+
     // Add notification items
     for (int i = 0; i < STATUS_BAR_NOTIFY_MAX; i++) {
         if (!bar_state.notifications[i].active) {

--- a/tests/device/test_status_bar.py
+++ b/tests/device/test_status_bar.py
@@ -51,6 +51,37 @@ def test_notification_badge_appears_with_update(device: DeviceClient):
     # Clean up
     device.notification_mock_reset()
 
+def test_notification_dropdown_shows_heading(device: DeviceClient):
+    """The notification dropdown should show a 'Notifications' heading.
+
+    Mirrors the web dashboard bell panel, which has a "Notifications" title at
+    the top of the popover. The heading is tagged 'notify_title' for
+    language-independent addressability.
+    """
+    device.notification_mock_reset()
+    time.sleep(0.5)
+
+    device.notification_mock(notification_type=0, message="Firmware v99.0.0 available")
+    time.sleep(0.5)
+
+    # Open the dropdown
+    device.click(tag="notifications")
+    time.sleep(0.5)
+
+    try:
+        # The heading should be present in the dropdown overlay
+        assert device.wait_for_widget(tag="notify_title", timeout=3.0), \
+            "Expected a 'notify_title' heading in the notification dropdown"
+        title = device.find_widget(tag="notify_title")
+        assert title is not None and title.text_en == "Notifications", \
+            f"Expected heading text 'Notifications', got '{getattr(title, 'text_en', None)}'"
+    finally:
+        # Close the dropdown and clean up
+        device.click(tag="notifications")
+        time.sleep(0.3)
+        device.notification_mock_reset()
+
+
 def test_notification_icon_shows_dropdown(device: DeviceClient):
     """Clicking the notification icon should show the dropdown with notifications.
     

--- a/tests/device/test_status_bar.py
+++ b/tests/device/test_status_bar.py
@@ -73,8 +73,11 @@ def test_notification_dropdown_shows_heading(device: DeviceClient):
         assert device.wait_for_widget(tag="notify_title", timeout=3.0), \
             "Expected a 'notify_title' heading in the notification dropdown"
         title = device.find_widget(tag="notify_title")
-        assert title is not None and title.text_en == "Notifications", \
-            f"Expected heading text 'Notifications', got '{getattr(title, 'text_en', None)}'"
+        assert title is not None, "notify_title heading widget should exist"
+        # In English the visible text is the heading; text_en is only populated
+        # when a translated (non-English) string is shown.
+        assert "Notifications" in (title.text, title.text_en), \
+            f"Expected heading text 'Notifications', got text='{title.text}' text_en='{title.text_en}'"
     finally:
         # Close the dropdown and clean up
         device.click(tag="notifications")


### PR DESCRIPTION
## Summary
Adds a **Notifications** heading to the on-device status-bar notification dropdown so it matches the web dashboard bell panel (which already has a `Notifications` heading). Previously the device dropdown showed only the notification items with no title.

## Changes
- **i18n**: new `STR_NOTIFY_TITLE` string with EN (`Notifications`), FR (`Notifications`), ES (`Notificaciones`) translations.
- **status_bar.cpp**: render a muted, underlined heading at the top of the dropdown panel (tagged `notify_title` for language-independent test addressability); grow the panel height to make room.
- **tests**: new device UI test `test_notification_dropdown_shows_heading` asserting the heading appears with English text `Notifications`.

## Validation
- Firmware builds clean (esp32p4, 47% free).
- No web change needed — the web bell already has this heading; this brings the device to parity.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
