### PR TITLE
ci: dedupe crash-detection gate and lock its contract with a test (F-14)

### DIFF
--- a/.github/scripts/scan_crashes.sh
+++ b/.github/scripts/scan_crashes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Canonical firmware-crash signature scanner for the device-tests serial log.
+#
+# This is the SINGLE SOURCE OF TRUTH for the crash regex, shared by:
+#   - .github/workflows/device-tests.yml  ("Detect firmware crashes on device")
+#   - tests/api/test_crash_detection.py   (hostside regression test)
+# so the two can never drift.
+#
+# Only two signals are trustworthy crash evidence, and neither can be produced
+# by a test. Device/API tests deliberately SEED event-log entries named
+# "application_crash", "watchdog_reset" and "brownout_reset" to exercise the
+# event-log UI; those are journalled events, NOT crashes, and must be ignored:
+#   - "Crash reboot ("  : printed by boot_stats on the next boot ONLY when the
+#                         hardware reset reason is PANIC or a watchdog
+#                         (main/boot_stats.cpp is_crash_reason), so it is
+#                         derived from the hardware reset reason and can never
+#                         be produced by a seeded event.
+#   - "Guru Meditation" : a live panic dump printed on the serial line.
+#
+# Usage:   scan_crashes.sh <serial-log>
+# Output:  matching "<lineno>:<line>" records on stdout (grep -nE format).
+# Exit:    0 if at least one crash signature is found,
+#          1 if none are found (or the log file is missing).
+set -uo pipefail
+
+# Keep this regex in sync ONLY here. tests/api/test_crash_detection.py pins the
+# match/no-match behaviour against representative fixture lines.
+CRASH_RE='Guru Meditation|Crash reboot \('
+
+log="${1:?usage: scan_crashes.sh <serial-log>}"
+[ -f "$log" ] || exit 1
+
+hits="$(grep -nE "$CRASH_RE" "$log" || true)"
+[ -n "$hits" ] || exit 1
+
+printf '%s\n' "$hits"
+exit 0

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -840,41 +840,18 @@ jobs:
             echo "No serial log captured — skipping crash check."
             exit 0
           fi
-          # Trustworthy crash signals only (never produced by seeded events):
-          #  - "Crash reboot (" : boot_stats, any real crash reset reason
-          #  - "Guru Meditation": live panic dump
-          CRASH_RE='Guru Meditation|Crash reboot \('
-          HITS=$(grep -nE "$CRASH_RE" controller-serial.log || true)
+          # Canonical crash regex lives in .github/scripts/scan_crashes.sh — a
+          # single source of truth covered by tests/api/test_crash_detection.py,
+          # so the "ignore test-seeded application_crash/watchdog_reset events"
+          # contract can't silently regress. Trustworthy signals only:
+          #   "Crash reboot (" (boot_stats, real crash reset reason) and
+          #   "Guru Meditation" (live panic dump).
+          HITS=$(bash .github/scripts/scan_crashes.sh controller-serial.log || true)
           if [ -z "$HITS" ]; then
             echo "OK: no firmware crash signatures in serial log (test-seeded application_crash/watchdog_reset event-log entries are ignored)."
             exit 0
           fi
           COUNT=$(printf '%s\n' "$HITS" | grep -cE 'Crash reboot \(|Guru Meditation' || true)
