### PR TITLE
Web: add Back button to Cycle history page

### DIFF
--- a/main/web/index.html
+++ b/main/web/index.html
@@ -1066,7 +1066,7 @@
         </section>`;
       }
       return `<div class="page">
-        ${pageHead("Cycle history", "Compressor run cycles with inlet, outlet, and setpoint temperatures over the last 8 hours.", `<button class="btn" data-action="history-refresh">Refresh</button>`)}
+        ${pageHead("Cycle history", "Compressor run cycles with inlet, outlet, and setpoint temperatures over the last 8 hours.", `<button class="btn" data-route="status">‹ Back</button><button class="btn" data-action="history-refresh">Refresh</button>`)}
         ${body}
       </div>`;
     }


### PR DESCRIPTION
Cycle history moved out of the bottom nav (opened via a button on the Status screen), so there was no obvious way back from it. Add an explicit **< Back** control (routes to Status) in the page header, mirroring the device UI's history Back button. Refresh stays alongside it.

Single-line change in \main/web/index.html\ (\historyPage()\ header action).