### PR TITLE
F-05: migrate test_localization.py to a condition-wait

### DIFF
--- a/tests/device/test_localization.py
+++ b/tests/device/test_localization.py
@@ -10,7 +10,6 @@ panel headers) are set at screen creation and do NOT refresh on language
 change. Those are excluded from this test and tracked as a known issue.
 """
 
-import time
 import pytest
 from device_client import DeviceClient
 
@@ -155,10 +154,14 @@ def _switch_language(device: DeviceClient, lang_name: str):
     assert device.wait_for_screen("language", timeout=5.0)
 
     device.click(tag=LANG_TAGS[lang_name])
-    # No screen transition here, so there is no settled-screen signal to wait
-    # on; give the language-change preference a beat to apply before we
-    # navigate away and re-render the (now translated) screens.
-    time.sleep(0.3)
+    # No screen transition here, so wait on the real observable: the API
+    # preference reflecting the newly selected language, before we navigate
+    # away and re-render the (now translated) screens.
+    device.wait_until(
+        f"language preference is {lang_name}",
+        lambda: device.get_preferences().get("language") == lang_name,
+        timeout=5.0,
+    )
 
     # Navigate back: language → settings → main
     device.click(tag="language_back")

--- a/tests/device/test_localization.py
+++ b/tests/device/test_localization.py
@@ -170,6 +170,20 @@ def _switch_language(device: DeviceClient, lang_name: str):
     device.click(tag="settings_close")
     assert device.wait_for_screen("main", timeout=5.0)
 
+    # wait_for_screen only gates on the screen being *settled* — the main
+    # screen's translated labels (tank description, footer nav) are refreshed
+    # separately on the ~1s state timer, so they can lag the settle. Gate on
+    # the tank description actually showing the target language before
+    # returning, so callers never race the re-render. Best-effort (never
+    # raises): each test's own assert still makes the authoritative check with
+    # a clear message if a label genuinely fails to translate.
+    device.wait_until(
+        f"main screen tank description in {lang_name}",
+        lambda: device.has_widget(text=TANK_DESCRIPTION[lang_name]),
+        timeout=5.0,
+        raise_on_timeout=False,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/sleep_budget.json
+++ b/tests/sleep_budget.json
@@ -13,7 +13,6 @@
   "tests/device/device_client.py": 4,
   "tests/device/test_error_history_duration.py": 1,
   "tests/device/test_https.py": 1,
-  "tests/device/test_localization.py": 1,
   "tests/device/test_main_screen.py": 1,
   "tests/device/test_screenshot_api.py": 1,
   "tests/web/conftest.py": 5,


### PR DESCRIPTION
## F-05: migrate `test_localization.py` to a condition-wait

Part of the flaky-test hardening effort (#164). An earlier PR (#190) migrated
most of this file; this removes the one remaining fixed `time.sleep(0.3)` in
`_switch_language`.

### Changes
- The language-button click has no screen transition, so the sleep masked the preference-apply latency. Waiting until `get_preferences()` reports the selected language is the deterministic observable (same pattern already used in `test_language.py`).
- Removed `import time`. File reaches **0 sleeps**, dropped from `sleep_budget.json` (total **54 -> 53**).

### Validation
- `python tests/api/test_sleep_budget.py` ratchet: green.
- `python -m pytest tests/device/test_localization.py`: **18 passed** on dev device `.21`.
