### PR TITLE
Populate stack-watermark baseline from first real CI snapshot (#164 H-03)

### DIFF
--- a/tests/stack_watermark_budget.json
+++ b/tests/stack_watermark_budget.json
@@ -1,1 +1,24 @@
-{}
+{
+  "IDLE0": 660,
+  "IDLE1": 655,
+  "Tmr Svc": 986,
+  "arctic_demo_syn": 1557,
+  "esp_timer": 1454,
+  "ha_ws_push": 4548,
+  "httpd": 4418,
+  "ipc0": 256,
+  "ipc1": 386,
+  "main": 2344,
+  "mdns": 1761,
+  "rpc_rx": 1394,
+  "rpc_tx": 2352,
+  "sdio_process_rx": 2294,
+  "sdio_read": 1838,
+  "sdio_rx_buf": 2760,
+  "sdio_write": 2517,
+  "sys_evt": 1238,
+  "taskLVGL": 5582,
+  "telemetry_histo": 1648,
+  "tiT": 1039,
+  "wifi_super": 2152
+}


### PR DESCRIPTION
## Summary

Follow-up to #176: populate the stack high-water-mark **baseline** from the first real device-suite snapshot, activating the per-task ratchet.

#176 shipped the gate with an empty baseline, so only the unconditional **256 B danger floor** was live. This commits `tests/stack_watermark_budget.json` with a floor per task = **0.6 × observed free stack** (min 256 B) — a >40% headroom margin before any task trips.

Highlights from the first CI snapshot:
- **`arctic_demo_syn`**: observed 2596 B free (healthy after the #174 static-buffer fix) → floor **1557 B**. A future change that eats this task's stack now fails CI long before it can overflow the 4 KB task stack — exactly the regression that caused the original crash.
- **`ipc0`** (an ESP-IDF system task we don't control): just **384 B free** — the tightest task. It passes the 256 B danger floor but **would have false-failed a 512 B floor**, confirming the danger floor is correctly calibrated. Its ratchet floor clamps to 256, so it adds no flakiness.

## Validation
- Hostside gate tests: 8 passed, 1 skipped.
- Baseline regenerated via `python tests/api/test_stack_watermark_budget.py --write` from the real snapshot; passes against its own source by construction.
- This PR's own device run will re-snapshot and check the committed baseline live — a self-test that it isn't too tight.

Completes #164 **H-03** (endpoint + gate in #176, baseline here).