-          STREAK=$(grep -oE 'consecutive crash streak now [0-9]+' controller-serial.log | grep -oE '[0-9]+$' | sort -n | tail -1 || true)
-          echo "::warning title=Device firmware crashed::The controller crashed during the device-tests run (crash reboots: ${COUNT:-?}, peak consecutive streak: ${STREAK:-?}). This is a latent firmware bug, not a test flake. See the crash summary and the controller-serial-log artifact."
-          {
-            echo "### ⚠️ Device firmware crash detected"
-            echo ""
-            echo "Crash reboots / panics: **${COUNT:-?}**  |  peak consecutive crash streak: **${STREAK:-?}**"
-            echo ""
-            echo "Crash-signature lines from the serial log:"
-            echo '```'
-            printf '%s\n' "$HITS" | head -40
-            echo '```'
-            # If a live Guru Meditation dump was captured, surface the backtrace
-            # so it can be decoded with riscv32-esp-elf-addr2line against the ELF.
-            if grep -q 'Guru Meditation' controller-serial.log; then
-              echo "Panic backtrace excerpt (decode with riscv32-esp-elf-addr2line -pfiaC -e arctic_controller.elf):"
-              echo '```'
-              grep -nE 'Guru Meditation|Core .* register dump|MEPC|MTVAL|MCAUSE|A[0-9]+ +:|SP +:|RA +:|Backtrace|Stack memory' controller-serial.log | head -60
-              echo '```'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "$HITS" | head -40
-          # Crash detection is a hard gate now that the flash-race reboot crash
-          # is fixed (all reboots go through system_safe_restart()).
-          exit 1
-
           STREAK=$(grep -oE 'consecutive crash streak now [0-9]+' controller-serial.log | grep -oE '[0-9]+$' | sort -n | tail -1 || true)
           echo "::warning title=Device firmware crashed::The controller crashed during the device-tests run (crash reboots: ${COUNT:-?}, peak consecutive streak: ${STREAK:-?}). This is a latent firmware bug, not a test flake. See the crash summary and the controller-serial-log artifact."
           {

--- a/tests/api/test_crash_detection.py
+++ b/tests/api/test_crash_detection.py
@@ -1,0 +1,77 @@
+"""Pin the crash-detection contract used by the device-tests CI gate.
+
+``.github/scripts/scan_crashes.sh`` is the single source of truth for which
+serial-log lines count as a genuine firmware crash. Device/API tests
+deliberately SEED event-log entries named ``application_crash``,
+``watchdog_reset`` and ``brownout_reset`` to exercise the event-log UI — those
+are journalled events, not crashes, and must NEVER trip the gate (matching them
+once failed an otherwise-clean run). Conversely a real ``Guru Meditation`` panic
+or a boot_stats ``Crash reboot (...)`` MUST trip it.
+
+Rather than duplicate the regex (which would drift), this test *extracts* the
+canonical ``CRASH_RE`` from the shell script and applies it in pure Python, so
+it is portable (no bash needed) and can't diverge from what CI actually runs.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.hostside
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "scripts" / "scan_crashes.sh"
+
+# Serial-log lines tests legitimately produce (seeded event-log entries and
+# ordinary clean reboots) — none of these may be treated as a crash.
+BENIGN_LINES = [
+    "I (12345) event_log: journaled event application_crash",
+    "I (12346) event_log: journaled event watchdog_reset",
+    "I (12347) event_log: journaled event brownout_reset",
+    'I (12348) test_endpoints: seeding event {"type":"application_crash"}',
+    "I (12349) boot_stats: reboot reason SW_CPU_RESET (clean)",
+    "I (12350) ota: intentional reboot requested via /api/ota/reboot",
+]
+
+# Serial-log lines that are genuine, hardware-derived crash evidence.
+CRASH_LINES = [
+    "Guru Meditation Error: Core 0 panic'ed (Load access fault).",
+    "I (900) boot_stats: Crash reboot (Panic) - consecutive crash streak now 1",
+    "I (901) boot_stats: Crash reboot (Task watchdog)",
+]
+
+
+def _canonical_crash_regex() -> str:
+    """Extract ``CRASH_RE`` from the shared scanner (single source of truth)."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(r"^CRASH_RE='([^']*)'", text, re.MULTILINE)
+    assert m, "could not find CRASH_RE='...' in scan_crashes.sh"
+    return m.group(1)
+
+
+def test_script_exists_and_applies_the_canonical_regex():
+    assert SCRIPT.is_file(), f"missing crash scanner: {SCRIPT}"
+    # The regex we test is the one the script actually greps with.
+    assert 'grep -nE "$CRASH_RE"' in SCRIPT.read_text(encoding="utf-8")
+
+
+def test_seeded_event_log_entries_are_not_crashes():
+    """Seeded application_crash/watchdog_reset/brownout_reset must not match."""
+    rx = re.compile(_canonical_crash_regex())
+    matched = [ln for ln in BENIGN_LINES if rx.search(ln)]
+    assert matched == [], f"seeded/benign lines were flagged as crashes: {matched}"
+
+
+def test_real_crash_signatures_are_detected():
+    """Guru Meditation and boot_stats 'Crash reboot (' must match."""
+    rx = re.compile(_canonical_crash_regex())
+    missed = [ln for ln in CRASH_LINES if not rx.search(ln)]
+    assert missed == [], f"real crash signatures were not detected: {missed}"
+
+
+def test_mixed_log_reports_only_crash_lines():
+    """With seeded events AND a real crash present, only crashes are reported."""
+    rx = re.compile(_canonical_crash_regex())
+    hits = [ln for ln in (BENIGN_LINES + CRASH_LINES) if rx.search(ln)]
+    assert sorted(hits) == sorted(CRASH_LINES)


### PR DESCRIPTION
## Summary

Fixes audit finding **F-14** — the device-tests crash-detection gate had a duplicated, unreachable shell block after its `exit 1`, and its crash regex had no test guarding the "ignore test-seeded events" contract.

## Changes

- **`.github/workflows/device-tests.yml`** — remove the dead duplicated block in the *"Detect firmware crashes on device"* step (everything after the first `exit 1` was unreachable). The step now calls a shared script for the match.
- **`.github/scripts/scan_crashes.sh`** (new) — single source of truth for the crash-signature regex. Only `Guru Meditation` (live panic) and boot_stats `Crash reboot (` (hardware-derived reset reason) count; test-seeded event-log entries (`application_crash` / `watchdog_reset` / `brownout_reset`) are deliberately excluded.
- **`tests/api/test_crash_detection.py`** (new, `hostside`) — extracts `CRASH_RE` straight from the script and applies it in pure Python (no bash needed), pinning the contract both ways:
  - seeded `application_crash` / `watchdog_reset` / `brownout_reset` and clean reboots MUST NOT match;
  - real `Guru Meditation` and `Crash reboot (...)` MUST match;
  - in a mixed log, only the crash lines are reported.

Extracting the regex from the script means the test can't drift from what CI actually greps with.

## Validation
- `python -m pytest tests/api/test_crash_detection.py` — 4 passed; collected under the `hostside` marker.
- Workflow YAML parses clean; crash-gate step now has a single coherent body ending in one `exit 1`.
- New test is ruff-clean.
