### PR TITLE
F-05: migrate test_error_mapping.py to condition-waits

### DIFF
--- a/tests/device/test_error_mapping.py
+++ b/tests/device/test_error_mapping.py
@@ -11,18 +11,13 @@ never hardcodes register bit positions — the library owns that mapping.
 Tests run with all other faults cleared so each code is isolated.
 """
 
-import time
 import pytest
 from device_client import DeviceClient
 
 # ---------------------------------------------------------------------------
 # Timing
 # ---------------------------------------------------------------------------
-UI_SETTLE = 1.5  # seconds — wait for the 1-second main screen timer
-
-
-def _wait():
-    time.sleep(UI_SETTLE)
+UI_SETTLE = 1.5  # seconds — performance budget for a main-screen settle
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +75,6 @@ def _restore_demo_faults(device: DeviceClient):
     device.clear_all_faults()
     device.inject_fault(DEMO_DEFAULT_FAULT, True)
     device.set_demo_fields(unit_on=1)
-    _wait()
 
 
 # =========================================================================
@@ -128,12 +122,25 @@ class TestFaultPanel:
         device.clear_all_faults()
         for code, _label in FAULT_DEFS:
             device.inject_fault(code, True)
-        _wait()
 
-        # Click the error card to open the errors panel
+        # The error card is repainted by a ~1s main-screen timer; wait for it to
+        # exist before clicking rather than sleeping a fixed settle.
+        device.wait_for_widget(tag="error_label", timeout=5.0,
+                               expect_within=UI_SETTLE, raise_on_timeout=False)
         device.click(tag="error_label")
-        time.sleep(1.0)  # panel animation
+        assert device.wait_for_screen("errors", timeout=5.0), \
+            f"Expected 'errors' screen, got '{device.screen}'"
 
+        # Panel cards render asynchronously after the screen settles, so poll for
+        # every code to appear before the authoritative assert below.
+        device.wait_until(
+            "all fault codes present in panel",
+            lambda: all(
+                code in " ".join(w.text or "" for w in device.widgets)
+                for code, _ in FAULT_DEFS
+            ),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
         all_text = " ".join(w.text or "" for w in device.widgets)
 
         for code, _label in FAULT_DEFS:
@@ -142,18 +149,28 @@ class TestFaultPanel:
 
         # Close panel
         device.click(symbol="CLOSE")
-        time.sleep(0.5)
+        device.wait_for_screen("main", timeout=5.0, raise_on_timeout=False)
 
     def test_all_descriptions_in_panel(self, device: DeviceClient):
         """Each fault description fragment should appear in the panel."""
         device.clear_all_faults()
         for code, _label in FAULT_DEFS:
             device.inject_fault(code, True)
-        _wait()
 
+        device.wait_for_widget(tag="error_label", timeout=5.0,
+                               expect_within=UI_SETTLE, raise_on_timeout=False)
         device.click(tag="error_label")
-        time.sleep(1.0)
+        assert device.wait_for_screen("errors", timeout=5.0), \
+            f"Expected 'errors' screen, got '{device.screen}'"
 
+        device.wait_until(
+            "all fault descriptions present in panel",
+            lambda: all(
+                label in " ".join(w.text or "" for w in device.widgets)
+                for _code, label in FAULT_DEFS
+            ),
+            timeout=5.0, expect_within=UI_SETTLE, raise_on_timeout=False,
+        )
         all_text = " ".join(w.text or "" for w in device.widgets)
 
         for code, label in FAULT_DEFS:
@@ -161,4 +178,4 @@ class TestFaultPanel:
                 f"Description '{label}' for {code} not found in panel"
 
         device.click(symbol="CLOSE")
-        time.sleep(0.5)
+        device.wait_for_screen("main", timeout=5.0, raise_on_timeout=False)

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -13,7 +13,6 @@
   "tests/device/device_client.py": 4,
   "tests/device/test_display_idle_settings.py": 2,
   "tests/device/test_error_history_duration.py": 1,
-  "tests/device/test_error_mapping.py": 5,
   "tests/device/test_home_assistant_pairing.py": 4,
   "tests/device/test_https.py": 1,
   "tests/device/test_language.py": 4,


### PR DESCRIPTION
## F-05: migrate `test_error_mapping.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces all 5 fixed
`time.sleep()` delays in `test_error_mapping.py` with deterministic
condition-waits.

### Changes
- Removed the `_wait()` helper and unused `import time`.
- Dropped the fixture teardown settle (API calls are synchronous; the next test resets state).
- Both panel tests now gate on `wait_for_screen("errors")`, `wait_until(all codes/labels present)` and `wait_for_screen("main")` on close.
- File reaches **0 sleeps** and is dropped from `sleep_budget.json` (total **84 -> 79**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_error_mapping.py`: **33 passed** on dev device `.21`.
