### PR TITLE
Fix httpd URI-handler slot exhaustion causing intermittent device-test 404s

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -742,6 +742,28 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Assert no httpd handler-registration failures
+        if: always()
+        run: |
+          # Catch httpd URI-handler table overflow early. When the handler
+          # table fills up, httpd_register_uri_handler silently drops the tail
+          # handlers and those routes answer 404 — which otherwise only surfaces
+          # as a confusing, intermittent failure in an unrelated UI test (e.g.
+          # test_back_from_sub_screen "Click failed (404)"). Fail loudly here,
+          # naming the root cause, regardless of whether this particular boot
+          # happened to drop a route that a test exercised.
+          if [ ! -f controller-serial.log ]; then
+            echo "No serial log captured — skipping handler-registration check."
+            exit 0
+          fi
+          HITS=$(grep -nE 'no slots left for registering handler|Failed to register test endpoint|test endpoint\(s\) FAILED to register' controller-serial.log || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::httpd URI-handler registration failed on the device — the URI-handler table overflowed. Increase uri_handlers in main/api_server.cpp. Offending serial-log lines:"
+            echo "$HITS"
+            exit 1
+          fi
+          echo "OK: no httpd URI-handler registration failures in serial log."
+
       - name: Publish UI test results
         uses: dorny/test-reporter@v2
         if: always() && steps.ui_tests.outcome != 'skipped'

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -417,7 +417,16 @@ bool api_server_start(void)
         return false;
     }
 
-    const int uri_handlers = 111;
+    // URI-handler table size for the port-80 and port-443 servers. This must
+    // exceed the total number of handlers registered on a single server. The
+    // worst case is the CONFIG_TEST_ENDPOINTS build, where the ~61 production
+    // handlers on port 443 are joined by the ~53 /api/test/* instrumentation
+    // handlers (see test_endpoints_register), for ~114 total. The value below
+    // leaves comfortable headroom so that adding an endpoint does not silently
+    // overflow the table — an overflow makes httpd_register_uri_handler return
+    // "no slots left" and the affected route then answers 404. (Production
+    // builds register far fewer handlers, so they are unaffected either way.)
+    const int uri_handlers = 140;
     const int stack_size   = 16384;  // Default task stack
     const int max_headers  = 16;
     const int recv_timeout = 10;     // seconds

--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -2201,6 +2201,26 @@ static esp_err_t screenshot_get_handler(httpd_req_t* req)
 // Registration
 // ============================================================================
 
