### PR TITLE
F-05: migrate test_temperature_unit.py to condition-waits

### DIFF
--- a/tests/device/test_temperature_unit.py
+++ b/tests/device/test_temperature_unit.py
@@ -6,7 +6,6 @@ menu changes between Celsius and Fahrenheit, confirmed by the
 preferences API.
 """
 
-import time
 from device_client import DeviceClient
 
 
@@ -19,16 +18,20 @@ def test_toggle_temp_unit(device: DeviceClient):
     # Open settings
     device.click(tag="settings")
     assert device.wait_for_screen("settings", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag="temp_unit_switch", timeout=5.0)
 
     # Toggle the switch
+    expected = "fahrenheit" if initial_unit == "celsius" else "celsius"
     result = device.toggle("temp_unit_switch")
     assert result["success"] is True
-    time.sleep(0.3)
+    device.wait_until(
+        f"temp_unit preference is {expected}",
+        lambda: device.get_preferences().get("temp_unit") == expected,
+        timeout=5.0,
+    )
 
     # Verify via preferences API
     prefs = device.get_preferences()
-    expected = "fahrenheit" if initial_unit == "celsius" else "celsius"
     assert prefs["temp_unit"] == expected, \
         f"Expected temp_unit='{expected}', got '{prefs['temp_unit']}'"
 
@@ -47,11 +50,15 @@ def test_restore_temp_unit(device: DeviceClient):
         # Open settings and toggle back
         device.click(tag="settings")
         assert device.wait_for_screen("settings", timeout=5.0)
-        time.sleep(0.5)
+        assert device.wait_for_widget(tag="temp_unit_switch", timeout=5.0)
 
         result = device.toggle("temp_unit_switch")
         assert result["success"] is True
-        time.sleep(0.3)
+        device.wait_until(
+            "temp_unit preference is celsius",
+            lambda: device.get_preferences().get("temp_unit") == "celsius",
+            timeout=5.0,
+        )
 
     prefs = device.get_preferences()
     assert prefs["temp_unit"] == "celsius", \

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -21,7 +21,6 @@
   "tests/device/test_security_screen.py": 1,
   "tests/device/test_settings_menu.py": 3,
   "tests/device/test_temperature_history_screen.py": 2,
-  "tests/device/test_temperature_unit.py": 4,
   "tests/device/test_web_screen.py": 2,
   "tests/web/conftest.py": 5,
   "tests/web/test_change_password.py": 2,


### PR DESCRIPTION
## F-05: migrate `test_temperature_unit.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces all 4 fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- The 0.5s settle after opening settings is replaced by waiting on the `temp_unit_switch` widget.
- The 0.3s sleep after toggling is replaced by waiting until the API preference reports the expected `temp_unit` (`wait_until` on `get_preferences`). The switch toggle has no screen transition, so the preference is the real observable.
- Removed unused `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **71 -> 67**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_temperature_unit.py`: **2 passed** on dev device `.21`.
