### PR TITLE
test: gate wait_for_screen on settled screen, not just scheduled (F-02/F-03)

### DIFF
--- a/main/test_endpoints.cpp
+++ b/main/test_endpoints.cpp
@@ -660,6 +660,22 @@ static const char* get_screen_name(void)
     }
 }
 
+// True when no screen-load transition is in flight, i.e. the active screen
+// (lv_scr_act()), its widget tree, and the per-module visibility flags all
+// agree. Each screen module sets its visible flag immediately after calling
+// lv_screen_load_anim(), so get_screen_name() reports the *scheduled* screen
+// while lv_scr_act() still walks the previous one for the duration of the
+// ~300ms load animation (the chronic scheduled-vs-settled race). LVGL sets
+// disp->scr_to_load synchronously inside lv_screen_load_anim() (before the flag
+// flips) and clears it only when the load completes (or immediately for a
+// zero-duration/instant transition), so "scr_to_load == NULL" precisely marks a
+// settled, self-consistent UI. Tests gate wait_for_screen on this to avoid
+// acting on a screen that is merely scheduled.
+static bool screen_is_settled(void)
+{
+    return lv_display_get_screen_loading(lv_display_get_default()) == NULL;
+}
+
 // ============================================================================
 // GET /api/test/ui-state
 // Uses a pre-allocated PSRAM buffer to avoid heap fragmentation on complex screens
@@ -690,9 +706,12 @@ static esp_err_t ui_state_get_handler(httpd_req_t* req)
     }
 
     const char* screen_name = get_screen_name();
+    bool settled = screen_is_settled();
 
     int pos = 0;
-    pos += snprintf(buf + pos, BUF_SIZE - pos, "{\"screen\":\"%s\",\"widgets\":[", screen_name);
+    pos += snprintf(buf + pos, BUF_SIZE - pos,
+                    "{\"screen\":\"%s\",\"settled\":%s,\"widgets\":[",
+                    screen_name, settled ? "true" : "false");
 
     int widget_count = 0;
     lv_obj_t* scr = lv_scr_act();
@@ -724,11 +743,13 @@ static esp_err_t screen_get_handler(httpd_req_t* req)
     }
 
     const char* screen_name = get_screen_name();
+    bool settled = screen_is_settled();
 
     bsp_display_unlock();
 
     char buf[128];
-    snprintf(buf, sizeof(buf), "{\"screen\":\"%s\"}", screen_name);
+    snprintf(buf, sizeof(buf), "{\"screen\":\"%s\",\"settled\":%s}",
+             screen_name, settled ? "true" : "false");
     httpd_resp_sendstr(req, buf);
     return ESP_OK;
 }

--- a/tests/device/device_client.py
+++ b/tests/device/device_client.py
@@ -87,17 +87,33 @@ class DeviceClient:
         r.raise_for_status()
         return r.json()
 
+    def _screen_payload(self) -> dict:
+        """Raw ``/api/test/screen`` JSON: ``{"screen": ..., "settled": ...}``.
+
+        ``settled`` is ``True`` only when no screen-load transition is in flight
+        (LVGL's ``scr_to_load`` cleared) — i.e. the active screen, its widget
+        tree, and the firmware's per-module visibility flags all agree. Older
+        firmware without the field is treated as always-settled for
+        backward-compatibility.
+        """
+        r = self.session.get(
+            f"{self.base_url}/api/test/screen", timeout=self.timeout
+        )
+        r.raise_for_status()
+        return r.json()
+
     @property
     def screen(self) -> str:
         """Current screen name (e.g. 'main', 'settings').
 
         Uses the lightweight /api/test/screen endpoint (no widget tree walk).
         """
-        r = self.session.get(
-            f"{self.base_url}/api/test/screen", timeout=self.timeout
-        )
-        r.raise_for_status()
-        return r.json()["screen"]
+        return self._screen_payload()["screen"]
+
+    @property
+    def screen_settled(self) -> bool:
+        """Whether the current screen is settled (no load animation in flight)."""
+        return bool(self._screen_payload().get("settled", True))
 
     @property
     def widgets(self) -> list[Widget]:
