### PR TITLE
ci: make the credential provisioning retry loop actually retry

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -620,11 +620,21 @@ jobs:
             # Capture the HTTP status so a failure is diagnosable (a bare
             # `curl -skf ... >/dev/null` hid whether we got a 404/401/5xx or a
             # timeout, which made the original flake impossible to triage).
+            #
+            # The `|| HTTP_CODE="000"` is load-bearing. Steps default to
+            # `bash -e`, so an unguarded assignment from a command
+            # substitution aborts the whole step the moment curl exits
+            # non-zero (28 timeout, 7 connection refused, ...). That killed
+            # this loop on attempt 1 and made the retries dead code: it only
+            # ever retried when curl SUCCEEDED but returned a non-200 status,
+            # which is the one case least likely to be transient. Guarding
+            # the assignment turns a transport error into a retryable "000",
+            # matching the `|| true` idiom used by the sibling curl steps.
             HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
               --connect-timeout 3 --max-time 10 \
               -X POST "$ARCTIC_URL/api/test/credentials" \
               -H "Content-Type: application/json" \
-              -d "$BODY")
+              -d "$BODY") || HTTP_CODE="000"
             if [ "$HTTP_CODE" = "200" ]; then
               echo "ARCTIC_USERNAME=$TEST_USERNAME" >> "$GITHUB_ENV"
               echo "ARCTIC_PASSWORD=$TEST_PASSWORD" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The step that provisions isolated test credentials wraps its `curl` in a
5-attempt retry loop, but **the retries were dead code**.

Steps default to `bash -e`. An unguarded assignment from a command
substitution therefore aborts the whole step the moment `curl` exits
non-zero:

```bash
HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" ... -d "$BODY")
```

So the loop only ever retried when curl **succeeded** but returned a
non-200 status, which is the one case *least* likely to be transient.
Every genuinely transient failure the retry was written to absorb
(exit 28 timeout, exit 7 connection refused) killed the step on attempt 1.

## Evidence

Run `33996483943` exited **28**, not the `exit 1` at the end of the loop,
and the `::error::Could not provision test credentials ...` line never
printed. That combination is only reachable if the loop body never
completed a single iteration.

Verified against real bash against an unreachable endpoint:

```
--- OLD (unguarded, bash -e) ---
OLD exit=7            <- printed nothing at all, not even "attempt 1"

--- NEW (guarded) ---
attempt 1 got 000
attempt 2 got 000
attempt 3 got 000
loop finished
NEW exit=0
```

## Fix

Guard the assignment so a transport error becomes a retryable `"000"`:

```bash
  -d "$BODY") || HTTP_CODE="000"
```

This matches the `|| true` idiom already used by the eight sibling curl
steps in this same workflow (lines 315, 321, 323, 325, 388, 441, 657, 659).

Behaviour on a real failure is unchanged apart from being *reported*: the
loop now runs all five attempts and then fails with the existing
`::error::` annotation and `exit 1`, instead of dying silently with curl's
raw exit code.

## Risk

Comment-and-one-operator change to a single workflow step. No test or
firmware code is touched. The device suite exercises this step on every
run, so a green `device-tests` here is direct evidence the provisioning
path still works.
