### PR TITLE
test: enforce baseline TLS/auth device state across suites (F-12)

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -725,6 +725,51 @@ jobs:
           TLS_FULLCHAIN_PEM: ${{ secrets.TLS_FULLCHAIN_PEM }}
           TLS_PRIVKEY_PEM: ${{ secrets.TLS_PRIVKEY_PEM }}
 
+      - name: Reset device to baseline TLS/auth state
+        if: always()
+        run: |
+          # Safety net for finding F-12 (shared TLS/auth state across suites):
+          # regardless of how the three test suites above exited, force the
+          # device back to a known baseline — no administrator TLS cert
+          # (identity only) and web auth disabled — and confirm it. A leftover
+          # self-signed admin cert (the HTTPS suite uploads one valid for 1 day)
+          # would otherwise linger onto the *next* CI run and, once expired,
+          # break TLS handshakes before that run gets a chance to clean up.
+          set -uo pipefail
+          BASE="${ARCTIC_URL}"   # already https:// at this point
+          has_cert() {
+            curl -sk --max-time 10 -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              "${BASE}/api/tls/status" 2>/dev/null \
+              | python3 -c "import sys,json;print(json.load(sys.stdin).get('has_certs',False))" 2>/dev/null \
+              || echo Unknown
+          }
+          STATE="$(has_cert)"
+          echo "TLS status before reset: has_certs=${STATE}"
+          if [ "$STATE" = "True" ]; then
+            echo "Administrator cert present — deleting and rebooting to identity."
+            curl -sk --max-time 10 -X DELETE -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              "${BASE}/api/tls/certificate" >/dev/null 2>&1 || true
+            curl -sk --max-time 10 -X POST -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              "${BASE}/api/ota/reboot" >/dev/null 2>&1 || true
+            for _ in $(seq 1 30); do
+              sleep 2
+              curl -sk --max-time 5 "${BASE}/api/health" >/dev/null 2>&1 && break
+            done
+            STATE="$(has_cert)"
+            if [ "$STATE" = "True" ]; then
+              echo "::warning::Baseline reset could not remove the administrator TLS cert (has_certs=${STATE}); the next run may inherit it."
+            else
+              echo "Administrator cert removed — device on identity cert (has_certs=${STATE})."
+            fi
+          else
+            echo "No administrator cert to remove (has_certs=${STATE})."
+          fi
+          # Permissive web-auth baseline for the next run (best-effort).
+          curl -sk --max-time 10 -X POST -H "X-API-Key: ${ARCTIC_API_KEY}" \
+            -H "Content-Type: application/json" -d '{"web_auth_enabled": false}' \
+            "${BASE}/api/auth/config" >/dev/null 2>&1 || true
+          echo "Baseline TLS/auth reset complete."
+
       - name: Stop controller serial capture
         if: always()
         run: |

--- a/tests/device/test_https.py
+++ b/tests/device/test_https.py
@@ -111,11 +111,59 @@ def self_signed_cert() -> tuple[str, str]:
     return _generate_self_signed_cert()
 
 
+def _ensure_no_admin_cert(device: DeviceClient, verify_timeout: float = 30.0) -> bool:
+    """Delete any administrator TLS cert and reboot to the device identity.
+
+    Unlike a fire-and-forget delete, this polls ``/api/tls/status`` until
+    ``has_certs`` is *externally* observable as ``False`` — so the restored
+    baseline is confirmed, not merely requested. This matters because a leftover
+    administrator cert changes which certificate HTTPS serves and would leak
+    into later suites (api/web) sharing the same physical device in a CI run.
+
+    Returns ``True`` once the device is confirmed on the identity cert.
+    """
+    if not _tls_status().get("has_certs"):
+        return True
+    _api_delete("/api/tls/certificate")
+    device.reboot()
+    if not device.wait_for_device(timeout=verify_timeout):
+        return False
+    deadline = time.time() + verify_timeout
+    while time.time() < deadline:
+        try:
+            if not _tls_status().get("has_certs"):
+                return True
+        except Exception:
+            pass
+        time.sleep(1.0)
+    return False
+
+
+def _restore_auth_config(original: dict, verify_timeout: float = 10.0) -> None:
+    """Restore auth config to ``original`` and poll until it takes effect."""
+    want_web = original.get("web_auth_enabled", True)
+    want_api = original.get("api_auth_enabled", True)
+    _api_post(
+        "/api/auth/config",
+        json={"web_auth_enabled": want_web, "api_auth_enabled": want_api},
+    )
+    deadline = time.time() + verify_timeout
+    while time.time() < deadline:
+        try:
+            cur = _api_get("/api/auth/config").json()
+            if (cur.get("web_auth_enabled") == want_web
+                    and cur.get("api_auth_enabled") == want_api):
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+
+
 @pytest.fixture(scope="module")
 def auth_enabled(device: DeviceClient):
     """Ensure both web and API auth are enabled (required for cert upload).
 
-    Restores previous auth config after the module completes.
+    Restores previous auth config after the module completes, verified.
     """
     # Read current config
     r = _api_get("/api/auth/config")
@@ -130,36 +178,27 @@ def auth_enabled(device: DeviceClient):
 
     yield
 
