### PR TITLE
F-05: migrate test_display_idle_settings.py to condition-waits

### DIFF
--- a/tests/device/test_display_idle_settings.py
+++ b/tests/device/test_display_idle_settings.py
@@ -1,5 +1,3 @@
-import time
-
 from device_client import DeviceClient
 
 
@@ -8,7 +6,7 @@ def _open_display(device: DeviceClient):
     assert device.wait_for_screen("settings", timeout=5.0)
     device.click(tag="settings_display")
     assert device.wait_for_screen("display", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag="display_dim_timeout", timeout=5.0)
 
 
 def test_configure_staged_display_timeouts(device: DeviceClient):
@@ -54,7 +52,17 @@ def test_off_timeout_runs_when_dimming_is_never(device: DeviceClient):
     device.click(tag="settings_close")
     assert device.wait_for_screen("main", timeout=5.0)
 
-    time.sleep(65)
+    # The off timeout is set to 1 minute with dimming Never, so the screen
+    # turns off after ~60s of inactivity. Poll the idle status (the "status"
+    # action does not register activity, so it will not reset the timer)
+    # until the off timeout fires, instead of a fixed sleep that could flake
+    # on timing jitter.
+    device.wait_until(
+        "display off timeout fires after ~1 minute idle",
+        lambda: device.set_display_idle("status").get("off") is True,
+        timeout=90.0,
+        poll=3.0,
+    )
     status = device.set_display_idle("status")
     assert status["dimmed"] is False
     assert status["off"] is True

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -11,7 +11,6 @@
   "tests/api/test_session_api.py": 3,
   "tests/device/conftest.py": 3,
   "tests/device/device_client.py": 4,
-  "tests/device/test_display_idle_settings.py": 2,
   "tests/device/test_error_history_duration.py": 1,
   "tests/device/test_https.py": 1,
   "tests/device/test_localization.py": 1,


### PR DESCRIPTION
## F-05: migrate `test_display_idle_settings.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces both fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- The 0.5s settle in `_open_display` (after `wait_for_screen("display")`) is replaced by waiting on the `display_dim_timeout` roller widget.
- The fixed `time.sleep(65)` that waited for the screen-off timeout to fire is replaced by a `wait_until` that polls the idle status until `off` is True (timeout 90s, poll 3s).
  - **Verified safe against firmware:** the `/api/test/display-idle` `status` action does **not** call `display_idle_handle_activity()` (only the `wake` action does), so polling never resets the idle timer. This is strictly more robust than a fixed 65s sleep, which could flake on timing jitter around the 60s boundary.
- Removed `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **61 -> 59**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_display_idle_settings.py`: **3 passed** on dev device `.21` (75.9s; off timeout fired at ~60s).
