### PR TITLE
fix(restart): eliminate esp_restart cache-writeback flash-op race

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -122,6 +122,7 @@ idf_component_register(
         esp_http_client
         esp-tls
         mbedtls
+        spi_flash
         arctic-macon
 )
 

--- a/main/system_restart.cpp
+++ b/main/system_restart.cpp
@@ -5,6 +5,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#include "esp_private/cache_utils.h"
+
 #include "history_storage.h"
 #include "telemetry_history.h"
 
@@ -21,11 +23,29 @@ void system_safe_restart(void) {
     // in-flight write. After this returns, none of our writers will touch flash.
     history_storage_begin_reboot();
 
-    // Give any in-flight NVS commit (e.g. timezone write on NTP sync, cert/wifi
-    // saves) time to finish. NVS operations are short; this is a safety margin
-    // so no SPI-flash op is running when esp_restart_noos() stalls the other
-    // core and flushes the cache.
-    vTaskDelay(pdMS_TO_TICKS(400));
+    // The real hazard is esp_restart_noos(): on this dual-core, SPIRAM-enabled
+    // target it stalls the *other* core and then executes the ROM routine
+    // Cache_WriteBack_All(). If that other core happened to be in the middle of
+    // a SPI-flash operation at the moment it was stalled, the cache is disabled
+    // and in an inconsistent state, so the ROM cache write-back dereferences an
+    // invalid address and panics (Store access fault, MCAUSE 0x7, inside
+    // Cache_WriteBack_All at ROM 0x4fc10a60). Gating only *our* partition
+    // writers above is not enough, because arbitrary NVS commits (timezone on
+    // NTP sync, TLS certs, Wi-Fi creds, app prefs, boot_stats, ...) can still be
+    // mid-flight and are not under our control.
+    //
+    // Every flash operation - legacy spi_flash and the esp_flash/NVS path alike
+    // - must first acquire spi_flash_op_lock() before it disables the cache
+    // (see spi_flash_disable_interrupts_caches_and_other_cpu()). By taking that
+    // same lock here and never releasing it, we deterministically guarantee that
+    // once we proceed, no core is inside a flash op with the cache disabled:
+    //   - any in-flight op has completed and released the mutex before we
+    //     acquire it, and
+    //   - any new op blocks on the mutex *before* touching the cache.
+    // esp_restart() then runs with the cache in a normal, enabled state and the
+    // ROM write-back can no longer fault. We intentionally never unlock - the
+    // chip is about to reset.
+    spi_flash_op_lock();
 
     ESP_LOGW(TAG, "Flash writers quiesced - restarting now");
     esp_restart();


### PR DESCRIPTION
## Problem

The device-tests crash gate (armed in #174) caught a **real recurrence** of the residual reboot-path firmware panic that #110 deferred with *"the now-armed gate will catch it if it recurs."* It has recurred:

```
W (14177) system_restart: Flash writers quiesced - restarting now
Guru Meditation Error: Core  1 panic'ed (Store access fault). Exception was unhandled.
MEPC : 0x4fc10a60  MTVAL : 0x3ff100a0  MCAUSE : 0x00000007
```

MEPC `0x4fc10a60` is the ROM routine `Cache_WriteBack_All` ? the panic is on the `esp_restart()` path, not in application code. This is a latent `main` firmware bug (surfaced by, not caused by, a test-only PR whose firmware tree is byte-identical to main).

## Root cause

On this dual-core, `CONFIG_SPIRAM=y` target, `esp_restart_noos()` (esp_system/port/soc/esp32p4/system_internal.c) resets + **stalls the other core**, then runs `Cache_WriteBack_All(CACHE_MAP_L1_DCACHE)`. If the stalled core was **mid SPI-flash operation** (cache disabled + inconsistent) at the instant it was stalled, the ROM write-back dereferences an invalid address ? Store access fault.

The previous `system_safe_restart()` gated only *our* partition writers and then relied on a **400 ms `vTaskDelay` heuristic**. That does not cover arbitrary NVS commits (timezone-on-NTP-sync, TLS certs, Wi-Fi creds, app prefs, boot_stats), any of which can be mid-flight and race the reset.

## Fix

Before `esp_restart()`, acquire `spi_flash_op_lock()` ? the recursive mutex that **every** flash operation (legacy `spi_flash` and the `esp_flash`/NVS path) must take *before* it disables the cache (verified in `spi_flash_disable_interrupts_caches_and_other_cpu()`, cache_utils.c). Holding it ? and never releasing, since we are about to reset ? deterministically guarantees that once we proceed no core is inside a flash op with the cache disabled:

- any in-flight op has completed and released the mutex before we acquire it, and
- any new op blocks on the mutex **before** touching the cache.

`esp_restart()` then runs with the cache in a normal, enabled state and the ROM write-back can no longer fault. This replaces a fragile timing heuristic with a hard synchronization guarantee.

## Changes
- `main/system_restart.cpp` ? take `spi_flash_op_lock()` instead of the 400 ms delay; extensive comment explaining the ROM race.
- `main/CMakeLists.txt` ? add `spi_flash` to `REQUIRES` for the `esp_private/cache_utils.h` include.

## Validation
- Builds clean locally (47% app partition free); `sdkconfig` churn reverted.
- The device-tests suite exercises heavy reboot + concurrent-flash workloads with the crash gate **armed** ? this run is the hardware validation path. A clean run (no crash signatures) confirms the fix.
