### PR TITLE
F-05: migrate test_navigation.py to condition-waits

### DIFF
--- a/tests/device/test_navigation.py
+++ b/tests/device/test_navigation.py
@@ -5,7 +5,6 @@ Verifies that each settings menu row navigates to its sub-screen
 and the back button returns to the settings menu.
 """
 
-import time
 import pytest
 from device_client import DeviceClient
 
@@ -33,7 +32,7 @@ def test_open_sub_screen(device: DeviceClient, row_tag, screen_name, back_tag):
     device.click(tag="settings")
     assert device.wait_for_screen("settings", timeout=5.0), \
         f"Settings did not open — on '{device.screen}'"
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag=row_tag, timeout=5.0)
 
     device.click(tag=row_tag)
     assert device.wait_for_screen(screen_name, timeout=5.0), \
@@ -46,11 +45,11 @@ def test_back_from_sub_screen(device: DeviceClient, row_tag, screen_name, back_t
     """Pressing back from a sub-screen should return to the settings menu."""
     device.click(tag="settings")
     assert device.wait_for_screen("settings", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag=row_tag, timeout=5.0)
 
     device.click(tag=row_tag)
     assert device.wait_for_screen(screen_name, timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag=back_tag, timeout=5.0)
 
     device.click(tag=back_tag)
     assert device.wait_for_screen("settings", timeout=5.0), \

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -16,7 +16,6 @@
   "tests/device/test_https.py": 1,
   "tests/device/test_localization.py": 1,
   "tests/device/test_main_screen.py": 1,
-  "tests/device/test_navigation.py": 3,
   "tests/device/test_screenshot_api.py": 1,
   "tests/device/test_security_screen.py": 1,
   "tests/device/test_settings_menu.py": 3,


### PR DESCRIPTION
## F-05: migrate `test_navigation.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces all 3 fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- Each 0.5s settle sat right after a `wait_for_screen()` (which already gates on the screen being settled) and before a click on a widget of the just-loaded screen. Each is replaced by waiting on that click target widget (`wait_for_widget` on the settings row, then the sub-screen back button).
- Removed unused `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **67 -> 64**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_navigation.py`: **16 passed** on dev device `.21`.
