### PR TITLE
fix: stop truncating HTTPS responses with a 1s send timeout

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -456,9 +456,6 @@ bool api_server_start(void)
         // Port 80 only serves essential health/OTA bootstrap routes when
         // mandatory HTTPS is active, so two concurrent clients are sufficient.
         http_config.max_open_sockets   = 2;
-#ifdef CONFIG_TEST_ENDPOINTS
-        http_config.send_wait_timeout  = 1;
-#endif
         
         ret = httpd_start(&server, &http_config);
         if (ret != ESP_OK) {
@@ -489,9 +486,10 @@ bool api_server_start(void)
         ssl_config.httpd.max_resp_headers   = max_headers;
         ssl_config.httpd.recv_wait_timeout  = recv_timeout;
         ssl_config.httpd.max_open_sockets   = 4;      // TLS buffers in PSRAM via EXTERNAL_MEM_ALLOC
-#ifdef CONFIG_TEST_ENDPOINTS
-        ssl_config.httpd.send_wait_timeout  = 1;
-#endif
+        // Leave send_wait_timeout at its default. A very short send timeout
+        // truncates responses (empty/partial body, seen as bogus 404s) and
+        // tears down the TLS connection whenever the single-threaded server is
+        // briefly busy under test/HA load — do not shorten it.
         ssl_config.servercert    = cert;
         ssl_config.servercert_len = cert_len;
         ssl_config.prvtkey_pem   = key;
@@ -538,7 +536,11 @@ bool api_server_start(void)
         // while another TLS connection is still closing or handshaking.
         integration_config.httpd.lru_purge_enable = false;
         integration_config.httpd.recv_wait_timeout = 10;
-        integration_config.httpd.send_wait_timeout = 1;
+        // Match recv_wait_timeout. A very short send timeout truncates HA REST
+        // and WSS responses (empty/partial body) whenever the single-threaded
+        // server is briefly busy, and tears down the TLS connection — do not
+        // shorten it.
+        integration_config.httpd.send_wait_timeout = 10;
         integration_config.servercert = cert;
         integration_config.servercert_len = cert_len;
         integration_config.prvtkey_pem = key;


### PR DESCRIPTION
## Second root cause of the intermittent device-test `Device unreachable` aborts

Follows #159 (URI-handler slot exhaustion). That fix removed the `no slots left` overflow, but re-running the blocked feature PR still 404'd on navigation with an **empty body** while a storm of `-0x7780` (`MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE`) TLS handshake failures began exactly at the failure point and never recovered — no reboot, crash, or heap issue.

### Root cause
Commit `4b53876` added `send_wait_timeout = 1` (one second) as part of a WebSocket slow-client harness spike, but blanket-applied it to the **main API servers**:
- port 80 (bootstrap), port 443 (API) — under `CONFIG_TEST_ENDPOINTS`
- port 8443 (HA integration) — **unconditional / production**

A 1s TLS send timeout aborts a response mid-send whenever the single-threaded httpd is briefly busy: the client gets a truncated reply (status line, empty body → looks like a 404) and the connection is torn down → self-sustaining `-0x7780` storm.

### Fix
- Drop the 1s override on port 80 and 443 (use default 10s).
- Raise the **production** 8443 HA integration server 1s → 10s (it could truncate real Home Assistant REST/WSS responses — a latent prod bug).
- Leave the port-81 feasibility harness alone (short send timeout is its purpose).

Builds clean with `CONFIG_TEST_ENDPOINTS=y`. Verified by CI device-tests.
