### PR TITLE
test: DeviceClient waits raise on timeout + wait_until primitive (F-04/F-05/F-15)

### DIFF
--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -225,9 +225,15 @@ def test_something(device):
 - **Use tags over labels** — tags are language-independent and don't break when
   translations change
 - **Use `wait_for_screen()` and `wait_for_widget()`** — LVGL animations need
-  time; never assert immediately after a click
-- **Use `time.sleep(0.3–0.5)`** after toggles/rollers — LVGL processes events
-  on the next tick
+  time; never assert immediately after a click. These **raise `DeviceError` on
+  timeout** (with the last observed screen + widget tags), so a missed
+  transition fails loudly instead of silently proceeding. Use the best-effort
+  `try_wait_screen()` / `try_wait_widget()` variants only in cleanup/teardown.
+- **Prefer `wait_until()` over `time.sleep()`** after toggles/rollers — instead
+  of sleeping a guessed interval, wait for the exact observable condition, e.g.
+  `device.wait_until("temp unit is fahrenheit", lambda: device.get_preferences()["temp_unit"] == "fahrenheit")`.
+  Fixed sleeps are a chronic source of flakiness; reserve them for genuinely
+  time-based behavior (e.g. an inactivity timeout).
 - **Mock, don't connect** — use `wifi_mock()`, `firmware_mock()`, etc. to inject
   controlled state rather than depending on real network services
 - **Restore state** — if your test changes a persistent setting (language,

--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -50,7 +50,7 @@ def _return_to_main(device: DeviceClient):
             return
 
     if current == "main":
-        device.wait_for_widget(tag="settings", timeout=3.0)
+        device.try_wait_widget(tag="settings", timeout=3.0)
         return
 
     # Dismiss reboot confirmation overlay if present (absorbs all taps)
@@ -68,8 +68,8 @@ def _return_to_main(device: DeviceClient):
             device.click(tag="nav_home")
         except Exception:
             pass
-        device.wait_for_screen("main", timeout=5.0)
-        device.wait_for_widget(tag="settings", timeout=3.0)
+        device.try_wait_screen("main", timeout=5.0)
+        device.try_wait_widget(tag="settings", timeout=3.0)
         return
 
     # The errors screen is still a standalone overlay opened from the Home tab.
@@ -81,8 +81,8 @@ def _return_to_main(device: DeviceClient):
                 device.click(symbol="CLOSE")
             except Exception:
                 pass
-        device.wait_for_screen("main", timeout=5.0)
-        device.wait_for_widget(tag="settings", timeout=3.0)
+        device.try_wait_screen("main", timeout=5.0)
+        device.try_wait_widget(tag="settings", timeout=3.0)
         return
 
     # If on a sub-screen, go back to settings first
@@ -113,7 +113,7 @@ def _return_to_main(device: DeviceClient):
                 device.click(symbol="LEFT")
             except Exception:
                 pass
-        device.wait_for_screen("settings", timeout=5.0)
+        device.try_wait_screen("settings", timeout=5.0)
         time.sleep(0.5)
 
     # Close settings to return to main
@@ -124,8 +124,8 @@ def _return_to_main(device: DeviceClient):
             device.click(symbol="CLOSE")
         except Exception:
             pass
-    device.wait_for_screen("main", timeout=5.0)
-    device.wait_for_widget(tag="settings", timeout=5.0)
+    device.try_wait_screen("main", timeout=5.0)
+    device.try_wait_widget(tag="settings", timeout=5.0)
 
 
 @pytest.fixture(scope="session")

--- a/tests/device/device_client.py
+++ b/tests/device/device_client.py
@@ -520,24 +520,89 @@ class DeviceClient:
             time.sleep(poll)
         return False
 
-    def wait_for_screen(self, name: str, timeout: float = 3.0, poll: float = 0.3) -> bool:
-        """Poll until the screen name matches, or timeout."""
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            if self.screen == name:
-                return True
-            time.sleep(poll)
-        return False
+    def wait_for_screen(self, name: str, timeout: float = 3.0, poll: float = 0.3,
+                        raise_on_timeout: bool = True) -> bool:
+        """Wait until the current screen matches ``name``.
+
+        Raises ``DeviceError`` on timeout by default (with the last observed
+        screen and widget tags for diagnostics). Pass ``raise_on_timeout=False``
+        — or use :meth:`try_wait_screen` — in cleanup/best-effort paths where a
+        miss should not fail the test.
+        """
+        return self.wait_until(
+            f"screen {name!r}",
+            lambda: self.screen == name,
+            timeout=timeout, poll=poll, raise_on_timeout=raise_on_timeout,
+        )
+
+    def try_wait_screen(self, name: str, timeout: float = 3.0, poll: float = 0.3) -> bool:
+        """Best-effort :meth:`wait_for_screen` — returns bool, never raises."""
+        return self.wait_for_screen(name, timeout=timeout, poll=poll, raise_on_timeout=False)
 
     def wait_for_widget(self, *, tag: Optional[str] = None, text: Optional[str] = None,
+                        timeout: float = 5.0, poll: float = 0.3,
+                        raise_on_timeout: bool = True) -> bool:
+        """Wait until a widget with the given tag or text appears in the tree.
+
+        Raises ``DeviceError`` on timeout by default. Use
+        :meth:`try_wait_widget` (or ``raise_on_timeout=False``) in best-effort
+        paths.
+        """
+        what = f"widget tag={tag!r}" if tag else f"widget text={text!r}"
+        return self.wait_until(
+            what,
+            lambda: self.has_widget(tag=tag, text=text),
+            timeout=timeout, poll=poll, raise_on_timeout=raise_on_timeout,
+        )
+
+    def try_wait_widget(self, *, tag: Optional[str] = None, text: Optional[str] = None,
                         timeout: float = 5.0, poll: float = 0.3) -> bool:
-        """Poll until a widget with the given tag or text appears in the tree."""
+        """Best-effort :meth:`wait_for_widget` — returns bool, never raises."""
+        return self.wait_for_widget(tag=tag, text=text, timeout=timeout, poll=poll,
+                                    raise_on_timeout=False)
+
+    def wait_until(self, description: str, predicate, timeout: float = 5.0,
+                   poll: float = 0.3, raise_on_timeout: bool = True) -> bool:
+        """Poll ``predicate()`` until it returns truthy, or ``timeout`` elapses.
+
+        This is the shared condition-based wait primitive that replaces fixed
+        ``time.sleep()`` band-aids: instead of sleeping a guessed interval, wait
+        for the exact observable condition. Exceptions raised by ``predicate``
+        (e.g. a transient HTTP error) are treated as "not yet" and retried.
+
+        On timeout, raises ``DeviceError`` including ``description`` plus a
+        best-effort snapshot of the current screen and widget tags — so a
+        failure says what it was waiting for and what the device was actually
+        showing. Pass ``raise_on_timeout=False`` to get a bool back instead
+        (for cleanup/best-effort checks).
+        """
         deadline = time.time() + timeout
-        while time.time() < deadline:
-            if self.has_widget(tag=tag, text=text):
-                return True
+        while True:
+            try:
+                if predicate():
+                    return True
+            except Exception:
+                pass
+            if time.time() >= deadline:
+                break
             time.sleep(poll)
+        if raise_on_timeout:
+            raise DeviceError(
+                f"Timed out after {timeout:.1f}s waiting for {description}. {self._diag()}"
+            )
         return False
+
+    def _diag(self) -> str:
+        """Best-effort snapshot of screen + widget tags for error messages."""
+        try:
+            screen = self.screen
+        except Exception as e:
+            return f"(device unreachable: {e})"
+        try:
+            tags = sorted(w.tag for w in self.widgets if w.tag)
+        except Exception:
+            tags = []
+        return f"Last observed screen={screen!r}, widget tags={tags}"
 
     def find_widget(self, *, tag: Optional[str] = None, text: Optional[str] = None) -> Optional[Widget]:
         """Find a widget by tag or text in the current tree."""


### PR DESCRIPTION
## Summary

Makes device-test waits **fail loudly** instead of silently continuing, and adds the shared `wait_until` primitive that replaces fixed `time.sleep()` band-aids. Addresses **F-04 / F-05 / F-15** from the flakiness audit (issue #164).

Previously `wait_for_screen()` / `wait_for_widget()` returned a bool that many call sites ignored — e.g. `device.wait_for_screen("status", timeout=3.0); device.click(...)`. A missed transition sailed on and surfaced later as a confusing 404 or wrong-screen assertion. That exact pattern was behind several of the "flaky" nav failures.

## Changes

- **`wait_until(description, predicate, timeout, poll, raise_on_timeout=True)`** — polls `predicate()` until truthy, treats predicate exceptions (transient HTTP errors) as "not yet", and on timeout raises `DeviceError` with the description **plus a snapshot of the current screen and widget tags**. This is the condition-based replacement for guessed sleeps.
- **`wait_for_screen()` / `wait_for_widget()`** now build on `wait_until` and **raise `DeviceError` on timeout by default** — a missed transition fails at the point it happened, with diagnostics.
- **`try_wait_screen()` / `try_wait_widget()`** best-effort variants (`raise_on_timeout=False`) for cleanup; `conftest._return_to_main()` switched to them so teardown never crashes on a device that wandered off-screen.
- **README**: stop recommending `time.sleep(0.3–0.5)` after toggles/rollers; point at `wait_until()` and document the raise-on-timeout semantics.

### Compatibility

- Every existing `assert device.wait_for_*(...)` site still fails the test on timeout (now via `DeviceError` with better context instead of a bare `AssertionError`).
- Bare navigation waits in **test bodies** now fail loudly at the missed transition (the intended hardening).
- **Teardown** waits are either `try_wait_*` (conftest) or already wrapped in `try/except` (e.g. the fahrenheit restore fixture), so a raise can't break cleanup — verified across all bare-call sites.

## Testing

- `py_compile` clean; unit-tested `wait_until` (success / raise-on-timeout with description / best-effort False / predicate-exception-then-raise).
- Full physical device suite runs in CI.

## Follow-up (issue #164)

Migrate the remaining ~281 raw `time.sleep()` calls to `wait_until()` and add a CI lint banning new raw sleeps. F-02/F-03 (settled-vs-scheduled screen), F-14 (CI crash-gate dedupe) still open.