+// Number of /api/test/* handlers that failed to register on the most recent
+// test_endpoints_register() call. A non-zero value means the httpd URI-handler
+// table overflowed ("no slots left"), which silently turns the affected route
+// into a 404 and makes device tests flaky. See uri_handlers in api_server.cpp.
+static int s_test_uri_reg_failures = 0;
+
+// Checked wrapper around httpd_register_uri_handler so that a table overflow is
+// logged loudly (and counted) instead of being silently ignored.
+static void reg_test_uri(httpd_handle_t server, const httpd_uri_t* uri)
+{
+    esp_err_t err = httpd_register_uri_handler(server, uri);
+    if (err != ESP_OK) {
+        s_test_uri_reg_failures++;
+        ESP_LOGE(TAG,
+                 "Failed to register test endpoint '%s': %s — increase "
+                 "uri_handlers in api_server.cpp (httpd table is full)",
+                 uri->uri, esp_err_to_name(err));
+    }
+}
+
 void test_endpoints_register_websocket(httpd_handle_t server)
 {
     httpd_uri_t websocket_feasibility_uri = {
@@ -2212,18 +2232,19 @@ void test_endpoints_register_websocket(httpd_handle_t server)
         .handle_ws_control_frames = false,
         .supported_subprotocol = NULL,
     };
-    httpd_register_uri_handler(server, &websocket_feasibility_uri);
+    reg_test_uri(server, &websocket_feasibility_uri);
 }
 
 void test_endpoints_register(httpd_handle_t server)
 {
+    s_test_uri_reg_failures = 0;
     httpd_uri_t integration_identity_uri = {
         .uri = "/api/test/ha-identity",
         .method = HTTP_GET,
         .handler = integration_identity_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &integration_identity_uri);
+    reg_test_uri(server, &integration_identity_uri);
 
     httpd_uri_t integration_token_uri = {
         .uri = "/api/test/ha-token",
@@ -2231,7 +2252,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = integration_token_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &integration_token_uri);
+    reg_test_uri(server, &integration_token_uri);
 
     httpd_uri_t integration_token_delete_uri = {
         .uri = "/api/test/ha-token",
@@ -2239,7 +2260,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = integration_token_delete_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &integration_token_delete_uri);
+    reg_test_uri(server, &integration_token_delete_uri);
 
     httpd_uri_t integration_pairing_uri = {
         .uri = "/api/test/ha-pairing-window",
@@ -2247,7 +2268,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = integration_pairing_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &integration_pairing_uri);
+    reg_test_uri(server, &integration_pairing_uri);
 
     httpd_uri_t test_credentials_uri = {
         .uri = "/api/test/credentials",
@@ -2255,7 +2276,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_credentials_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &test_credentials_uri);
+    reg_test_uri(server, &test_credentials_uri);
 
     httpd_uri_t ui_state_uri = {
         .uri = "/api/test/ui-state",
@@ -2263,7 +2284,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = ui_state_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &ui_state_uri);
+    reg_test_uri(server, &ui_state_uri);
 
     httpd_uri_t screen_uri = {
         .uri = "/api/test/screen",
@@ -2271,7 +2292,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = screen_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &screen_uri);
+    reg_test_uri(server, &screen_uri);
 
     httpd_uri_t click_uri = {
         .uri = "/api/test/click",
@@ -2279,7 +2300,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = click_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &click_uri);
+    reg_test_uri(server, &click_uri);
 
     httpd_uri_t click_options_uri = {
         .uri = "/api/test/click",
@@ -2287,7 +2308,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &click_options_uri);
+    reg_test_uri(server, &click_options_uri);
 
     httpd_uri_t set_slider_uri = {
         .uri = "/api/test/set-slider",
@@ -2295,7 +2316,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = set_slider_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_slider_uri);
+    reg_test_uri(server, &set_slider_uri);
 
     httpd_uri_t set_slider_options_uri = {
         .uri = "/api/test/set-slider",
@@ -2303,7 +2324,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_slider_options_uri);
+    reg_test_uri(server, &set_slider_options_uri);
 
     httpd_uri_t display_idle_uri = {
         .uri = "/api/test/display-idle",
@@ -2311,7 +2332,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = display_idle_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &display_idle_uri);
+    reg_test_uri(server, &display_idle_uri);
 
     httpd_uri_t display_idle_options_uri = {
         .uri = "/api/test/display-idle",
@@ -2319,7 +2340,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &display_idle_options_uri);
+    reg_test_uri(server, &display_idle_options_uri);
 
     httpd_uri_t scroll_uri = {
         .uri = "/api/test/scroll",
@@ -2327,7 +2348,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = scroll_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &scroll_uri);
+    reg_test_uri(server, &scroll_uri);
 
     httpd_uri_t scroll_options_uri = {
         .uri = "/api/test/scroll",
@@ -2335,7 +2356,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &scroll_options_uri);
+    reg_test_uri(server, &scroll_options_uri);
 
     httpd_uri_t set_roller_uri = {
         .uri = "/api/test/set-roller",
@@ -2343,7 +2364,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = set_roller_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_roller_uri);
+    reg_test_uri(server, &set_roller_uri);
 
     httpd_uri_t set_roller_options_uri = {
         .uri = "/api/test/set-roller",
@@ -2351,7 +2372,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_roller_options_uri);
+    reg_test_uri(server, &set_roller_options_uri);
 
     httpd_uri_t toggle_uri = {
         .uri = "/api/test/toggle",
@@ -2359,7 +2380,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = toggle_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &toggle_uri);
+    reg_test_uri(server, &toggle_uri);
 
     httpd_uri_t toggle_options_uri = {
         .uri = "/api/test/toggle",
@@ -2367,7 +2388,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &toggle_options_uri);
+    reg_test_uri(server, &toggle_options_uri);
 
     httpd_uri_t wifi_mock_uri = {
         .uri = "/api/test/wifi-mock",
@@ -2375,7 +2396,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = wifi_mock_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &wifi_mock_uri);
+    reg_test_uri(server, &wifi_mock_uri);
 
     httpd_uri_t wifi_mock_options_uri = {
         .uri = "/api/test/wifi-mock",
@@ -2383,7 +2404,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &wifi_mock_options_uri);
+    reg_test_uri(server, &wifi_mock_options_uri);
 
     httpd_uri_t wifi_mock_reset_uri = {
         .uri = "/api/test/wifi-mock-reset",
@@ -2391,7 +2412,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = wifi_mock_reset_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &wifi_mock_reset_uri);
+    reg_test_uri(server, &wifi_mock_reset_uri);
 
     httpd_uri_t wifi_mock_reset_options_uri = {
         .uri = "/api/test/wifi-mock-reset",
@@ -2399,7 +2420,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &wifi_mock_reset_options_uri);
+    reg_test_uri(server, &wifi_mock_reset_options_uri);
 
     httpd_uri_t type_text_uri = {
         .uri = "/api/test/type-text",
@@ -2407,7 +2428,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = type_text_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &type_text_uri);
+    reg_test_uri(server, &type_text_uri);
 
     httpd_uri_t type_text_options_uri = {
         .uri = "/api/test/type-text",
@@ -2415,7 +2436,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &type_text_options_uri);
+    reg_test_uri(server, &type_text_options_uri);
 
     httpd_uri_t firmware_mock_uri = {
         .uri = "/api/test/firmware-mock",
@@ -2423,7 +2444,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = firmware_mock_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &firmware_mock_uri);
+    reg_test_uri(server, &firmware_mock_uri);
 
     httpd_uri_t firmware_mock_options_uri = {
         .uri = "/api/test/firmware-mock",
@@ -2431,7 +2452,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &firmware_mock_options_uri);
+    reg_test_uri(server, &firmware_mock_options_uri);
 
     httpd_uri_t firmware_mock_reset_uri = {
         .uri = "/api/test/firmware-mock-reset",
@@ -2439,7 +2460,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = firmware_mock_reset_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &firmware_mock_reset_uri);
+    reg_test_uri(server, &firmware_mock_reset_uri);
 
     httpd_uri_t firmware_mock_reset_options_uri = {
         .uri = "/api/test/firmware-mock-reset",
@@ -2447,7 +2468,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &firmware_mock_reset_options_uri);
+    reg_test_uri(server, &firmware_mock_reset_options_uri);
 
     httpd_uri_t set_preference_uri = {
         .uri = "/api/test/set-preference",
@@ -2455,7 +2476,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = set_preference_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_preference_uri);
+    reg_test_uri(server, &set_preference_uri);
 
     httpd_uri_t set_preference_options_uri = {
         .uri = "/api/test/set-preference",
@@ -2463,7 +2484,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_preference_options_uri);
+    reg_test_uri(server, &set_preference_options_uri);
 
     httpd_uri_t set_demo_field_uri = {
         .uri = "/api/test/set-demo-field",
@@ -2471,7 +2492,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = set_demo_field_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_demo_field_uri);
+    reg_test_uri(server, &set_demo_field_uri);
 
     httpd_uri_t set_demo_field_options_uri = {
         .uri = "/api/test/set-demo-field",
@@ -2479,7 +2500,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &set_demo_field_options_uri);
+    reg_test_uri(server, &set_demo_field_options_uri);
 
     httpd_uri_t record_reset_reason_uri = {
         .uri = "/api/test/record-reset-reason",
@@ -2487,7 +2508,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = record_reset_reason_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &record_reset_reason_uri);
+    reg_test_uri(server, &record_reset_reason_uri);
 
     httpd_uri_t record_reset_reason_options_uri = {
         .uri = "/api/test/record-reset-reason",
@@ -2495,7 +2516,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &record_reset_reason_options_uri);
+    reg_test_uri(server, &record_reset_reason_options_uri);
 
     httpd_uri_t clear_error_history_uri = {
         .uri = "/api/test/clear-error-history",
@@ -2503,7 +2524,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = clear_error_history_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &clear_error_history_uri);
+    reg_test_uri(server, &clear_error_history_uri);
 
     httpd_uri_t clear_error_history_options_uri = {
         .uri = "/api/test/clear-error-history",
@@ -2511,7 +2532,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &clear_error_history_options_uri);
+    reg_test_uri(server, &clear_error_history_options_uri);
 
     httpd_uri_t inject_fault_uri = {
         .uri = "/api/test/inject-fault",
@@ -2519,7 +2540,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = inject_fault_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &inject_fault_uri);
+    reg_test_uri(server, &inject_fault_uri);
 
     httpd_uri_t inject_fault_options_uri = {
         .uri = "/api/test/inject-fault",
@@ -2527,7 +2548,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &inject_fault_options_uri);
+    reg_test_uri(server, &inject_fault_options_uri);
 
     httpd_uri_t clear_faults_uri = {
         .uri = "/api/test/clear-faults",
@@ -2535,7 +2556,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = clear_faults_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &clear_faults_uri);
+    reg_test_uri(server, &clear_faults_uri);
 
     httpd_uri_t clear_faults_options_uri = {
         .uri = "/api/test/clear-faults",
@@ -2543,7 +2564,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &clear_faults_options_uri);
+    reg_test_uri(server, &clear_faults_options_uri);
 
     httpd_uri_t populate_temperature_history_uri = {
         .uri = "/api/test/populate-temperature-history",
@@ -2551,7 +2572,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = populate_temperature_history_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &populate_temperature_history_uri);
+    reg_test_uri(server, &populate_temperature_history_uri);
 
     httpd_uri_t populate_temperature_history_options_uri = {
         .uri = "/api/test/populate-temperature-history",
@@ -2559,7 +2580,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &populate_temperature_history_options_uri);
+    reg_test_uri(server, &populate_temperature_history_options_uri);
 
     httpd_uri_t notification_mock_uri = {
         .uri = "/api/test/notification-mock",
@@ -2567,7 +2588,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = notification_mock_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &notification_mock_uri);
+    reg_test_uri(server, &notification_mock_uri);
 
     httpd_uri_t notification_mock_options_uri = {
         .uri = "/api/test/notification-mock",
@@ -2575,7 +2596,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &notification_mock_options_uri);
+    reg_test_uri(server, &notification_mock_options_uri);
 
     httpd_uri_t notification_mock_reset_uri = {
         .uri = "/api/test/notification-mock-reset",
@@ -2583,7 +2604,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = notification_mock_reset_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &notification_mock_reset_uri);
+    reg_test_uri(server, &notification_mock_reset_uri);
 
     httpd_uri_t notification_mock_reset_options_uri = {
         .uri = "/api/test/notification-mock-reset",
@@ -2591,7 +2612,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &notification_mock_reset_options_uri);
+    reg_test_uri(server, &notification_mock_reset_options_uri);
 
     // --- Session lock endpoints ---
 
@@ -2601,7 +2622,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = lock_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &lock_get_uri);
+    reg_test_uri(server, &lock_get_uri);
 
     httpd_uri_t lock_post_uri = {
         .uri = "/api/test/lock",
@@ -2609,7 +2630,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = lock_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &lock_post_uri);
+    reg_test_uri(server, &lock_post_uri);
 
     httpd_uri_t lock_options_uri = {
         .uri = "/api/test/lock",
@@ -2617,7 +2638,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &lock_options_uri);
+    reg_test_uri(server, &lock_options_uri);
 
     httpd_uri_t unlock_uri = {
         .uri = "/api/test/unlock",
@@ -2625,7 +2646,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = unlock_post_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &unlock_uri);
+    reg_test_uri(server, &unlock_uri);
 
     httpd_uri_t unlock_options_uri = {
         .uri = "/api/test/unlock",
@@ -2633,7 +2654,7 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = test_options_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &unlock_options_uri);
+    reg_test_uri(server, &unlock_options_uri);
 
     // Screenshot endpoint
     httpd_uri_t screenshot_uri = {
@@ -2642,9 +2663,17 @@ void test_endpoints_register(httpd_handle_t server)
         .handler = screenshot_get_handler,
         .user_ctx = NULL
     };
