### PR TITLE
feat(ha): publish EEV opening and electrical readings

### DIFF
--- a/docs/home-assistant-integration.md
+++ b/docs/home-assistant-integration.md
@@ -84,6 +84,12 @@ The initial exposed snapshot includes:
 - Temperatures.
 - Setpoints and setpoint limits.
 - Compressor frequency, power, thermal output, and COP when valid.
+- Primary EEV opening in raw steps, and AC/DC electrical readings. Each is
+  `null` when the underlying register has not been read, because 0 is a
+  legitimate measured value for all of them (0 EEV steps means the valve is
+  fully closed, not unknown). The mainboard publishes no full-scale EEV step
+  count, so the opening is raw steps only and is never expressed as a
+  percentage.
 - Current error state.
 - Firmware, protocol, and capability metadata.
 

--- a/main/ha_integration.cpp
+++ b/main/ha_integration.cpp
@@ -111,6 +111,40 @@ cJSON* createStateObject(const HeatPumpState& hp)
     cJSON_AddNumberToObject(
         readings, "compressor_frequency_hz", hp.compressor_freq);
     cJSON_AddNumberToObject(readings, "fan_rpm", hp.fan_speed);
+    // Primary EEV opening, in raw steps.
+    //
+    // Emitted as null rather than 0 when the reading is invalid. 0 steps means
+    // the valve is fully CLOSED, which is a real and alarming state, so
+    // collapsing "unknown" onto 0 would make consumers confidently display a
+    // fault that is not occurring.
+    //
+    // The key name matches the device's own /api/heatpump/status payload so the
+    // two representations stay consistent. Note this is raw steps only: the
+    // mainboard exposes no full-scale step count (no max-steps register, and no
+    // EEV advanced parameter carries one), so the device cannot convert this to
+    // a percentage and deliberately does not guess at one.
+    if (hp.primary_eev_valid) {
+        cJSON_AddNumberToObject(readings, "primary_eev", hp.primary_eev_opening);
+    } else {
+        cJSON_AddNullToObject(readings, "primary_eev");
+    }
+    // Electrical readings follow the same null-when-invalid rule: 0 V / 0 A are
+    // all legitimate measured values, so they must not double as "unknown".
+    if (hp.ac_voltage_valid) {
+        cJSON_AddNumberToObject(readings, "ac_voltage", hp.ac_voltage);
+    } else {
+        cJSON_AddNullToObject(readings, "ac_voltage");
+    }
+    if (hp.ac_current_valid) {
+        cJSON_AddNumberToObject(readings, "ac_current", hp.ac_current);
+    } else {
+        cJSON_AddNullToObject(readings, "ac_current");
+    }
+    if (hp.dc_voltage_valid) {
+        cJSON_AddNumberToObject(readings, "dc_voltage", hp.getDcVoltageV());
+    } else {
+        cJSON_AddNullToObject(readings, "dc_voltage");
+    }
     cJSON_AddNumberToObject(readings, "power_w", hp.realtime_power_w);
     cJSON_AddNumberToObject(readings, "thermal_w", hp.thermal_w);
     if (hp.cop_valid) {

--- a/main/heatpump_controller.cpp
+++ b/main/heatpump_controller.cpp
@@ -506,11 +506,15 @@ static void applyMaconMapping() {
 
     // Electrical readings.
     s_state.ac_current          = ms.ac_current;
+    s_state.ac_current_valid    = ms.ac_current_valid;
     s_state.ac_voltage          = ms.ac_voltage;
+    s_state.ac_voltage_valid    = ms.ac_voltage_valid;
     // The macon library owns raw->unit conversion and reports dc_voltage in
     // VOLTS. Store it as-is; no re-scaling in the consumer.
     s_state.dc_voltage          = ms.dc_voltage;
+    s_state.dc_voltage_valid    = ms.dc_voltage_valid;
     s_state.primary_eev_opening = ms.primary_eev;
+    s_state.primary_eev_valid   = ms.primary_eev_valid;
     s_state.compressor_freq     = ms.compressor_freq;
     // Real-time power in watts, decoded by the macon library.
     // Preferred over the old V*I/10 estimate, which is now 10x low because the

--- a/main/heatpump_controller.h
+++ b/main/heatpump_controller.h
@@ -49,10 +49,23 @@ struct HeatPumpState {
     uint16_t compressor_freq = 0;    // Hz
     uint16_t fan_speed = 0;          // fan speed in RPM (decoded by the macon library)
     uint16_t fan_speed_max = 0;      // full-scale fan speed in RPM (from macon lib); 0 until first read
+    // Electrical readings. Each carries a validity flag because 0 is a
+    // legitimate value for every one of them, so consumers must be able to
+    // distinguish "measured zero" from "never read / stale".
     uint16_t ac_voltage = 0;         // V
+    bool     ac_voltage_valid = false;
     uint16_t ac_current = 0;         // A
+    bool     ac_current_valid = false;
     uint16_t dc_voltage = 0;         // V (volts; unit conversion owned by macon lib)
+    bool     dc_voltage_valid = false;
+    // Primary electronic expansion valve opening, in raw steps. 0 steps is a
+    // REAL and alarming state (valve fully closed), so "unknown" must never be
+    // reported as 0 - consult primary_eev_valid and surface null/unavailable
+    // instead. Note the mainboard exposes no full-scale step count (there is
+    // no max-steps register and no EEV advanced parameter for it), so this
+    // value cannot be converted to a percentage on the device.
     uint16_t primary_eev_opening = 0;   // steps
+    bool     primary_eev_valid = false;
     uint32_t realtime_power_w = 0;   // W (real-time power; conversion owned by macon lib)
 
     // Estimated performance (owned by the macon library; flow is an outside


### PR DESCRIPTION
Implements the firmware half of the EEV handoff spec.

## Problem

The HA state payload (`ha_integration.cpp` `createStateObject()`) published
only `compressor_frequency_hz`, `fan_rpm`, `power_w`, `thermal_w` and `cop`.

The expansion-valve opening and the AC/DC electrical readings were already
decoded into `HeatPumpState` and already served by the device's own
`/api/heatpump/status`, but never reached Home Assistant. The
`macon-heat-pump-card` draws an expansion-valve element with no entity behind
it for exactly this reason.

## Change

Publishes four new keys in the HA `readings` object, reusing the key names
from the device's own API so the two payloads stay consistent:

| key | source | unit |
|---|---|---|
| `primary_eev` | `hp.primary_eev_opening` | steps |
| `ac_voltage` | `hp.ac_voltage` | V |
| `ac_current` | `hp.ac_current` | A |
| `dc_voltage` | `hp.getDcVoltageV()` | V |

### null, not 0

Each key is `null` when the underlying register has not been read.

This matters most for the EEV: **0 steps means the valve is fully CLOSED**, a
real and alarming state. Collapsing "unknown" onto 0 would make consumers
confidently render a fault that is not occurring. The same reasoning applies
to 0 V / 0 A, which are all legitimate measured values.

`arctic-macon` already tracks `primary_eev_valid`, `ac_voltage_valid`,
`ac_current_valid` and `dc_voltage_valid`, but `applyMaconMapping()` was
dropping all four on the floor. They are now propagated into `HeatPumpState`,
following the existing `cop_valid` precedent.

### Raw steps only, no percentage

The handoff spec asked for either a full-scale step count or a percentage.
Neither is possible: the mainboard exposes **no** EEV full-scale value.

- `macon_registers.cpp` maps reg 2104 as `{"Main EEV", "steps", scale 1.0}`
  and `macon_image.cpp` decodes it as `Kind::Raw`.
- The only two `CAT_EEV` advanced parameters are the superheat method
  (reg 2041) and the target superheat (reg 2042).

There is a precedent for an *assumed* full scale (`MACON_FAN_SPEED_MAX_RPM`
backing `fan_speed_max`), but an EEV could plausibly be a 480, 500 or
2000-step unit. Publishing a guessed denominator would produce a confidently
wrong opening indicator, which is the same failure mode as the 0-vs-null
issue above. So the device publishes raw steps and declines to guess; the
decision about a denominator belongs with whoever can identify the valve.

## Compatibility

Purely additive. No existing key or type changes, so older `pymacon` versions
are unaffected (the parser reads named keys via `.get()` and ignores unknown
ones).

The consuming side must use an **optional** parser for the new keys.
`pymacon`'s `_number()` raises `ArcticProtocolError`, which surfaces as
`ConfigEntryNotReady` and makes every entity unavailable; `_optional_number()`
is the correct helper. That is not just a rollout-ordering concern, since A/B
OTA can roll firmware backwards at any time.

## Testing

- Host-side suite passes locally: 45 passed, 3 skipped.
- Could not compile locally: this project now requires ESP-IDF >= 6.1 and only
  v5.5.2 is installed on the dev box, so the build is left to CI (which pins
  v6.1).

## Follow-ups (not in this PR)

- `arctic-macon` is a **submodule**, so its stale `reg2140 A5` comments
  (the register is 2104) need their own PR plus a pointer bump.
- `pymacon`: add optional `primary_eev` to `ReadingState`, parsed with
  `_optional_number`, as a trailing defaulted field.
- `hass-macon`: add the `expansion_valve_position` sensor.
