### PR TITLE
refactor(ui): route remaining confirm overlays through the shared dialog

### DIFF
--- a/main/settings/settings_home_assistant_screen.cpp
+++ b/main/settings/settings_home_assistant_screen.cpp
@@ -201,6 +201,12 @@ static void revoke_cancel_cb(lv_event_t* event)
     dismiss_revoke_overlay();
 }
 
+static void revoke_overlay_deleted_cb(lv_event_t* event)
+{
+    (void)event;
+    state.revoke_overlay = NULL;
+}
+
 static void revoke_btn_cb(lv_event_t* event)
 {
     (void)event;
@@ -208,57 +214,22 @@ static void revoke_btn_cb(lv_event_t* event)
         return;
     }
 
-    state.revoke_overlay = lv_obj_create(state.screen);
-    lv_obj_set_size(state.revoke_overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(
-        state.revoke_overlay, lv_color_hex(0x000000), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(
-        state.revoke_overlay, LV_OPA_70, LV_PART_MAIN);
-    lv_obj_set_style_border_width(state.revoke_overlay, 0, LV_PART_MAIN);
-    disable_scrolling(state.revoke_overlay);
+    state.revoke_overlay = ui_dialog_create(
+        i18n_get(STR_HA_REVOKE_CONFIRM), i18n_get(STR_HA_REVOKE_DESCRIPTION));
+    if (!state.revoke_overlay) {
+        return;
+    }
+    // The dialog lives on the top layer, so it can also be torn down by the
+    // shell's lv_obj_clean(lv_layer_top()); clear our handle either way.
+    lv_obj_add_event_cb(
+        state.revoke_overlay, revoke_overlay_deleted_cb, LV_EVENT_DELETE, NULL);
 
-    lv_obj_t* panel = lv_obj_create(state.revoke_overlay);
-    lv_obj_set_size(panel, 620, 330);
-    lv_obj_center(panel);
-    lv_obj_set_style_bg_color(panel, COLOR_CARD, LV_PART_MAIN);
-    lv_obj_set_style_border_width(panel, 0, LV_PART_MAIN);
-    lv_obj_set_style_radius(panel, 16, LV_PART_MAIN);
-    lv_obj_set_style_pad_all(panel, 25, LV_PART_MAIN);
-    disable_scrolling(panel);
-
-    lv_obj_t* title = lv_label_create(panel);
-    lv_label_set_text(title, i18n_get(STR_HA_REVOKE_CONFIRM));
-    lv_obj_set_style_text_font(title, FONT_LARGE, LV_PART_MAIN);
-    lv_obj_set_style_text_color(title, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 0);
-
-    lv_obj_t* description = lv_label_create(panel);
-    lv_label_set_text(description, i18n_get(STR_HA_REVOKE_DESCRIPTION));
-    lv_obj_set_width(description, 540);
-    lv_label_set_long_mode(description, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_font(description, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(description, COLOR_TEXT_DIM, LV_PART_MAIN);
-    lv_obj_set_style_text_align(description, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-    lv_obj_align(description, LV_ALIGN_CENTER, 0, -15);
-
-    lv_obj_t* cancel = lv_btn_create(panel);
-    lv_obj_set_size(cancel, 250, 65);
-    lv_obj_align(cancel, LV_ALIGN_BOTTOM_LEFT, 0, 0);
-    lv_obj_add_event_cb(cancel, revoke_cancel_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_t* cancel_label = lv_label_create(cancel);
-    lv_label_set_text(cancel_label, i18n_get(STR_CANCEL));
-    lv_obj_set_style_text_font(cancel_label, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_center(cancel_label);
-
-    lv_obj_t* confirm = lv_btn_create(panel);
-    lv_obj_set_size(confirm, 250, 65);
-    lv_obj_align(confirm, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
-    lv_obj_set_style_bg_color(confirm, COLOR_ERROR, LV_PART_MAIN);
-    lv_obj_add_event_cb(confirm, revoke_confirm_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_t* confirm_label = lv_label_create(confirm);
-    lv_label_set_text(confirm_label, i18n_get(STR_HA_REVOKE_ACTION));
-    lv_obj_set_style_text_font(confirm_label, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_center(confirm_label);
+    ui_dialog_add_action(state.revoke_overlay, i18n_get(STR_CANCEL),
+                         "ha_revoke_cancel", UI_DIALOG_ACTION_SECONDARY,
+                         revoke_cancel_cb);
+    ui_dialog_add_action(state.revoke_overlay, i18n_get(STR_HA_REVOKE_ACTION),
+                         "ha_revoke_confirm", UI_DIALOG_ACTION_DANGER,
+                         revoke_confirm_cb);
 }
 
 void home_assistant_screen_create(
@@ -427,6 +398,9 @@ void home_assistant_screen_close(void)
     if (state.pairing_started) {
         setup_pairing_cancel();
     }
+    // The confirm dialog lives on the top layer, so it would outlive this
+    // screen unless it is dismissed explicitly.
+    dismiss_revoke_overlay();
     mbedtls_platform_zeroize(
         state.pairing_code, sizeof(state.pairing_code));
     state.visible = false;

--- a/main/settings/settings_menu.cpp
+++ b/main/settings/settings_menu.cpp
@@ -280,94 +280,17 @@ static void show_reboot_confirmation(void)
     // Clean up previous overlay if any
     dismiss_reboot_overlay();
 
-    // --- Semi-transparent overlay covering the entire screen ---
-    lv_obj_t* overlay = lv_obj_create(state.screen);
-    lv_obj_remove_style_all(overlay);
-    lv_obj_set_size(overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(overlay, lv_color_hex(0x000000), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(overlay, LV_OPA_50, LV_PART_MAIN);
-    lv_obj_add_flag(overlay, LV_OBJ_FLAG_CLICKABLE);   // absorb taps
-    lv_obj_remove_flag(overlay, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_user_data(overlay, (void*)"reboot_overlay");
-    state.reboot_overlay = overlay;
+    state.reboot_overlay = ui_dialog_create_ex(
+        i18n_get(STR_DEMO_MODE_CHANGED), i18n_get(STR_RESTART_REQUIRED),
+        UI_DIALOG_LAYOUT_SHEET, "reboot_overlay", "reboot_panel");
+    if (!state.reboot_overlay) return;
 
-    // --- Bottom panel ---
-    lv_obj_t* panel = lv_obj_create(overlay);
-    lv_obj_remove_style_all(panel);
-    lv_obj_set_size(panel, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_color(panel, COLOR_CARD, LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, LV_PART_MAIN);
-    lv_obj_set_style_radius(panel, 24, LV_PART_MAIN);
-    lv_obj_set_style_pad_all(panel, 32, LV_PART_MAIN);
-    lv_obj_set_style_pad_bottom(panel, 48, LV_PART_MAIN);
-    lv_obj_remove_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_row(panel, 12, LV_PART_MAIN);
-    lv_obj_set_user_data(panel, (void*)"reboot_panel");
-
-    // "Demo mode changed."
-    lv_obj_t* line1 = lv_label_create(panel);
-    lv_label_set_text(line1, i18n_get(STR_DEMO_MODE_CHANGED));
-    lv_obj_set_style_text_font(line1, FONT_LARGE, LV_PART_MAIN);
-    lv_obj_set_style_text_color(line1, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_set_style_text_align(line1, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-
-    // "Restart required to take effect."
-    lv_obj_t* line2 = lv_label_create(panel);
-    lv_label_set_text(line2, i18n_get(STR_RESTART_REQUIRED));
-    lv_obj_set_style_text_font(line2, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(line2, COLOR_TEXT_DIM, LV_PART_MAIN);
-    lv_obj_set_style_text_align(line2, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-
-    // Button row
-    lv_obj_t* btn_row = lv_obj_create(panel);
-    lv_obj_remove_style_all(btn_row);
-    lv_obj_set_size(btn_row, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_flex_flow(btn_row, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(btn_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_column(btn_row, 24, LV_PART_MAIN);
-    lv_obj_set_style_pad_top(btn_row, 12, LV_PART_MAIN);
-    lv_obj_remove_flag(btn_row, LV_OBJ_FLAG_SCROLLABLE);
-
-    // Cancel button
-    lv_obj_t* cancel_btn = lv_button_create(btn_row);
-    lv_obj_set_size(cancel_btn, 200, 64);
-    lv_obj_set_style_bg_color(cancel_btn, COLOR_ROW, LV_PART_MAIN);
-    lv_obj_set_style_radius(cancel_btn, 12, LV_PART_MAIN);
-    lv_obj_set_user_data(cancel_btn, (void*)"reboot_cancel");
-    lv_obj_add_event_cb(cancel_btn, reboot_cancel_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_t* cancel_lbl = lv_label_create(cancel_btn);
-    lv_label_set_text(cancel_lbl, i18n_get(STR_CANCEL));
-    lv_obj_set_style_text_font(cancel_lbl, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(cancel_lbl, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_center(cancel_lbl);
-
-    // Restart button
-    lv_obj_t* restart_btn = lv_button_create(btn_row);
-    lv_obj_set_size(restart_btn, 200, 64);
-    lv_obj_set_style_bg_color(restart_btn, COLOR_ACCENT, LV_PART_MAIN);
-    lv_obj_set_style_radius(restart_btn, 12, LV_PART_MAIN);
-    lv_obj_set_user_data(restart_btn, (void*)"reboot_confirm");
-    lv_obj_add_event_cb(restart_btn, reboot_confirm_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_t* restart_lbl = lv_label_create(restart_btn);
-    lv_label_set_text(restart_lbl, i18n_get(STR_RESTART));
-    lv_obj_set_style_text_font(restart_lbl, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(restart_lbl, lv_color_hex(0x000000), LV_PART_MAIN);
-    lv_obj_center(restart_lbl);
-
-    // Position panel at the bottom and animate it sliding up
-    lv_obj_align(panel, LV_ALIGN_BOTTOM_MID, 0, 300);  // start off-screen
-    lv_anim_t anim;
-    lv_anim_init(&anim);
-    lv_anim_set_var(&anim, panel);
-    lv_anim_set_values(&anim, 300, 0);
-    lv_anim_set_duration(&anim, 300);
-    lv_anim_set_path_cb(&anim, lv_anim_path_ease_out);
-    lv_anim_set_exec_cb(&anim, [](void* obj, int32_t v) {
-        lv_obj_align((lv_obj_t*)obj, LV_ALIGN_BOTTOM_MID, 0, v);
-    });
-    lv_anim_start(&anim);
+    ui_dialog_add_action(state.reboot_overlay, i18n_get(STR_CANCEL),
+                         "reboot_cancel", UI_DIALOG_ACTION_SECONDARY,
+                         reboot_cancel_cb);
+    ui_dialog_add_action(state.reboot_overlay, i18n_get(STR_RESTART),
+                         "reboot_confirm", UI_DIALOG_ACTION_PRIMARY,
+                         reboot_confirm_cb);
 }
 
 static void temp_unit_switch_cb(lv_event_t* e)
@@ -528,99 +451,26 @@ static void show_factory_reset_confirmation(void)
     if (!state.screen) return;
     dismiss_factory_reset_overlay();
 
-    lv_obj_t* overlay = lv_obj_create(state.screen);
-    lv_obj_remove_style_all(overlay);
-    lv_obj_set_size(overlay, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(overlay, lv_color_hex(0x000000), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(overlay, LV_OPA_70, LV_PART_MAIN);
-    lv_obj_add_flag(overlay, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_remove_flag(overlay, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_user_data(overlay, (void*)"factory_reset_overlay");
-    state.factory_reset_overlay = overlay;
+    state.factory_reset_overlay = ui_dialog_create_ex(
+        i18n_get(STR_FACTORY_RESET_TITLE),
+        i18n_get(STR_FACTORY_RESET_DESCRIPTION),
+        UI_DIALOG_LAYOUT_SHEET, "factory_reset_overlay", "factory_reset_panel");
+    if (!state.factory_reset_overlay) return;
 
-    lv_obj_t* panel = lv_obj_create(overlay);
-    lv_obj_remove_style_all(panel);
-    lv_obj_set_size(panel, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_color(panel, COLOR_CARD, LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, LV_PART_MAIN);
-    lv_obj_set_style_radius(panel, 24, LV_PART_MAIN);
-    lv_obj_set_style_pad_all(panel, 32, LV_PART_MAIN);
-    lv_obj_set_style_pad_bottom(panel, 48, LV_PART_MAIN);
-    lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-                          LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_row(panel, 14, LV_PART_MAIN);
-    lv_obj_remove_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_user_data(panel, (void*)"factory_reset_panel");
+    ui_dialog_set_title_color(state.factory_reset_overlay, lv_color_hex(0xff5a5f));
+    ui_dialog_add_text(state.factory_reset_overlay,
+                       i18n_get(STR_FACTORY_RESET_WARNING));
 
-    lv_obj_t* title = lv_label_create(panel);
-    lv_label_set_text(title, i18n_get(STR_FACTORY_RESET_TITLE));
-    lv_obj_set_style_text_font(title, FONT_LARGE, LV_PART_MAIN);
-    lv_obj_set_style_text_color(title, lv_color_hex(0xff5a5f), LV_PART_MAIN);
-    lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-
-    lv_obj_t* description = lv_label_create(panel);
-    lv_obj_set_width(description, LV_PCT(100));
-    lv_label_set_long_mode(description, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(description, i18n_get(STR_FACTORY_RESET_DESCRIPTION));
-    lv_obj_set_style_text_font(description, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(description, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_set_style_text_align(description, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-
-    lv_obj_t* warning = lv_label_create(panel);
-    lv_label_set_text(warning, i18n_get(STR_FACTORY_RESET_WARNING));
-    lv_obj_set_style_text_font(warning, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(warning, COLOR_TEXT_DIM, LV_PART_MAIN);
-    lv_obj_set_style_text_align(warning, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
-
-    lv_obj_t* btn_row = lv_obj_create(panel);
-    lv_obj_remove_style_all(btn_row);
-    lv_obj_set_size(btn_row, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_flex_flow(btn_row, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(btn_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-                          LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_column(btn_row, 24, LV_PART_MAIN);
-    lv_obj_set_style_pad_top(btn_row, 12, LV_PART_MAIN);
-    lv_obj_remove_flag(btn_row, LV_OBJ_FLAG_SCROLLABLE);
-
-    lv_obj_t* cancel_btn = lv_button_create(btn_row);
-    lv_obj_set_size(cancel_btn, 200, 64);
-    lv_obj_set_style_bg_color(cancel_btn, COLOR_ROW, LV_PART_MAIN);
-    lv_obj_set_style_radius(cancel_btn, 12, LV_PART_MAIN);
-    lv_obj_set_user_data(cancel_btn, (void*)"factory_reset_cancel");
-    lv_obj_add_event_cb(cancel_btn, factory_reset_cancel_cb, LV_EVENT_CLICKED, NULL);
-    lv_obj_t* cancel_label = lv_label_create(cancel_btn);
-    lv_label_set_text(cancel_label, i18n_get(STR_CANCEL));
-    lv_obj_set_style_text_font(cancel_label, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(cancel_label, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_center(cancel_label);
-
-    lv_obj_t* confirm_btn = lv_button_create(btn_row);
-    lv_obj_set_size(confirm_btn, 260, 64);
-    lv_obj_set_style_bg_color(confirm_btn, lv_color_hex(0xd32f2f), LV_PART_MAIN);
-    lv_obj_set_style_radius(confirm_btn, 12, LV_PART_MAIN);
-    lv_obj_set_user_data(confirm_btn, (void*)"factory_reset_confirm");
-    lv_obj_add_event_cb(confirm_btn, factory_reset_confirm_cb, LV_EVENT_CLICKED, NULL);
+    ui_dialog_add_action(state.factory_reset_overlay, i18n_get(STR_CANCEL),
+                         "factory_reset_cancel", UI_DIALOG_ACTION_SECONDARY,
+                         factory_reset_cancel_cb);
+    lv_obj_t* confirm_btn = ui_dialog_add_action(
+        state.factory_reset_overlay, i18n_get(STR_FACTORY_RESET_CONFIRM),
+        "factory_reset_confirm", UI_DIALOG_ACTION_DANGER,
+        factory_reset_confirm_cb);
     state.factory_reset_confirm_btn = confirm_btn;
-
-    lv_obj_t* confirm_label = lv_label_create(confirm_btn);
-    lv_label_set_text(confirm_label, i18n_get(STR_FACTORY_RESET_CONFIRM));
-    lv_obj_set_style_text_font(confirm_label, FONT_NORMAL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(confirm_label, COLOR_TEXT, LV_PART_MAIN);
-    lv_obj_center(confirm_label);
-    state.factory_reset_confirm_label = confirm_label;
-
-    lv_obj_align(panel, LV_ALIGN_BOTTOM_MID, 0, 300);
-    lv_anim_t anim;
-    lv_anim_init(&anim);
-    lv_anim_set_var(&anim, panel);
-    lv_anim_set_values(&anim, 300, 0);
-    lv_anim_set_duration(&anim, 300);
-    lv_anim_set_path_cb(&anim, lv_anim_path_ease_out);
-    lv_anim_set_exec_cb(&anim, [](void* obj, int32_t v) {
-        lv_obj_align((lv_obj_t*)obj, LV_ALIGN_BOTTOM_MID, 0, v);
-    });
-    lv_anim_start(&anim);
+    state.factory_reset_confirm_label =
+        confirm_btn ? lv_obj_get_child(confirm_btn, 0) : NULL;
 }
 
 // ============================================================================
@@ -869,6 +719,11 @@ void settings_menu_force_close(lv_obj_t* return_screen)
             default: break;
         }
     }
+
+    // The confirmation dialogs live on the top layer, so deleting the settings
+    // screen no longer takes them with it.
+    dismiss_reboot_overlay();
+    dismiss_factory_reset_overlay();
 
     // A settings sub-screen leaves the settings root allocated but hidden.
     if (state.screen && state.screen != active_screen) {

--- a/main/ui_common.h
+++ b/main/ui_common.h
@@ -50,6 +50,11 @@ typedef enum {
     UI_DIALOG_ACTION_DANGER,
 } ui_dialog_action_style_t;
 
+typedef enum {
+    UI_DIALOG_LAYOUT_CENTER,  // Centred card, sized to its content
+    UI_DIALOG_LAYOUT_SHEET,   // Full-width sheet that slides up from the bottom
+} ui_dialog_layout_t;
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -61,6 +66,29 @@ typedef enum {
  * that overlay through lv_event_get_user_data().
  */
 lv_obj_t* ui_dialog_create(const char* title, const char* message);
+
+/**
+ * @brief Create a styled modal dialog, choosing its layout and test tags.
+ *
+ * @param overlay_tag Test-API tag for the overlay, or NULL for none. Must be a
+ *                    string with static storage duration.
+ * @param panel_tag   Test-API tag for the dialog panel, or NULL for none.
+ */
+lv_obj_t* ui_dialog_create_ex(const char* title,
+                              const char* message,
+                              ui_dialog_layout_t layout,
+                              const char* overlay_tag,
+                              const char* panel_tag);
+
+/**
+ * @brief Append an extra body line below the dialog message.
+ */
+lv_obj_t* ui_dialog_add_text(lv_obj_t* dialog, const char* text);
+
+/**
+ * @brief Override the dialog title colour (e.g. to flag a destructive action).
+ */
+void ui_dialog_set_title_color(lv_obj_t* dialog, lv_color_t color);
 
 /**
  * @brief Add an action button to a styled modal dialog.

--- a/main/ui_dialog.cpp
+++ b/main/ui_dialog.cpp
@@ -2,19 +2,64 @@
 
 namespace {
 
-struct DialogContext {
-    lv_obj_t* actions;
-};
+// The dialog is a fixed structure:
+//
+//   overlay (returned handle, tagged for the test API)
+//     └── panel
+//           ├── title label
+//           ├── message label
+//           ├── [extra body labels...]
+//           └── actions row (always the last child)
+//
+// Nothing is stashed in lv_obj user_data: that slot belongs to the test API's
+// widget tags, and a struct pointer parked there can be misread as a tag
+// string by the tag heuristic in test_endpoints.cpp.
 
-void dialog_delete_cb(lv_event_t* event)
+lv_obj_t* dialog_panel(lv_obj_t* dialog)
 {
-    auto* context = static_cast<DialogContext*>(lv_event_get_user_data(event));
-    lv_free(context);
+    if (!dialog || lv_obj_get_child_count(dialog) == 0) return nullptr;
+    return lv_obj_get_child(dialog, 0);
+}
+
+lv_obj_t* dialog_actions(lv_obj_t* dialog)
+{
+    lv_obj_t* panel = dialog_panel(dialog);
+    if (!panel) return nullptr;
+    uint32_t count = lv_obj_get_child_count(panel);
+    if (count == 0) return nullptr;
+    return lv_obj_get_child(panel, count - 1);
+}
+
+lv_obj_t* create_body_label(lv_obj_t* panel, const char* text)
+{
+    lv_obj_t* label = lv_label_create(panel);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+    lv_label_set_text(label, text ? text : "");
+    lv_obj_set_style_text_font(label, UI_FONT_SMALL, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, UI_COLOR_TEXT_DIM, LV_PART_MAIN);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+    return label;
+}
+
+void sheet_slide_exec_cb(void* obj, int32_t value)
+{
+    lv_obj_align(static_cast<lv_obj_t*>(obj), LV_ALIGN_BOTTOM_MID, 0, value);
 }
 
 }  // namespace
 
 extern "C" lv_obj_t* ui_dialog_create(const char* title, const char* message)
+{
+    return ui_dialog_create_ex(
+        title, message, UI_DIALOG_LAYOUT_CENTER, nullptr, nullptr);
+}
+
+extern "C" lv_obj_t* ui_dialog_create_ex(const char* title,
+                                         const char* message,
+                                         ui_dialog_layout_t layout,
+                                         const char* overlay_tag,
+                                         const char* panel_tag)
 {
     lv_obj_t* overlay = lv_obj_create(lv_layer_top());
     lv_obj_remove_style_all(overlay);
@@ -23,14 +68,12 @@ extern "C" lv_obj_t* ui_dialog_create(const char* title, const char* message)
     lv_obj_set_style_bg_opa(overlay, LV_OPA_70, LV_PART_MAIN);
     lv_obj_add_flag(overlay, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_remove_flag(overlay, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_user_data(overlay, const_cast<char*>(overlay_tag));
 
     lv_obj_t* panel = lv_obj_create(overlay);
-    lv_obj_set_width(panel, 640);
     lv_obj_set_height(panel, LV_SIZE_CONTENT);
     lv_obj_set_style_bg_color(panel, UI_COLOR_PANEL, LV_PART_MAIN);
     lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, LV_PART_MAIN);
-    lv_obj_set_style_border_width(panel, 2, LV_PART_MAIN);
-    lv_obj_set_style_border_color(panel, lv_color_hex(0x0f3460), LV_PART_MAIN);
     lv_obj_set_style_radius(panel, 24, LV_PART_MAIN);
     lv_obj_set_style_pad_all(panel, 32, LV_PART_MAIN);
     lv_obj_set_style_pad_row(panel, 20, LV_PART_MAIN);
@@ -38,23 +81,29 @@ extern "C" lv_obj_t* ui_dialog_create(const char* title, const char* message)
     lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
                           LV_FLEX_ALIGN_CENTER);
     lv_obj_remove_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_center(panel);
+    lv_obj_set_user_data(panel, const_cast<char*>(panel_tag));
+
+    if (layout == UI_DIALOG_LAYOUT_SHEET) {
+        lv_obj_set_width(panel, LV_PCT(100));
+        lv_obj_set_style_border_width(panel, 0, LV_PART_MAIN);
+        lv_obj_set_style_pad_bottom(panel, 48, LV_PART_MAIN);
+        lv_obj_align(panel, LV_ALIGN_BOTTOM_MID, 0, 300);  // start off-screen
+    } else {
+        lv_obj_set_width(panel, 640);
+        lv_obj_set_style_border_width(panel, 2, LV_PART_MAIN);
+        lv_obj_set_style_border_color(panel, lv_color_hex(0x0f3460), LV_PART_MAIN);
+        lv_obj_center(panel);
+    }
 
     lv_obj_t* title_label = lv_label_create(panel);
     lv_obj_set_width(title_label, LV_PCT(100));
     lv_label_set_long_mode(title_label, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(title_label, title);
+    lv_label_set_text(title_label, title ? title : "");
     lv_obj_set_style_text_font(title_label, UI_FONT_DIALOG_TITLE, LV_PART_MAIN);
     lv_obj_set_style_text_color(title_label, UI_COLOR_TEXT, LV_PART_MAIN);
     lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
 
-    lv_obj_t* message_label = lv_label_create(panel);
-    lv_obj_set_width(message_label, LV_PCT(100));
-    lv_label_set_long_mode(message_label, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(message_label, message);
-    lv_obj_set_style_text_font(message_label, UI_FONT_SMALL, LV_PART_MAIN);
-    lv_obj_set_style_text_color(message_label, UI_COLOR_TEXT_DIM, LV_PART_MAIN);
-    lv_obj_set_style_text_align(message_label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+    create_body_label(panel, message);
 
     lv_obj_t* actions = lv_obj_create(panel);
     lv_obj_remove_style_all(actions);
@@ -66,28 +115,48 @@ extern "C" lv_obj_t* ui_dialog_create(const char* title, const char* message)
     lv_obj_set_style_pad_top(actions, 8, LV_PART_MAIN);
     lv_obj_remove_flag(actions, LV_OBJ_FLAG_SCROLLABLE);
 
-    auto* context = static_cast<DialogContext*>(lv_malloc(sizeof(DialogContext)));
-    if (!context) {
-        lv_obj_delete(overlay);
-        return nullptr;
+    if (layout == UI_DIALOG_LAYOUT_SHEET) {
+        lv_anim_t anim;
+        lv_anim_init(&anim);
+        lv_anim_set_var(&anim, panel);
+        lv_anim_set_values(&anim, 300, 0);
+        lv_anim_set_duration(&anim, 300);
+        lv_anim_set_path_cb(&anim, lv_anim_path_ease_out);
+        lv_anim_set_exec_cb(&anim, sheet_slide_exec_cb);
+        lv_anim_start(&anim);
     }
-    context->actions = actions;
-    lv_obj_set_user_data(overlay, context);
-    lv_obj_add_event_cb(overlay, dialog_delete_cb, LV_EVENT_DELETE, context);
     return overlay;
 }
 
-extern "C" lv_obj_t* ui_dialog_add_action(lv_obj_t* dialog,
-                                            const char* label,
-                                            const char* tag,
-                                            ui_dialog_action_style_t style,
-                                            lv_event_cb_t event_cb)
+extern "C" lv_obj_t* ui_dialog_add_text(lv_obj_t* dialog, const char* text)
 {
-    if (!dialog) return nullptr;
-    auto* context = static_cast<DialogContext*>(lv_obj_get_user_data(dialog));
-    if (!context || !context->actions) return nullptr;
+    lv_obj_t* panel = dialog_panel(dialog);
+    lv_obj_t* actions = dialog_actions(dialog);
+    if (!panel || !actions) return nullptr;
 
-    lv_obj_t* button = lv_button_create(context->actions);
+    lv_obj_t* label = create_body_label(panel, text);
+    // Keep the action row last so buttons stay below every body line.
+    lv_obj_move_to_index(actions, lv_obj_get_child_count(panel) - 1);
+    return label;
+}
+
+extern "C" void ui_dialog_set_title_color(lv_obj_t* dialog, lv_color_t color)
+{
+    lv_obj_t* panel = dialog_panel(dialog);
+    if (!panel || lv_obj_get_child_count(panel) == 0) return;
+    lv_obj_set_style_text_color(lv_obj_get_child(panel, 0), color, LV_PART_MAIN);
+}
+
+extern "C" lv_obj_t* ui_dialog_add_action(lv_obj_t* dialog,
+                                          const char* label,
+                                          const char* tag,
+                                          ui_dialog_action_style_t style,
+                                          lv_event_cb_t event_cb)
+{
+    lv_obj_t* actions = dialog_actions(dialog);
+    if (!actions) return nullptr;
+
+    lv_obj_t* button = lv_button_create(actions);
     lv_obj_set_size(button, 220, 68);
     lv_obj_set_style_radius(button, 12, LV_PART_MAIN);
     lv_obj_set_style_shadow_width(button, 0, LV_PART_MAIN);

--- a/tests/api/test_ui_dialogs.py
+++ b/tests/api/test_ui_dialogs.py
@@ -7,6 +7,9 @@ unstyled default look, so assert the codebase stays free of direct msgbox use.
 
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.hostside
 
 ROOT = Path(__file__).resolve().parents[2]
 MAIN = ROOT / "main"


### PR DESCRIPTION
## What

Finishes the dialog standardisation started in #215 by moving the last three
hand-rolled confirmation overlays onto the shared `ui_dialog` component:

- Home Assistant **revoke** modal (`settings_home_assistant_screen.cpp`)
- Settings **demo-mode restart** bottom sheet (`settings_menu.cpp`)
- Settings **factory reset** bottom sheet (`settings_menu.cpp`)

Each of these previously built its own overlay, card panel, button row and
slide-up animation, so the "one styled dialog" rule from #215 only actually
held for two screens.

## Component changes

`ui_dialog` gained exactly what those call sites needed, and nothing more:

| Addition | Why |
|---|---|
| `UI_DIALOG_LAYOUT_SHEET` | Preserves the settings sheets' full-width, slide-up-from-bottom affordance instead of flattening them into centred modals |
| `ui_dialog_add_text()` | Factory reset has a third body line (the warning); keeps the action row last |
| `ui_dialog_set_title_color()` | Factory reset flags its title in red |
| Optional overlay/panel tags on `ui_dialog_create_ex()` | The existing device tests assert on `reboot_overlay` / `reboot_panel` / `factory_reset_overlay` / `factory_reset_panel` |

## Drive-by fix: user_data vs. test tags

`ui_dialog` used to `lv_malloc()` a `DialogContext` and park it in the
overlay's `lv_obj` user_data. That slot is what the test API reads as a
widget tag, and `is_valid_tag()` (`test_endpoints.cpp:381`) only *heuristically*
rejects non-string pointers — it accepts any pointer above `0x40000000` whose
first four bytes happen to be printable ASCII. A `DialogContext` whose first
member is an `lv_obj_t*` could therefore surface as a garbage tag in
`/api/test/ui-state`.

The context is gone; the panel and action row are now located structurally
(panel = overlay's only child, actions = panel's last child), which also frees
user_data for the real tags above.

## Lifetime

Dialogs live on `lv_layer_top()`, so they no longer die with the screen that
opened them. `settings_menu_close()` and `home_assistant_screen_close()` now
dismiss them explicitly, and the revoke handle is cleared from an
`LV_EVENT_DELETE` callback so it stays correct even when the shell tears the
layer down via `lv_obj_clean(lv_layer_top())`.

## Also

`tests/api/test_ui_dialogs.py` now carries the `hostside` marker, matching the
other static source checks in `tests/api/`.

## Validation

- Builds clean against ESP-IDF 6.1 on the self-hosted runner —
  `arctic_controller.bin` 0x239c50, 44% of the app partition free.
- Hardware coverage is the point of this PR: `test_demo_mode.py`,
  `test_settings_menu.py`, `test_display_idle.py` and
  `test_home_assistant_pairing.py` all drive these three dialogs by tag, so
  the device-tests job is the real gate.
