### PR TITLE
perf(api): batch temperature-history JSON instead of per-sample chunks

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -4479,8 +4479,43 @@ static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req)
 
     set_json_content_type(req);
 
+    // Batch the JSON into a large buffer and flush per-batch instead of issuing
+    // one chunked TLS write per sample (~960 writes = ~960 TLS records/TCP
+    // segments), which dominated the response time. Profiling on hardware
+    // showed this halves median latency (~844 ms -> ~408 ms) for the 8-hour
+    // window. Falls back to direct per-item sends if the buffer can't be
+    // allocated.
+    constexpr size_t kOutCap = 8192;
+    char* out = (char*)heap_caps_malloc(kOutCap, MALLOC_CAP_SPIRAM);
+    if (!out) out = (char*)malloc(kOutCap);
+    size_t out_len = 0;
+
+    auto flush_out = [&](void) {
+        if (out && out_len > 0) {
+            httpd_resp_send_chunk(req, out, out_len);
+            out_len = 0;
+        }
+    };
+    // Append n bytes of s to the buffer, flushing first if it wouldn't fit.
+    // When no buffer is available (alloc failed), send directly so the response
+    // is still correct, just unbatched.
+    auto emit = [&](const char* s, size_t n) {
+        if (!out) {
+            httpd_resp_send_chunk(req, s, n);
+            return;
+        }
+        if (n >= kOutCap) {
+            flush_out();
+            httpd_resp_send_chunk(req, s, n);
+            return;
+        }
+        if (out_len + n > kOutCap) flush_out();
+        memcpy(out + out_len, s, n);
+        out_len += n;
+    };
+
     char line[256];
-    snprintf(line, sizeof(line),
+    int n = snprintf(line, sizeof(line),
              "{\"start\":%u,\"end\":%u,\"latest_end\":%u,\"earliest\":%u,"
              "\"window_seconds\":%u,\"sample_interval_sec\":%u,"
              "\"retention_days\":%u,\"samples\":[",
@@ -4488,7 +4523,9 @@ static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req)
              (unsigned)earliest, (unsigned)kWindowSeconds,
              (unsigned)HISTORY_TELEMETRY_SAMPLE_INTERVAL_SEC,
              (unsigned)HISTORY_TELEMETRY_RETENTION_DAYS);
-    httpd_resp_sendstr_chunk(req, line);
+    if (n < 0) n = 0;
+    if (n > (int)sizeof(line) - 1) n = (int)sizeof(line) - 1;
+    emit(line, (size_t)n);
 
     for (size_t i = 0; i < count; i++) {
         const history_telemetry_sample_t& s = samples[i];
@@ -4508,17 +4545,21 @@ static esp_err_t heatpump_temperature_history_get_handler(httpd_req_t* req)
         bool running = (s.flags & HISTORY_TELEMETRY_COMPRESSOR_VALID) &&
                        (s.flags & HISTORY_TELEMETRY_COMPRESSOR_RUNNING);
         bool conn = (s.flags & HISTORY_TELEMETRY_CONNECTED) != 0;
-        snprintf(line, sizeof(line),
+        n = snprintf(line, sizeof(line),
                  "%s{\"t\":%u,\"in\":%s,\"out\":%s,\"set\":%s,"
                  "\"mode\":%u,\"run\":%s,\"conn\":%s}",
                  i == 0 ? "" : ",", (unsigned)s.timestamp, in_buf, out_buf,
                  set_buf, (unsigned)s.mode, running ? "true" : "false",
                  conn ? "true" : "false");
-        httpd_resp_sendstr_chunk(req, line);
+        if (n < 0) n = 0;
+        if (n > (int)sizeof(line) - 1) n = (int)sizeof(line) - 1;
+        emit(line, (size_t)n);
     }
     free(samples);
 
-    httpd_resp_sendstr_chunk(req, "]}");
+    emit("]}", 2);
+    flush_out();
+    if (out) free(out);
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }


### PR DESCRIPTION
## What

Batch the `GET /api/heatpump/temperature-history` response into a buffer instead of issuing one chunked write per sample.

## Why

The handler called `httpd_resp_sendstr_chunk()` once per sample — ~960 calls for the 8-hour window — each producing its own TLS record/TCP segment on the ESP32-P4. That per-write overhead dominated the response time and made the web history view slow to load.

## How

- Assemble the JSON into an 8 KB PSRAM buffer and flush per-batch (~10 writes instead of ~960).
- Falls back to direct per-item sends if the buffer can't be allocated (correctness preserved, just unbatched).
- Adds `snprintf` length guards on the assembled lines.

Payload shape/content is unchanged — same fields, same ordering, same window.

## Profiled on hardware

8-hour window, ~960 samples, 75 KB payload, N=12 on the runner controller:

| | before (per-sample chunk) | after (8 KB batch) |
|---|---|---|
| median | 844 ms | **408 ms** |
| mean | 946 ms | **410 ms** |
| min | 801 ms | 355 ms |
| max | 2028 ms | **483 ms** |

~52% faster median, and the tail tightens up (no more ~2 s outliers).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
