### PR TITLE
fix(ci): apply ESP-IDF read_otadata race-condition patch during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
       - 'lv_conf.h'
       - 'repos.json'
       - 'fetch_repos.py'
+      - 'patches/**'
       - '.github/workflows/build.yml'
   pull_request:
     branches:
@@ -30,6 +31,7 @@ on:
       - 'lv_conf.h'
       - 'repos.json'
       - 'fetch_repos.py'
+      - 'patches/**'
       - '.github/workflows/build.yml'
   workflow_dispatch:
     inputs:
@@ -89,6 +91,10 @@ jobs:
           esp_idf_version: v5.5.2
           target: ${{ env.TARGET }}
           path: '.'
+          # Applies patches/esp-idf-5.5.2-read_otadata-race-fix.patch (see
+          # patches/README.md, issue #210) before building, then builds
+          # normally.
+          command: bash -c "patch -p1 -d \"$IDF_PATH\" < patches/esp-idf-5.5.2-read_otadata-race-fix.patch && idf.py build"
 
       - name: Verify OTA rollback protection is enabled
         # P0 tripwire: assert the EFFECTIVE compiled config (not what
@@ -168,6 +174,8 @@ jobs:
           esp_idf_version: v5.5.2
           target: ${{ env.TARGET }}
           path: '.'
+          # See patches/README.md (issue #210).
+          command: bash -c "patch -p1 -d \"$IDF_PATH\" < patches/esp-idf-5.5.2-read_otadata-race-fix.patch && idf.py build"
 
       - name: Verify demo mode is compiled out
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -163,6 +163,9 @@ jobs:
           esp_idf_version: v5.5.2
           target: esp32p4
           path: '.'
+          # Applies patches/esp-idf-5.5.2-read_otadata-race-fix.patch (see
+          # patches/README.md, issue #210) before building.
+          command: bash -c "patch -p1 -d \"$IDF_PATH\" < patches/esp-idf-5.5.2-read_otadata-race-fix.patch && idf.py build"
 
       - name: Record production firmware provenance
         env:

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -20,6 +20,7 @@ on:
       - 'fetch_repos.py'
       - 'tests/**'
       - '!tests/**/*.md'
+      - 'patches/**'
       - '.github/workflows/device-tests.yml'
   push:
     # Authoritative post-merge validation of the exact main commit SHA. The
@@ -152,6 +153,9 @@ jobs:
           esp_idf_version: v5.5.2
           target: esp32p4
           path: '.'
