### PR TITLE
F-05: migrate test_security_screen.py to a condition-wait

### DIFF
--- a/tests/device/test_security_screen.py
+++ b/tests/device/test_security_screen.py
@@ -1,7 +1,6 @@
 """Physical Security-screen tests (Home-Assistant-independent securing)."""
 
 import re
-import time
 
 from device_client import DeviceClient
 
@@ -11,7 +10,7 @@ def _open_security_screen(device: DeviceClient) -> None:
     assert device.wait_for_screen("settings", timeout=5.0)
     device.click(tag="settings_security")
     assert device.wait_for_screen("security", timeout=5.0)
-    time.sleep(0.5)
+    assert device.wait_for_widget(tag="security_status", timeout=5.0)
 
 
 def test_security_screen_shows_status_without_home_assistant(

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -16,7 +16,6 @@
   "tests/device/test_localization.py": 1,
   "tests/device/test_main_screen.py": 1,
   "tests/device/test_screenshot_api.py": 1,
-  "tests/device/test_security_screen.py": 1,
   "tests/web/conftest.py": 5,
   "tests/web/test_change_password.py": 2,
   "tests/web/test_dashboard.py": 1,


### PR DESCRIPTION
## F-05: migrate `test_security_screen.py` to a condition-wait

Part of the flaky-test hardening effort (#164). Replaces the fixed
`time.sleep(0.5)` in `_open_security_screen` with a `wait_for_widget` on
the `security_status` label.

### Changes
- The settle sat right after `wait_for_screen("security")` (which already gates on the screen being settled) and before the tests inspect the security-screen widgets. Waiting on the always-present status label is the deterministic equivalent.
- Removed `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **55 -> 54**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_security_screen.py`: **3 passed** on dev device `.21`.