@@ -522,16 +538,28 @@ class DeviceClient:
 
     def wait_for_screen(self, name: str, timeout: float = 3.0, poll: float = 0.3,
                         raise_on_timeout: bool = True) -> bool:
-        """Wait until the current screen matches ``name``.
+        """Wait until the current screen matches ``name`` *and* is settled.
+
+        "Settled" means no screen-load animation is in flight, so the active
+        screen, its widget tree, and the firmware's visibility flags all agree.
+        Waiting only for the name match returned too early during the ~300ms
+        load animation — the endpoint reported the *scheduled* screen while
+        ``lv_scr_act()`` (and thus the widget tree / click targets) still
+        pointed at the previous one, so a follow-up action could 404 or hit the
+        old screen. Gating on ``settled`` closes that scheduled-vs-settled race.
 
         Raises ``DeviceError`` on timeout by default (with the last observed
         screen and widget tags for diagnostics). Pass ``raise_on_timeout=False``
         — or use :meth:`try_wait_screen` — in cleanup/best-effort paths where a
         miss should not fail the test.
         """
+        def _on_settled_screen() -> bool:
+            payload = self._screen_payload()
+            return payload.get("screen") == name and payload.get("settled", True)
+
         return self.wait_until(
-            f"screen {name!r}",
-            lambda: self.screen == name,
+            f"settled screen {name!r}",
+            _on_settled_screen,
             timeout=timeout, poll=poll, raise_on_timeout=raise_on_timeout,
         )
 
@@ -595,14 +623,16 @@ class DeviceClient:
     def _diag(self) -> str:
         """Best-effort snapshot of screen + widget tags for error messages."""
         try:
-            screen = self.screen
+            payload = self._screen_payload()
+            screen = payload.get("screen")
+            settled = payload.get("settled", True)
         except Exception as e:
             return f"(device unreachable: {e})"
         try:
             tags = sorted(w.tag for w in self.widgets if w.tag)
         except Exception:
             tags = []
-        return f"Last observed screen={screen!r}, widget tags={tags}"
+        return f"Last observed screen={screen!r} (settled={settled}), widget tags={tags}"
 
     def find_widget(self, *, tag: Optional[str] = None, text: Optional[str] = None) -> Optional[Widget]:
         """Find a widget by tag or text in the current tree."""


### PR DESCRIPTION
## Summary

Fixes the chronic **scheduled-vs-settled screen race** (audit findings F-02 / F-03) behind several intermittent web/nav test failures.

Each screen module sets its per-module visibility flag *immediately* after calling `lv_screen_load_anim()`, so `get_screen_name()` reports the **scheduled** screen while `lv_scr_act()` — and therefore the widget tree and click targets — still points at the *previous* screen for the duration of the ~300 ms load animation. A test that called `wait_for_screen()` and then hit `/api/test/ui-state`, `/api/test/click`, or a widget wait could 404 or act on the outgoing screen.

## Changes

**Firmware (`main/test_endpoints.cpp`)**
- Add `screen_is_settled()` — reads LVGL's `disp->scr_to_load`, which is set synchronously inside `lv_screen_load_anim()` (before the visibility flag flips) and cleared only when the load completes (or immediately for a zero-duration/instant transition). `NULL` ⇒ the active screen, its widget tree, and the module visibility flags all agree.
- Expose a new `"settled"` boolean on both `/api/test/screen` and `/api/test/ui-state`, computed under the display lock next to the screen name.

**Tests (`tests/device/device_client.py`)**
- `wait_for_screen()` now requires `screen == name` **AND** `settled == true`. Older firmware without the field is treated as always-settled (backward-compatible).
- `_diag()` reports the settled state in timeout messages; adds a `screen_settled` property for diagnostics.

## Validation
- Firmware builds clean with `CONFIG_TEST_ENDPOINTS=y` (45% app partition free); `sdkconfig` restored.
- `python -m py_compile` passes; no new ruff findings introduced.