-    # Restore original auth config
-    _api_post(
-        "/api/auth/config",
-        json={
-            "web_auth_enabled": original.get("web_auth_enabled", True),
-            "api_auth_enabled": original.get("api_auth_enabled", True),
-        },
-    )
+    # Restore original auth config (verified: poll until externally visible)
+    _restore_auth_config(original)
 
 
 @pytest.fixture(autouse=True, scope="module")
 def clean_tls_state(device: DeviceClient, auth_enabled):
     """Ensure no leftover certs before tests and clean up after."""
-    status = _tls_status()
-    if status.get("has_certs"):
-        _api_delete("/api/tls/certificate")
-        device.reboot()
-        assert device.wait_for_device(timeout=30.0), "Device did not come back after clearing certs"
+    assert _ensure_no_admin_cert(device), \
+        "Device retained an administrator TLS cert before HTTPS tests"
 
     yield
 
-    # Clean up: delete any certs left by tests
+    # Verified cleanup: a leftover admin cert would change the certificate
+    # served to later suites (api/web) in the same CI run, so confirm the
+    # identity restore rather than firing and forgetting.
     try:
-        status = _tls_status()
-        if status.get("has_certs"):
-            _api_delete("/api/tls/certificate")
-            device.reboot()
-            device.wait_for_device(timeout=30.0)
-    except Exception:
-        pass  # best effort cleanup
+        if not _ensure_no_admin_cert(device):
+            print("WARNING: HTTPS teardown could not confirm identity-cert restore; "
+                  "later suites may see a leftover administrator cert.")
+    except Exception as e:
+        print(f"WARNING: HTTPS teardown cleanup error: {e}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -190,6 +190,46 @@ def _browser_login(page: Page):
         page.wait_for_selector(".rail", timeout=10000)
 
 
+# ---------- Session baseline enforcement ----------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _web_auth_baseline(base_url: str):
+    """Force a known web-auth baseline (disabled) at the end of the web session.
+
+    The web suite toggles global web-auth state via cached module globals
+    (``login_page`` enables it, ``dashboard_page`` disables it). If a test errors
+    before its own fixture cleanup runs — or a transient re-disable call fails —
+    web auth can be left enabled and leak into a later suite that shares the same
+    physical device in a CI run. This session-scoped teardown resets the cached
+    flags and forces web auth back to disabled, then confirms it via
+    ``/api/auth/status`` so the baseline is verified, not merely requested.
+    """
+    yield
+    global _auth_disabled, _auth_needs_login
+    _auth_disabled = None
+    _auth_needs_login = False
+    _ensure_auth_disabled(base_url)
+
+    # Verify the baseline is externally observable (best-effort).
+    import requests
+    import time
+
+    headers = {"X-API-Key": API_KEY} if API_KEY else {}
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{base_url}/api/auth/status", headers=headers,
+                             timeout=5, verify=False)
+            if r.ok and not r.json().get("web_auth_enabled"):
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    print("WARNING: web-auth baseline reset could not be confirmed disabled at "
+          "session end; a later suite may inherit web auth enabled.")
+
+
 # ---------- Page fixtures ----------
 
 


### PR DESCRIPTION
## Summary

Fixes audit finding **F-12** — mutable **device-side** TLS/auth state leaking across the three device-tests suites and into the next CI run.

The `device`, `api`, and `web` suites run as **separate pytest processes** sharing **one physical device**. Python module globals reset per process, but the *device* state does not: an uploaded administrator TLS cert or a web-auth-enabled toggle persists. The HTTPS lifecycle suite uploads a self-signed admin cert (valid 1 day) and its teardown was fire-and-forget inside a bare `except: pass`, so a failed cleanup could leave that cert in place — and once it expires it breaks TLS handshakes before the next run can recover.

## Changes

**`tests/device/test_https.py`**
- New `_ensure_no_admin_cert()` — deletes the admin cert, reboots, and **polls `/api/tls/status` until `has_certs` is externally observed `False`** (verified restore, not fire-and-forget). Used in both the pre-test guard and teardown; teardown now logs a clear warning instead of silently swallowing.
- `auth_enabled` restore now polls until the config change is externally visible (`_restore_auth_config()`).

**`tests/web/conftest.py`**
- New session-scoped autouse `_web_auth_baseline` fixture: at session end, resets cached auth globals and forces web auth back to **disabled**, confirmed via `/api/auth/status`. Prevents a test that errors before its own cleanup from leaking web auth enabled into a later suite.

**`.github/workflows/device-tests.yml`**
- New `if: always()` **"Reset device to baseline TLS/auth state"** step after the suites (while serial capture is still live, so any reboot is logged). Deletes any admin cert + reboots to identity, verifies via `/api/tls/status`, and sets a permissive web-auth baseline — the final safety net guaranteeing a clean device state regardless of suite outcomes.

## Validation
- `python -m py_compile` passes on both test files; workflow YAML parses clean.
- No new ruff issue categories introduced (existing `BLE001`/`S110`/`I001` style throughout is preserved).
- Behavioral verification runs on the physical device via CI (single-device serialized).
