### PR TITLE
Harden crash gate: same-boot fatal signatures + bash-executed test (#164 H-01/H-02)

### DIFF
--- a/.github/scripts/scan_crashes.sh
+++ b/.github/scripts/scan_crashes.sh
@@ -26,7 +26,20 @@ set -uo pipefail
 
 # Keep this regex in sync ONLY here. tests/api/test_crash_detection.py pins the
 # match/no-match behaviour against representative fixture lines.
-CRASH_RE='Guru Meditation|Crash reboot \('
+#
+# Signatures, and why each is safe (no test legitimately emits them):
+#   Guru Meditation          - exception panic dump header (covers Load/Store/
+#                              Illegal-instruction causes shown on that line).
+#   Crash reboot \(          - boot_stats journalling the PREVIOUS boot's crash.
+#   A stack overflow in task - FreeRTOS stack-overflow hook. NOTE: this path
+#                              prints NO "Guru Meditation" line, so without this
+#                              signature an overflow is only caught on the *next*
+#                              boot's "Crash reboot (" - and missed entirely if
+#                              the run ends first (this actually happened).
+#   abort() was called       - abort()/assert-driven panic.
+#   assert failed:           - ESP-IDF assertion panic.
+#   CORRUPT HEAP             - heap-corruption detector panic.
+CRASH_RE='Guru Meditation|Crash reboot \(|A stack overflow in task|abort\(\) was called|assert failed:|CORRUPT HEAP'
 
 log="${1:?usage: scan_crashes.sh <serial-log>}"
 [ -f "$log" ] || exit 1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -865,7 +865,7 @@ jobs:
             echo "::error title=Crash gate broken::scan_crashes.sh exited $rc (expected 0=crash or 1=clean). The crash detector failed to run — failing the job rather than silently passing. Check the script for CRLF line endings or a bad checkout."
             exit 1
           fi
-          COUNT=$(printf '%s\n' "$HITS" | grep -cE 'Crash reboot \(|Guru Meditation' || true)
+          COUNT=$(printf '%s\n' "$HITS" | grep -cE 'Crash reboot \(|Guru Meditation|A stack overflow in task|abort\(\) was called|assert failed:|CORRUPT HEAP' || true)
           STREAK=$(grep -oE 'consecutive crash streak now [0-9]+' controller-serial.log | grep -oE '[0-9]+$' | sort -n | tail -1 || true)
           echo "::warning title=Device firmware crashed::The controller crashed during the device-tests run (crash reboots: ${COUNT:-?}, peak consecutive streak: ${STREAK:-?}). This is a latent firmware bug, not a test flake. See the crash summary and the controller-serial-log artifact."
           {

--- a/tests/api/test_crash_detection.py
+++ b/tests/api/test_crash_detection.py
@@ -14,6 +14,9 @@ it is portable (no bash needed) and can't diverge from what CI actually runs.
 """
 
 import re
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -39,6 +42,10 @@ CRASH_LINES = [
     "Guru Meditation Error: Core 0 panic'ed (Load access fault).",
     "I (900) boot_stats: Crash reboot (Panic) - consecutive crash streak now 1",
     "I (901) boot_stats: Crash reboot (Task watchdog)",
+    "***ERROR*** A stack overflow in task arctic_demo_sync has been detected.",
+    "abort() was called at PC 0x4008a1b2 on core 0",
+    "assert failed: xQueueSemaphoreTake queue.c:1545 (pxQueue)",
+    "CORRUPT HEAP: Bad head at 0x3fca1234. Expected 0xabba1234",
 ]
 
 
@@ -75,3 +82,51 @@ def test_mixed_log_reports_only_crash_lines():
     rx = re.compile(_canonical_crash_regex())
     hits = [ln for ln in (BENIGN_LINES + CRASH_LINES) if rx.search(ln)]
     assert sorted(hits) == sorted(CRASH_LINES)
+
+
+def test_scanner_has_no_crlf_line_endings():
+    """The scanner MUST be LF-only. CRLF silently breaks bash on the Linux
+    runner (bash errors on every ``\\r``), the failure gets swallowed, and the
+    gate reports "no crash" for real crashes — an actual weeks-long outage.
+    This byte check runs everywhere (no bash needed) and pins that exact bug.
+    """
+    raw = SCRIPT.read_bytes()
+    assert b"\r" not in raw, "scan_crashes.sh contains CR bytes (CRLF) — bash on CI will break"
+
+
+_BASH = shutil.which("bash")
+# The point of this test is to catch a bash-syntax/CRLF break the way CI would.
+# On Windows ``bash`` usually resolves to the WSL launcher, which can't take a
+# Windows-style path — so restrict the executed check to the Linux CI runner.
+_SKIP_BASH = _BASH is None or sys.platform.startswith("win")
+
+
+@pytest.mark.skipif(_SKIP_BASH, reason="bash-execution check runs on Linux CI only")
+def test_scanner_executes_under_bash(tmp_path):
+    """Actually run the scanner under bash (as CI does), so a bash-syntax or
+    CRLF break FAILS this test instead of silently disabling the gate.
+
+    A crash log must exit 0; a benign log must exit 1. A broken script exits
+    with neither (e.g. 2), tripping both assertions.
+    """
+    crash_log = tmp_path / "crash.log"
+    crash_log.write_text("\n".join(BENIGN_LINES + CRASH_LINES) + "\n", encoding="utf-8")
+    benign_log = tmp_path / "benign.log"
+    benign_log.write_text("\n".join(BENIGN_LINES) + "\n", encoding="utf-8")
+
+    crash = subprocess.run(
+        [_BASH, str(SCRIPT), str(crash_log)], capture_output=True, text=True
+    )
+    assert crash.returncode == 0, (
+        f"scanner should exit 0 when a crash is present; got {crash.returncode}\n"
+        f"stdout={crash.stdout!r} stderr={crash.stderr!r}"
+    )
+    assert "Guru Meditation" in crash.stdout, f"crash line not reported: {crash.stdout!r}"
+
+    benign = subprocess.run(
+        [_BASH, str(SCRIPT), str(benign_log)], capture_output=True, text=True
+    )
+    assert benign.returncode == 1, (
+        f"scanner should exit 1 when no crash is present; got {benign.returncode}\n"
+        f"stdout={benign.stdout!r} stderr={benign.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Closes the two crash-gate hardening follow-ups (**H-01**, **H-02**) added to #164 after the `arctic_demo_sync` stack overflow (fixed in #174) exposed them — and after discovering the gate had been silently disabled by CRLF for weeks.

### H-01 — broaden the crash regex to same-boot fatals
The stack overflow prints `***ERROR*** A stack overflow in task ...` with **no** `Guru Meditation` line, so today it's caught only via the *next* boot's `Crash reboot (` — and missed entirely if the run ends first. Add these clearly-fatal, non-seedable signatures to the canonical `scan_crashes.sh` regex:
- `A stack overflow in task`
- `abort() was called`
- `assert failed:`
- `CORRUPT HEAP`

The test-seeded `application_crash` / `watchdog_reset` / `brownout_reset` event-log entries contain none of these, so the "ignore seeded events" contract is preserved. `test_crash_detection.py` fixtures pin each new signature; the workflow COUNT grep is aligned so the summary count is right for overflow-only crashes.

### H-02 — execute `scan_crashes.sh` under bash in the hostside test
The hostside test only extracted `CRASH_RE` in Python and never ran the script — so it was blind to the CRLF break that disabled the gate. Adds:
- `test_scanner_has_no_crlf_line_endings` — portable byte check (all platforms) pinning the exact CRLF regression.
- `test_scanner_executes_under_bash` — runs the script under bash on the Linux CI runner, asserting exit 0 for a crash log and 1 for a benign log, so a bash/CRLF break fails CI instead of silently passing.

## Validation
- `pytest tests/api/test_crash_detection.py` on Windows → 5 passed, 1 skipped (bash-exec skips off-Linux by design).
- Ran `scan_crashes.sh` under real WSL bash: all six signatures matched a crash log (rc=0); benign log rc=1.
- `scan_crashes.sh` confirmed LF-only (0 CR bytes).

Part of #164 (H-01, H-02). H-03 (stack high-water-mark ratchet gate) tracked as a follow-up.