+          # Applies patches/esp-idf-5.5.2-read_otadata-race-fix.patch (see
+          # patches/README.md, issue #210) before building.
+          command: bash -c "patch -p1 -d \"$IDF_PATH\" < patches/esp-idf-5.5.2-read_otadata-race-fix.patch && idf.py build"
 
       - name: Verify test instrumentation was compiled
         run: grep -q '^#define CONFIG_TEST_ENDPOINTS 1$' build/config/sdkconfig.h

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,42 @@
+# ESP-IDF patches
+
+Patches applied to the vendored ESP-IDF toolchain (`v5.5.2`) inside the
+`espressif/esp-idf-ci-action` Docker container before building. Applied via
+the action's `command:` override — see `.github/workflows/build.yml`,
+`create-release.yml`, and `device-tests.yml` for the exact invocation.
+
+## esp-idf-5.5.2-read_otadata-race-fix.patch
+
+Fixes a race condition in `components/app_update/esp_ota_ops.c`'s
+`read_otadata()` that causes a fatal, unrecoverable
+`HP_SYS_HP_WDT_RESET` crash on ESP32-P4 (frozen core, `PC=0x4FF00000`).
+
+**Root cause:** `read_otadata()` reads the `otadata` partition via
+`esp_partition_mmap()` + `memcpy()`. Under our build config
+(`CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y` + `CONFIG_SPIRAM_RODATA=y`, i.e.
+XIP-from-PSRAM), ESP-IDF's `spi_flash_os_func_app.c` sets
+`SPI_FLASH_CACHE_NO_DISABLE`, which replaces the legacy cross-core
+cache-disable/freeze-other-CPU guard with a plain mutex
+(`s_spi1_flash_mutex`) around physical flash operations. `esp_partition_mmap()`
++ `memcpy()` never takes that mutex, so a concurrent flash erase/write on the
+other core (in our case, `log_persist_task`'s debug-log flush, triggered by a
+WARN-level log) can be read mid-operation — corrupted/torn data, or in the
+worst case a fault while the flash chip is mid-erase and the mmap'd region is
+being fetched as an instruction/data access, producing the WDT-frozen crash.
+
+Confirmed via live JTAG on real hardware, and via ESP-IDF source inspection
+(`spi_flash_os_func_app.c`'s `SPI_FLASH_CACHE_NO_DISABLE` macro). Validated by
+replacing the mmap+memcpy read with two `esp_partition_read()` calls (which DO
+take the mutex) — 35-minute soak test on real hardware, zero errors across
+38,801 polls (previously reproduced the crash in ~10 minutes typical).
+
+This aligns with upstream ESP-IDF commit `789ce684`
+(`ESP_PARTITION_MMAP_BLOCKS_WRITE`), which addresses the same class of issue
+for mmap'd reads racing flash writes.
+
+Full root-cause writeup and testing history:
+https://github.com/sslivins/arctic-controller/issues/210
+
+This patch should be dropped once we upgrade to an ESP-IDF release that
+includes an equivalent upstream fix for `read_otadata()` specifically (the
+`789ce684` mechanism does not appear to cover this call site as of v5.5.2).

--- a/patches/esp-idf-5.5.2-read_otadata-race-fix.patch
+++ b/patches/esp-idf-5.5.2-read_otadata-race-fix.patch
@@ -1,0 +1,28 @@
+diff --git a/components/app_update/esp_ota_ops.c b/components/app_update/esp_ota_ops.c
+index f77d54b5..76140d6b 100644
+--- a/components/app_update/esp_ota_ops.c
++++ b/components/app_update/esp_ota_ops.c
+@@ -81,16 +81,15 @@ static const esp_partition_t *read_otadata(esp_ota_select_entry_t *two_otadata)
+         return NULL;
+     }
+ 
+-    esp_partition_mmap_handle_t ota_data_map;
+-    const void *result = NULL;
+-    esp_err_t err = esp_partition_mmap(otadata_partition, 0, otadata_partition->size, ESP_PARTITION_MMAP_DATA, &result, &ota_data_map);
++    esp_err_t err = esp_partition_read(otadata_partition, 0, &two_otadata[0], sizeof(esp_ota_select_entry_t));
+     if (err != ESP_OK) {
+-        ESP_LOGE(TAG, "mmap otadata filed. Err=0x%8x", err);
++        ESP_LOGE(TAG, "failed to read otadata[0]. Err=0x%8x", err);
++        return NULL;
++    }
++    err = esp_partition_read(otadata_partition, otadata_partition->erase_size, &two_otadata[1], sizeof(esp_ota_select_entry_t));
++    if (err != ESP_OK) {
++        ESP_LOGE(TAG, "failed to read otadata[1]. Err=0x%8x", err);
+         return NULL;
+-    } else {
+-        memcpy(&two_otadata[0], result, sizeof(esp_ota_select_entry_t));
+-        memcpy(&two_otadata[1], result + otadata_partition->erase_size, sizeof(esp_ota_select_entry_t));
+-        esp_partition_munmap(ota_data_map);
+     }
+     return otadata_partition;
+ }


### PR DESCRIPTION
Vendors and applies the ESP-IDF \ead_otadata()\ mmap+memcpy race-condition fix (root-caused and validated in #210) to all three build pipelines (\uild.yml\, \create-release.yml\, \device-tests.yml\) via \patches/esp-idf-5.5.2-read_otadata-race-fix.patch\, applied inside the \sp-idf-ci-action\ container before \idf.py build\.

See \patches/README.md\ and #210 for the full root-cause writeup and repro testing history (v1-v8).

Closes/relates to #210 (leaving open until we confirm no further crashes in production and decide on upstreaming).