### PR TITLE
fix: JSON 404 handler on HTTPS API server + click diagnostics

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -104,6 +104,8 @@ static SemaphoreHandle_t s_ha_command_mutex = nullptr;
 static esp_err_t web_root_handler(httpd_req_t* req);
 static esp_err_t http_https_required_handler(httpd_req_t* req,
                                              httpd_err_code_t err);
+static esp_err_t https_api_not_found_handler(httpd_req_t* req,
+                                             httpd_err_code_t err);
 static esp_err_t web_login_handler(httpd_req_t* req);
 static esp_err_t web_logout_handler(httpd_req_t* req);
 static esp_err_t favicon_handler(httpd_req_t* req);
@@ -1390,6 +1392,19 @@ bool api_server_start(void)
         }
     }
 
+    // The HTTPS API server previously had no 404 handler, so a routing miss
+    // fell back to the esp_http_server default 404 whose empty-ish body was
+    // indistinguishable from a truncated response. Register an explicit JSON
+    // 404 handler so every miss is diagnosable (logs + echoes method/URI).
+    if (server_ssl != NULL) {
+        esp_err_t rerr = httpd_register_err_handler(
+            server_ssl, HTTPD_404_NOT_FOUND, https_api_not_found_handler);
+        if (rerr != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to register HTTPS 404 handler: %s",
+                     esp_err_to_name(rerr));
+        }
+    }
+
     ESP_LOGI(TAG, "HTTP server started on port 80");
     if (server_ssl != NULL) {
         ESP_LOGI(TAG, "HTTPS server started on port 443");
@@ -1484,6 +1499,33 @@ static esp_err_t http_https_required_handler(httpd_req_t* req,
 
     httpd_resp_set_status(req, "404 Not Found");
     httpd_resp_set_type(req, "text/plain");
+    httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+// 404 handler for the HTTPS API server (port 443). Without this the port-443
+// server falls back to esp_http_server's built-in 404, whose body ("Nothing
+// matches the given URI") is unhelpful and — crucially — indistinguishable
+// from a truncated/reset response (both surface to the test client as an
+// empty-bodied 404). Emitting an explicit JSON body that echoes the requested
+// method + URI turns every real routing miss into a diagnosable failure and
+// removes that ambiguity when triaging device-test flakes.
+static esp_err_t https_api_not_found_handler(httpd_req_t* req,
+                                             httpd_err_code_t err)
+{
+    (void)err;
+
+    // The request URI is still available on the request struct here.
+    ESP_LOGW(TAG, "HTTPS 404: no handler for %s %s",
+             http_method_str((enum http_method)req->method), req->uri);
+
+    char body[256];
+    snprintf(body, sizeof(body),
+             "{\"error\":\"Not Found\",\"method\":\"%.15s\",\"uri\":\"%.160s\"}",
+             http_method_str((enum http_method)req->method), req->uri);
+
+    httpd_resp_set_status(req, "404 Not Found");
+    httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }

--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -828,6 +828,7 @@ static esp_err_t click_post_handler(httpd_req_t* req)
     cJSON_Delete(body);  // Safe to delete now — we've copied all strings
 
     if (!bsp_display_lock(1000)) {
+        ESP_LOGW(TAG, "click: display lock busy >1s (UI stalled) — returning 503");
         send_json_error(req, "503 Service Unavailable", "Could not acquire display lock");
         return ESP_OK;
     }


### PR DESCRIPTION
## Diagnosability + correctness fix for the intermittent device-test nav 404s

Follows #159 (URI-handler slots) and #160 (send-timeout truncation). Those took the device-test UI suite from *session-abort* to **202 passed, 3 failed**. The remaining 3 (`test_back_from_sub_screen[wifi|firmware|time]`) fail with `Click failed (404):` and an **empty body** — and only on the three sub-screens that do blocking background I/O on open (WiFi scan ~3.2s, firmware GitHub check, NTP).

### Root problem this PR addresses
The **port-443 HTTPS API server never had a `HTTPD_404_NOT_FOUND` handler** (only port-80 did — api_server.cpp:1385). So a 404 on the API port fell back to esp_http_server's default, whose body is indistinguishable from a truncated/reset response. That's why the failure is an un-diagnosable *empty-bodied* 404 — we can't tell a routing miss from a mid-send transport failure.

### Changes
- Register `https_api_not_found_handler` on `server_ssl`: logs `HTTPS 404: no handler for <method> <uri>` and returns a JSON body echoing method+URI. Every real miss is now named; the API port can never emit an empty 404 body again.
- Add an `ESP_LOGW` on the `/api/test/click` display-lock-timeout (503) path so CI serial logs reveal when a click is blocked because the UI task stalled >1s.

### Why
This turns the next device-test run into a decisive experiment: if the 404 now carries a JSON body naming the URI, it's a routing miss; if it's *still* empty, it's pure transport truncation. Either way we stop guessing. Also a genuine correctness fix — a production HTTPS API should never return a bare/empty 404.

Builds clean with `CONFIG_TEST_ENDPOINTS=y`.