-    httpd_register_uri_handler(server, &screenshot_uri);
+    reg_test_uri(server, &screenshot_uri);
 
-    ESP_LOGI(TAG, "Test instrumentation endpoints registered");
+    if (s_test_uri_reg_failures > 0) {
+        ESP_LOGE(TAG,
+                 "%d test endpoint(s) FAILED to register (httpd URI table "
+                 "overflow) — these routes will return 404 and device tests "
+                 "will be unreliable. Increase uri_handlers in api_server.cpp.",
+                 s_test_uri_reg_failures);
+    } else {
+        ESP_LOGI(TAG, "Test instrumentation endpoints registered");
+    }
 }
 
 #endif // CONFIG_TEST_ENDPOINTS

--- a/tests/api/test_web_home_assistant_page.py
+++ b/tests/api/test_web_home_assistant_page.py
@@ -8,6 +8,7 @@ the pairing code must never leak into a status/read response.
 """
 
 from pathlib import Path
+import re
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -68,5 +69,20 @@ def test_routes_registered_and_handler_budget_bumped() -> None:
     source = _api_server()
     for uri in ('"/api/ha/status"', '"/api/ha/pair"', '"/api/ha/revoke"'):
         assert uri in source, uri
-    # Four new routes were added; the handler budget must cover them.
-    assert "const int uri_handlers = 111;" in source
+    # The httpd URI-handler budget must stay comfortably above the number of
+    # handlers registered on a single server. In CONFIG_TEST_ENDPOINTS builds
+    # the port-443 server registers ~61 production handlers plus ~53
+    # /api/test/* instrumentation handlers (~114 total); if the budget drops
+    # back near that count the tail registrations silently overflow the table
+    # and those routes answer 404 (see the slot-exhaustion fix). Assert a floor
+    # with headroom rather than pinning an exact literal, so a legitimate bump
+    # does not break this test while a regression below the safe floor does.
+    match = re.search(r"const int uri_handlers = (\d+);", source)
+    assert match, "uri_handlers declaration not found in api_server.cpp"
+    uri_handlers = int(match.group(1))
+    assert uri_handlers >= 130, (
+        f"uri_handlers={uri_handlers} is too low: the CONFIG_TEST_ENDPOINTS "
+        "build registers ~114 handlers on one server and needs headroom to "
+        "avoid silently overflowing the httpd URI-handler table"
+    )
+


### PR DESCRIPTION
## Problem

Device UI tests intermittently fail with `test_back_from_sub_screen[...]` → `DeviceError: Click failed (404)`, and every boot log contains:

```
W httpd_uri: httpd_register_uri_handler: no slots left for registering handler
```

(4 occurrences per boot in the captured serial log.)

## Root cause

Both the port-80 and port-443 `httpd` servers share `max_uri_handlers = 111` (`api_server.cpp`). In `CONFIG_TEST_ENDPOINTS` builds, the port-443 server registers:

- ~61 **production** handlers (via the `REGISTER_URI` macro, which `abort()`s on failure), **plus**
- ~53 **`/api/test/*`** instrumentation handlers (via `test_endpoints_register()`, which did **not** check return codes)

≈ **114 handlers on one server**, exceeding the 111-slot table. The tail registrations silently fail with "no slots left" and those routes then answer **404**.

The exact production handler count varies per boot (some handlers register conditionally on TLS/cert state), so the total floats around the 111 boundary — which is why it "sometimes works and sometimes doesn't". `/api/test/screenshot` is registered **last** so it drops on any overflow; `/api/test/click` drops on deeper overflow, producing the intermittent nav-test failures.

**Production builds are unaffected** — without test endpoints they register far fewer than 111 handlers.

## Fix

- Raise `uri_handlers` **111 → 140** in `api_server.cpp` (comfortable headroom; documented with a comment).
- Route all `/api/test/*` registrations through a checked `reg_test_uri()` wrapper that logs `ESP_LOGE` and counts failures, plus a loud summary log if any registration fails — so a future overflow is **obvious in the boot log** instead of silently 404ing.

## Verification

- Built cleanly with `CONFIG_TEST_ENDPOINTS=y` (the worst-case handler count) — no "no slots left" warnings expected at 140.
- Evidence: captured serial log from device-tests run `32876421851` showed exactly 4 dropped handlers/boot and `test_back_from_sub_screen[wifi|firmware|time]` 404s.

This fix unblocks reliable device-tests (e.g. PR #158, whose only failures were this pre-existing signature).
