### PR TITLE
fix: eliminate intermittent esp_restart Cache_WriteBack_All crash on reboot

### DIFF
--- a/main/system_restart.cpp
+++ b/main/system_restart.cpp
@@ -2,6 +2,7 @@
 
 #include <esp_log.h>
 #include <esp_system.h>
+#include <esp_rom_sys.h>   // esp_rom_software_reset_system()
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -23,30 +24,47 @@ void system_safe_restart(void) {
     // in-flight write. After this returns, none of our writers will touch flash.
     history_storage_begin_reboot();
 
-    // The real hazard is esp_restart_noos(): on this dual-core, SPIRAM-enabled
-    // target it stalls the *other* core and then executes the ROM routine
-    // Cache_WriteBack_All(). If that other core happened to be in the middle of
-    // a SPI-flash operation at the moment it was stalled, the cache is disabled
-    // and in an inconsistent state, so the ROM cache write-back dereferences an
-    // invalid address and panics (Store access fault, MCAUSE 0x7, inside
-    // Cache_WriteBack_All at ROM 0x4fc10a60). Gating only *our* partition
-    // writers above is not enough, because arbitrary NVS commits (timezone on
-    // NTP sync, TLS certs, Wi-Fi creds, app prefs, boot_stats, ...) can still be
-    // mid-flight and are not under our control.
-    //
-    // Every flash operation - legacy spi_flash and the esp_flash/NVS path alike
-    // - must first acquire spi_flash_op_lock() before it disables the cache
-    // (see spi_flash_disable_interrupts_caches_and_other_cpu()). By taking that
-    // same lock here and never releasing it, we deterministically guarantee that
-    // once we proceed, no core is inside a flash op with the cache disabled:
-    //   - any in-flight op has completed and released the mutex before we
-    //     acquire it, and
-    //   - any new op blocks on the mutex *before* touching the cache.
-    // esp_restart() then runs with the cache in a normal, enabled state and the
-    // ROM write-back can no longer fault. We intentionally never unlock - the
-    // chip is about to reset.
+    // Take (and never release) the global SPI-flash op lock. Every flash
+    // operation - legacy spi_flash and the esp_flash/NVS path alike - must
+    // acquire this mutex before it programs/erases flash, so once we hold it:
+    //   - any in-flight op has already completed and released the mutex, and
+    //   - any new op (arbitrary NVS commit: timezone, TLS certs, Wi-Fi creds,
+    //     app prefs, boot_stats, ...) blocks on the mutex before touching flash.
+    // That guarantees no flash program/erase is in progress when we pull the
+    // trigger below, so the hard reset cannot corrupt a half-written sector.
     spi_flash_op_lock();
 
+    // Why not simply call esp_restart()? On this dual-core, SPIRAM-enabled P4,
+    // esp_restart() -> esp_restart_noos() stalls the *other* core and then runs
+    // the ROM routine Cache_WriteBack_All(CACHE_MAP_L1_DCACHE) (compiled in only
+    // because CONFIG_SPIRAM=y). Intermittently (~5% of reboots under load) that
+    // write-back faults with a Store access fault to an unmapped address
+    // (MCAUSE 0x7, MTVAL 0x3ff100a0, PC inside Cache_WriteBack_All at ROM
+    // 0x4fc10a60): a dirty L1 data-cache line carries a bogus tag and the ROM
+    // dutifully tries to write it back to invalid memory and panics. Holding the
+    // flash-op lock does NOT prevent it (proven on hardware) - the faulting line
+    // is not associated with a flash operation.
+    //
+    // We do not need any dirty PSRAM data to survive a reboot, so instead of
+    // asking the ROM to write the cache back, we skip that step entirely and
+    // trigger a full HP-digital-domain reset directly via the ROM's
+    // software_reset primitive. This resets the CPUs and peripherals (incl. DMA)
+    // in hardware - no cache maintenance, no core-stall dance - and reports a
+    // clean RESET_REASON_CORE_SW -> ESP_RST_SW ("SOFTWARE") reset, so boot_stats
+    // does not misclassify the reboot as a crash.
     ESP_LOGW(TAG, "Flash writers quiesced - restarting now");
-    esp_restart();
+
+    // Stop task switching and mask interrupts so nothing runs (and nothing can
+    // start a new flash/cache access) between here and the reset. Neither call
+    // returns meaningfully on this path; the chip is about to reset.
+    vTaskSuspendAll();
+    portDISABLE_INTERRUPTS();
+
+    // Full software system reset. Does not run the ROM cache write-back, so it
+    // cannot hit the Cache_WriteBack_All fault above.
+    esp_rom_software_reset_system();
+
+    // Not reached - the reset takes effect immediately.
+    while (true) {
+    }
 }


### PR DESCRIPTION
## Summary

Fixes an intermittent firmware crash on the reboot path that was surfacing as flaky `device-tests` (the crash gate catching a panic during `esp_restart`).

## Root cause

On this dual-core, SPIRAM-enabled ESP32-P4, `esp_restart()` → `esp_restart_noos()` stalls the other core and then runs the ROM routine `Cache_WriteBack_All(CACHE_MAP_L1_DCACHE)` (compiled in only because `CONFIG_SPIRAM=y`). Intermittently (~5% of reboots under event-log-write load) that write-back faults:

```
Store access fault  MCAUSE 0x7  MTVAL 0x3ff100a0
PC inside Cache_WriteBack_All (ROM 0x4fc10a60)
```

A dirty L1 data-cache line carries a bogus tag (`0x3ff10000` is unmapped on P4), and the ROM dutifully writes it back to invalid memory and panics.

The previous mitigation (holding `spi_flash_op_lock()` before `esp_restart()`) was **disproven on hardware**: the lock is demonstrably held (`"Flash writers quiesced"` logs before the panic) yet the write-back still faults — the faulting cache line is not associated with a flash op.

## Fix

We don't need any dirty PSRAM data to survive a reboot, so instead of asking the ROM to write the cache back, skip that step entirely. In `system_safe_restart()`, after quiescing flash writers:

1. `vTaskSuspendAll()` + `portDISABLE_INTERRUPTS()` — nothing runs (and no new flash/cache access can start) between here and the reset.
2. `esp_rom_software_reset_system()` — full HP-digital-domain reset in hardware (resets CPUs + peripherals incl. DMA), **no cache maintenance, no core-stall dance**, so the faulting ROM write-back never runs.

The `spi_flash_op_lock()` is kept (never released) purely to guarantee no flash program/erase is in flight when the hard reset fires, so it can't corrupt a half-written sector.

Reset reason is a clean `RESET_REASON_CORE_SW` → `ESP_RST_SW` ("SOFTWARE"), so `boot_stats` does not misclassify the reboot as a crash and the crash gate stays green.

## Validation (hardware-in-the-loop)

Built the test-enabled variant, USB-flashed the CI controller, and ran the event-log-write + reboot repro loop that reliably triggers the crash on `main`:

- **60 / 60 reboot cycles clean** (baseline ~5%/cycle would give ~3 crashes).
- **0** `Guru Meditation` / `Cache_WriteBack` / `Store access fault` strings in the serial log.
- Every reboot logs `RESET REASON: SOFTWARE (3)`.

## Notes

This is a latent bug on `main` (not caused by any test change); it was blocking the F-05 sleep-migration PR #192, which will be rebased onto this fix.
