### PR TITLE
F-05: migrate test_web_screen.py to condition-waits

### DIFF
--- a/tests/device/test_web_screen.py
+++ b/tests/device/test_web_screen.py
@@ -1,17 +1,15 @@
 """Physical Web Interface settings-screen tests (QR code + dashboard URL)."""
 
-import time
-
 from device_client import DeviceClient
 
 
 def _open_web_screen(device: DeviceClient) -> None:
     device.click(tag="settings")
     assert device.wait_for_screen("settings", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag="settings_web", timeout=5.0)
     device.click(tag="settings_web")
     assert device.wait_for_screen("web", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag="web_url", timeout=5.0)
 
 
 def test_web_screen_shows_url(device: DeviceClient):

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -17,7 +17,6 @@
   "tests/device/test_main_screen.py": 1,
   "tests/device/test_screenshot_api.py": 1,
   "tests/device/test_security_screen.py": 1,
-  "tests/device/test_web_screen.py": 2,
   "tests/web/conftest.py": 5,
   "tests/web/test_change_password.py": 2,
   "tests/web/test_dashboard.py": 1,


### PR DESCRIPTION
## F-05: migrate `test_web_screen.py` to condition-waits

Part of the flaky-test hardening effort (#164). Replaces both fixed
`time.sleep()` delays with deterministic condition-waits.

### Changes
- Both 0.5s settles sat in `_open_web_screen` right after a `wait_for_screen()` (which already gates on the screen being settled) and before a click / widget lookup. They are replaced by waiting on the next target widget (`settings_web` row, then `web_url` on the web screen).
- Removed `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **57 -> 55**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_web_screen.py`: **3 passed** on dev device `.21`.
