### PR TITLE
F-05: migrate test_temperature_history_screen.py to condition-waits

### DIFF
--- a/tests/device/test_temperature_history_screen.py
+++ b/tests/device/test_temperature_history_screen.py
@@ -1,7 +1,5 @@
 """Device tests for the eight-hour temperature history graph."""
 
-import time
-
 from device_client import DeviceClient
 
 
@@ -21,9 +19,23 @@ def test_temperature_history_page_and_navigation(device: DeviceClient):
     device.wait_for_widget(tag="temperature_history_next")
     device.wait_for_widget(tag="temperature_history_latest")
 
+    # At open the window sits at the latest 8h, so "next" is disabled. Paging
+    # back enables it, and paging forward returns to latest (disabled again).
+    # Waiting on that button state replaces fixed settles and also asserts the
+    # pagination actually took effect.
     device.click(tag="temperature_history_previous")
-    time.sleep(0.5)
+    device.wait_until(
+        "history next button enabled after paging back",
+        lambda: (w := device.find_widget(tag="temperature_history_next"))
+        is not None and not w.disabled,
+        timeout=5.0,
+    )
     device.click(tag="temperature_history_next")
-    time.sleep(0.5)
+    device.wait_until(
+        "history next button disabled back at latest window",
+        lambda: (w := device.find_widget(tag="temperature_history_next"))
+        is not None and bool(w.disabled),
+        timeout=5.0,
+    )
     device.click(tag="temperature_history_back")
     device.wait_for_widget(tag="temperature_history_open")

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -17,7 +17,6 @@
   "tests/device/test_main_screen.py": 1,
   "tests/device/test_screenshot_api.py": 1,
   "tests/device/test_security_screen.py": 1,
-  "tests/device/test_temperature_history_screen.py": 2,
   "tests/device/test_web_screen.py": 2,
   "tests/web/conftest.py": 5,
   "tests/web/test_change_password.py": 2,


### PR DESCRIPTION
## F-05: migrate `test_temperature_history_screen.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces both fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- The two 0.5s settles sat between history pagination clicks (previous/next). Pagination triggers an async window query with no screen transition, so the sleeps masked the reload.
- They are replaced by waiting on the `temperature_history_next` button's `disabled` state: at open the window sits at the latest 8h so `next` is disabled; paging back enables it; paging forward returns to latest and disables it again.
- This is strictly more robust than fixed sleeps **and** asserts the pagination actually took effect (the original asserted nothing about the intermediate pages).
- Removed `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **59 -> 57**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_temperature_history_screen.py`: **1 passed** on dev device `.21`.
