### PR TITLE
F-05: migrate test_settings_menu.py to condition-waits

### DIFF
--- a/tests/device/test_settings_menu.py
+++ b/tests/device/test_settings_menu.py
@@ -5,8 +5,6 @@ Verifies that pressing the settings button opens the settings menu
 and that the settings screen contains the expected UI elements.
 """
 
-import time
-
 from device_client import DeviceClient
 
 
@@ -25,8 +23,7 @@ def test_open_settings_menu(device: DeviceClient):
 
 def test_settings_menu_has_close_button(device: DeviceClient):
     """The settings screen should have a close (X) button."""
-    import time
-    time.sleep(0.5)  # Give device time to settle
+    assert device.wait_for_widget(tag="settings", timeout=5.0)
 
     device.click(tag="settings")
     assert device.wait_for_screen("settings", timeout=5.0), \
@@ -60,7 +57,7 @@ def test_factory_reset_requires_confirmation_and_can_be_cancelled(
     assert device.wait_for_screen("settings", timeout=3.0)
 
     device.click(tag="settings_factory_reset")
-    time.sleep(0.4)
+    assert device.wait_for_widget(tag="factory_reset_overlay", timeout=5.0)
 
     assert device.has_widget(tag="factory_reset_overlay")
     assert device.has_widget(tag="factory_reset_panel")
@@ -68,6 +65,10 @@ def test_factory_reset_requires_confirmation_and_can_be_cancelled(
     assert device.has_widget(tag="factory_reset_cancel")
 
     device.click(tag="factory_reset_cancel")
-    time.sleep(0.3)
+    device.wait_until(
+        "factory reset overlay dismissed",
+        lambda: not device.has_widget(tag="factory_reset_overlay"),
+        timeout=5.0,
+    )
     assert not device.has_widget(tag="factory_reset_overlay")
     assert device.screen == "settings"

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -18,7 +18,6 @@
   "tests/device/test_main_screen.py": 1,
   "tests/device/test_screenshot_api.py": 1,
   "tests/device/test_security_screen.py": 1,
-  "tests/device/test_settings_menu.py": 3,
   "tests/device/test_temperature_history_screen.py": 2,
   "tests/device/test_web_screen.py": 2,
   "tests/web/conftest.py": 5,


### PR DESCRIPTION
## F-05: migrate `test_settings_menu.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces all 3 fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- The "give device time to settle" sleep before opening settings is replaced by waiting on the `settings` button widget.
- The factory-reset test waits on the `factory_reset_overlay` widget appearing (after the reset tap) and being dismissed (after cancel) instead of fixed 0.4s / 0.3s sleeps. The overlay is a modal with no screen transition, so its presence is the real observable.
- Removed the top-level and a stray local `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **64 -> 61**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_settings_menu.py`: **4 passed** on dev device `.21`.
