### PR TITLE
F-05: migrate fixed sleeps to condition-waits in test_error_history_duration.py

### DIFF
--- a/tests/device/test_error_history_duration.py
+++ b/tests/device/test_error_history_duration.py
@@ -23,6 +23,29 @@ UI_SETTLE = 1.5  # Wait for 1s main screen timer
 DEMO_FAULT = "P02"
 ERROR_HOLD_SECONDS = 3
 
+# Duration labels render as "<label> | <sep> <n><unit>" e.g. "Duration: | 3s".
+_DURATION_RE = re.compile(r'\|\s*\S+\s+\d+[smhd]')
+
+
+def _errors_json(device: DeviceClient) -> dict:
+    """GET /api/heatpump/errors as JSON."""
+    r = device.session.get(f"{device.base_url}/api/heatpump/errors",
+                           timeout=device.timeout)
+    r.raise_for_status()
+    return r.json()
+
+
+def _active_codes(device: DeviceClient) -> list:
+    """Active error codes from /api/heatpump/errors."""
+    data = _errors_json(device)
+    active = data.get("active", data.get("errors", []))
+    return [e.get("code", "") for e in active if isinstance(e, dict)]
+
+
+def _has_duration_label(device: DeviceClient) -> bool:
+    """True once a cleared-error duration label has rendered on the panel."""
+    return any(w.text and _DURATION_RE.search(w.text) for w in device.widgets)
+
 
 @pytest.fixture(autouse=True)
 def _restore_demo_state(device: DeviceClient):
@@ -31,7 +54,6 @@ def _restore_demo_state(device: DeviceClient):
     device.clear_all_faults()
     device.inject_fault(DEMO_FAULT, True)
     device.set_demo_fields(unit_on=1)
-    time.sleep(UI_SETTLE)
 
 
 class TestErrorHistoryDuration:
@@ -41,32 +63,54 @@ class TestErrorHistoryDuration:
         """A cleared error held for ~3s should show duration like '3s' or '4s'."""
         # 1. Clear all faults and history
         device.clear_all_faults()
-        time.sleep(UI_SETTLE)
+        device.wait_until(
+            "all faults cleared",
+            lambda: not _active_codes(device),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
         device.clear_error_history()
 
         # 2. Set P02 fault
         device.inject_fault("P02", True)
-        time.sleep(UI_SETTLE)
+        device.wait_until(
+            "P02 active",
+            lambda: "P02" in _active_codes(device),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
 
-        # 3. Hold for a known duration
+        # 3. Hold for a known duration. This sleep is INTENTIONAL: the test
+        #    measures how long the fault was active, so it must stay active for
+        #    a real, known wall-clock interval. It is not a UI settle.
         time.sleep(ERROR_HOLD_SECONDS)
 
         # 4. Clear the fault — this creates a history entry
         device.inject_fault("P02", False)
-        time.sleep(UI_SETTLE)
+        device.wait_until(
+            "P02 cleared",
+            lambda: "P02" not in _active_codes(device),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
 
         # 5. Open the error panel
         device.click(tag="error_label")
-        time.sleep(1.0)  # panel animation
+        assert device.wait_for_screen("errors", timeout=5.0), \
+            f"Expected 'errors' screen, got '{device.screen}'"
 
         # 6. Find duration text in the widget tree
         #    The duration label is language-dependent (Duration:/Duración:/Durée :)
         #    but the time format is always like "3s", "5m 30s", etc.
         #    Look for labels containing a time duration pattern after a pipe separator.
+        #    The card renders asynchronously after the screen settles, so poll for
+        #    it before the authoritative assert below.
+        device.wait_until(
+            "cleared-error duration label present",
+            lambda: _has_duration_label(device),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
         widgets = device.widgets
         duration_texts = [
             w.text for w in widgets
-            if w.text and re.search(r'\|\s*\S+\s+\d+[smhd]', w.text)
+            if w.text and _DURATION_RE.search(w.text)
         ]
 
         assert len(duration_texts) > 0, \
@@ -91,7 +135,7 @@ class TestErrorHistoryDuration:
 
         # 8. Close panel
         device.click(symbol="CLOSE")
-        time.sleep(0.5)
+        device.wait_for_screen("main", timeout=5.0, raise_on_timeout=False)
 
         # 9. Clean up error history
         device.clear_error_history()

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -12,7 +12,7 @@
   "tests/device/conftest.py": 3,
   "tests/device/device_client.py": 4,
   "tests/device/test_display_idle_settings.py": 2,
-  "tests/device/test_error_history_duration.py": 7,
+  "tests/device/test_error_history_duration.py": 1,
   "tests/device/test_error_mapping.py": 5,
   "tests/device/test_home_assistant_pairing.py": 4,
   "tests/device/test_https.py": 1,


### PR DESCRIPTION
## Summary

F-05 sleep-migration for `tests/device/test_error_history_duration.py`: replace fixed `time.sleep()` UI settles with condition-based waits so the test gates on the exact observable instead of a guessed interval.

## Changes

- **Fixture teardown:** drop the trailing `UI_SETTLE` after restoring demo state — the API calls set state synchronously and the next test resets it anyway.
- **After `clear_all_faults` / `inject_fault`:** poll `/api/heatpump/errors` active codes (all cleared → P02 active → P02 cleared) instead of `UI_SETTLE` guesses.
- **Opening the error panel:** `wait_for_screen("errors")` (gates on `settled`) plus a best-effort poll for the cleared-error duration label to render, replacing the `sleep(1.0)` "panel animation".
- **Closing the panel:** `wait_for_screen("main")` instead of `sleep(0.5)`.

## Intentional sleep kept

`time.sleep(ERROR_HOLD_SECONDS)` stays: the test **measures** how long a fault was active, so it must stay active for a real, known wall-clock interval. It is not a UI settle. Commented as such.

## Budget

`test_error_history_duration.py` 7 → 1; total 90 → 84. `tests/sleep_budget.json` regenerated; ratchet passes.

## Validation

Ran on hardware (.21): **1 passed** (9s).
