### PR TITLE
ci: gate PRs through a single fail-closed orchestrator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,25 +17,12 @@ on:
       - 'fetch_repos.py'
       - 'patches/**'
       - '.github/workflows/build.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'main/**'
-      - 'components/**'
-      - 'managed_components/**'
-      - 'dependencies/**'
-      - 'CMakeLists.txt'
-      - 'sdkconfig*'
-      - 'partitions.csv'
-      - 'lv_conf.h'
-      - 'repos.json'
-      - 'fetch_repos.py'
-      - 'patches/**'
-      # See the note in device-tests.yml: `build` is a required status
-      # check, and an `on:`-level paths skip creates no check run at all,
-      # which blocks the PR permanently. Trigger on any workflow change.
-      - '.github/workflows/**'
+  # No `pull_request` trigger: the PR path runs through ci.yml, which has no
+  # paths filter and calls this workflow. An `on:`-level paths filter creates
+  # NO check run, so a required context never reports and the PR blocks
+  # forever; ci.yml always reports instead. `merge_group` is driven by ci.yml
+  # for the same reason.
+  workflow_call:
   workflow_dispatch:
     inputs:
       target:
@@ -45,11 +32,6 @@ on:
         type: choice
         options:
           - esp32p4
-
-  # Run against the prospective merged state when a PR is queued via the merge
-  # queue. No paths filter here: skipping a required check in the queue would
-  # stall it, so build always runs for merge groups.
-  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,223 @@
+name: CI
+
+# Single always-reporting entry point for pull requests and the merge queue.
+#
+# WHY THIS EXISTS
+#
+# An `on:`-level `paths:` filter creates NO check run at all. A required status
+# check that never reports leaves the PR permanently BLOCKED, with every
+# visible check green and nothing in flight. A job-level `if:` skip behaves
+# completely differently: it DOES create a check run, with conclusion
+# `skipped`, which branch protection ACCEPTS as passing.
+#
+# That asymmetry produced two opposite failure modes in this repo:
+#
+#   * DEADLOCK - build.yml and device-tests.yml were both paths-filtered, so a
+#     PR touching only docs/**, web/** or a *.md file triggered neither, and
+#     the required `build` and `device-tests` contexts never reported.
+#     A workflow_dispatch run CANNOT rescue this: dispatched job check runs
+#     attach to the commit but are not associated with the pull request, so
+#     they never satisfy protection (verified on PR #219).
+#
+#   * VACUOUS PASS - `device-tests` depends on preflight and the firmware
+#     build, so a FAILURE upstream turned it into `skipped`, which protection
+#     accepted as a pass. The hardware gate could go green having tested
+#     nothing.
+#
+# THE FIX
+#
+# This workflow has no paths filter, so it always reports. It decides what is
+# relevant, calls the heavy suites via `workflow_call`, and ends in `ci-gate`,
+# which ENUMERATES the acceptable outcome combinations and fails on anything
+# else. `ci-gate` is intended to be the ONLY required status check.
+#
+# The called workflows deliberately no longer carry `pull_request` triggers.
+# Restoring one would double-run the physical suite: device-tests.yml has a
+# global concurrency group and there is a single physical controller, so a
+# duplicate run serialises into ~80 minutes.
+#
+# NOT ROUTED THROUGH HERE: device-tests.yml keeps its DIRECT `push` trigger.
+# create-release.yml resolves release attestations via
+# `actions/workflows/device-tests.yml/runs?event=push`, and a workflow_call
+# invocation produces no top-level run entry for that query to find.
+
+on:
+  pull_request:
+    branches:
+      - main
+  # Kept in step with the PR path so enabling a merge queue later cannot
+  # deadlock on a context that only pull requests produce.
+  merge_group:
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      # Always an explicit literal 'true' or 'false'.
+      hw_relevant: ${{ steps.decide.outputs.hw_relevant }}
+      is_fork: ${{ steps.decide.outputs.is_fork }}
+    steps:
+      - name: Decide whether the physical device suite is relevant
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Merge-queue runs validate the prospective merged state and have no
+          # PR file list to inspect. Always run the full suite there.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "hw_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+            echo "event=${EVENT}: forcing hw_relevant=true"
+            exit 0
+          fi
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "::error::pull_request event with no PR number; refusing to guess relevance."
+            exit 1
+          fi
+
+          # --paginate matters: a large PR would otherwise be truncated at 30
+          # files and could be misclassified as documentation-only.
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > changed.txt
+
+          if [ ! -s changed.txt ]; then
+            echo "::error::Could not determine the changed files for PR #${PR_NUMBER}. Failing closed rather than assuming the hardware suite is unnecessary."
+            exit 1
+          fi
+
+          echo "Changed files:"
+          sed 's/^/  /' changed.txt
+
+          # EXCLUSION list, not an inclusion list. Anything not recognised as
+          # inert documentation/metadata counts as hardware-relevant, so a new
+          # source directory is covered automatically instead of silently
+          # bypassing the device suite.
+          NON_HW='^(docs/|\.github/ISSUE_TEMPLATE/|\.github/PULL_REQUEST_TEMPLATE)|(^|/)[^/]*\.md$|^LICENSE$|^\.gitignore$|^\.gitattributes$|^\.editorconfig$|^\.github/dependabot\.yml$'
+
+          RELEVANT=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if echo "$f" | grep -Eq "$NON_HW"; then
+              echo "  inert:    $f"
+            else
+              echo "  relevant: $f"
+              RELEVANT=true
+            fi
+          done < changed.txt
+
+          FORK=false
+          if [ "${IS_FORK:-false}" = "true" ]; then
+            FORK=true
+          fi
+
+          echo "hw_relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$FORK" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### CI classification"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| event | \`${EVENT}\` |"
+            echo "| changed files | $(wc -l < changed.txt) |"
+            echo "| hardware relevant | \`${RELEVANT}\` |"
+            echo "| fork PR | \`${FORK}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  call-build:
+    needs: classify
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  call-host-tests:
+    needs: classify
+    uses: ./.github/workflows/host-tests.yml
+    secrets: inherit
+
+  call-device-tests:
+    needs: classify
+    # Fork PRs are excluded deliberately, NOT as an oversight: the device suite
+    # runs on a self-hosted runner with physical access to the controller, so
+    # executing fork-authored code there would be a host, network and hardware
+    # exposure. Fork PRs also receive no repository secrets and cannot write
+    # check runs. ci-gate turns a hardware-relevant fork PR into an explicit
+    # FAILURE with instructions, rather than letting the skip read as a pass.
+    if: needs.classify.outputs.hw_relevant == 'true' && needs.classify.outputs.is_fork == 'false'
+    uses: ./.github/workflows/device-tests.yml
+    secrets: inherit
+
+  # The ONLY status check that should be required on main.
+  ci-gate:
+    needs: [classify, call-build, call-host-tests, call-device-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce an acceptable CI outcome
+        env:
+          CLASSIFY: ${{ needs.classify.result }}
+          HW: ${{ needs.classify.outputs.hw_relevant }}
+          FORK: ${{ needs.classify.outputs.is_fork }}
+          BUILD: ${{ needs.call-build.result }}
+          HOST: ${{ needs.call-host-tests.result }}
+          DEVICE: ${{ needs.call-device-tests.result }}
+        run: |
+          set -euo pipefail
+
+          echo "classify=${CLASSIFY} hw_relevant=${HW} is_fork=${FORK}"
+          echo "call-build=${BUILD}"
+          echo "call-host-tests=${HOST}"
+          echo "call-device-tests=${DEVICE}"
+
+          fail() {
+            echo "::error::$1"
+            exit 1
+          }
+
+          # Everything downstream is meaningless if the classifier did not
+          # produce a trustworthy decision.
+          if [ "$CLASSIFY" != "success" ]; then
+            fail "classify did not succeed (got '${CLASSIFY}'), so the relevance decision cannot be trusted."
+          fi
+
+          case "$HW" in
+            true|false) ;;
+            *) fail "hw_relevant is '${HW}', expected the literal 'true' or 'false'." ;;
+          esac
+          case "$FORK" in
+            true|false) ;;
+            *) fail "is_fork is '${FORK}', expected the literal 'true' or 'false'." ;;
+          esac
+
+          # These two always run unconditionally; a skip means something is
+          # structurally wrong and must never be read as a pass.
+          [ "$BUILD" = "success" ] || fail "call-build is '${BUILD}', expected success."
+          [ "$HOST" = "success" ] || fail "call-host-tests is '${HOST}', expected success."
+
+          if [ "$HW" = "true" ] && [ "$FORK" = "true" ]; then
+            fail "This fork PR changes hardware-relevant files, but the physical device suite cannot run on fork code. A maintainer must re-push the commit to a branch in this repository so the device suite can validate it. Refusing to pass without hardware validation."
+          fi
+
+          if [ "$HW" = "true" ]; then
+            [ "$DEVICE" = "success" ] || fail "call-device-tests is '${DEVICE}', expected success. A skipped or failed hardware suite must never be read as a pass."
+            echo "Accepted: hardware-relevant change, physical device suite ran and passed."
+            exit 0
+          fi
+
+          # Documentation-only change: the suite must be skipped, and must not
+          # have run unexpectedly (which would mean the classifier and the job
+          # condition disagree).
+          [ "$DEVICE" = "skipped" ] || fail "Change classified as documentation-only, but call-device-tests is '${DEVICE}', expected skipped. The classifier and the job condition disagree."
+          echo "Accepted: documentation-only change, physical device suite correctly skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,17 @@ jobs:
     # check runs. ci-gate turns a hardware-relevant fork PR into an explicit
     # FAILURE with instructions, rather than letting the skip read as a pass.
     if: needs.classify.outputs.hw_relevant == 'true' && needs.classify.outputs.is_fork == 'false'
+    # A caller can only ever GRANT DOWNWARD, so these must cover the highest
+    # permission any job in device-tests.yml declares, or the run is rejected
+    # before it starts. `contents: write` is required by device-firmware-build
+    # solely to publish the nightly OTA prerelease; that step is gated on
+    # `github.event_name == 'schedule'` and so can never fire from this path.
+    # Scoping the grant to this one job keeps call-build and call-host-tests
+    # read-only rather than elevating the whole workflow.
+    permissions:
+      contents: write
+      actions: read
+      checks: write
     uses: ./.github/workflows/device-tests.yml
     secrets: inherit
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -4,33 +4,17 @@ on:
   schedule:
     # Run daily at 6 AM UTC
     - cron: '0 6 * * *'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'main/**'
-      - 'components/**'
-      - 'managed_components/**'
-      - 'dependencies/**'
-      - 'CMakeLists.txt'
-      - 'sdkconfig*'
-      - 'partitions.csv'
-      - 'lv_conf.h'
-      - 'repos.json'
-      - 'fetch_repos.py'
-      - 'tests/**'
-      - '!tests/**/*.md'
-      - 'patches/**'
-      # Any workflow change can alter how this suite is built, gated or
-      # reported, so trigger on all of them rather than just this file.
-      # `device-tests` is a required status check, and an `on:`-level paths
-      # skip creates NO check run at all (unlike a job-level `if:`, which
-      # reports `skipped` and is accepted by branch protection). A required
-      # context that never reports blocks the PR permanently, and a
-      # workflow_dispatch run cannot rescue it: dispatched job check runs
-      # attach to the commit but are not associated with the pull request.
-      # Erring towards over-triggering is therefore fail-closed on purpose.
-      - '.github/workflows/**'
+  # NOTE: there is deliberately no `pull_request` trigger here any more.
+  #
+  # The PR path now runs through ci.yml, which has NO paths filter and calls
+  # this workflow via `workflow_call`. That change exists because an
+  # `on:`-level paths filter creates NO check run at all, so a required
+  # context never reports and the PR is blocked forever. ci.yml always
+  # reports, and decides whether the hardware suite is relevant.
+  #
+  # Adding `pull_request` back here would ALSO double-run the suite: the
+  # concurrency group below is global and there is one physical device, so a
+  # duplicate run serialises into ~80 minutes.
   push:
     # Authoritative post-merge validation of the exact main commit SHA. The
     # release workflow consumes the attestation produced by these runs instead
@@ -43,10 +27,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-  # Validate the prospective merged state when a PR is queued via the merge
-  # queue. No paths filter: a skipped required check would stall the queue, so
-  # the physical suite always runs for merge groups.
-  merge_group:
+  # NOTE: `merge_group` is likewise driven by ci.yml, so that the merge queue
+  # sees exactly one always-reporting required context.
 
 # Only one device-test run at a time (single device on the network)
 concurrency:
@@ -73,7 +55,11 @@ jobs:
       contents: read
       actions: read
     outputs:
-      dedup: ${{ steps.check.outputs.dedup }}
+      # Always an explicit literal 'true' or 'false' -- never empty. An empty
+      # value cannot participate in a fail-closed policy, because it is
+      # indistinguishable from broken output plumbing, a renamed step or a
+      # missing output. See the `normalize` step below.
+      dedup: ${{ steps.normalize.outputs.dedup }}
       tree_sha: ${{ steps.tree.outputs.tree_sha }}
       artifact_name: ${{ steps.tree.outputs.artifact_name }}
       source_run_id: ${{ steps.check.outputs.source_run_id }}
@@ -116,7 +102,39 @@ jobs:
           echo "source_run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Tree already validated by run ${RUN_ID}; reusing its attestation and skipping the physical suite."
 
-  build:
+      - name: Normalize the dedup decision
+        id: normalize
+        # The `check` step above only runs for push-to-main, so on every other
+        # event its output is the empty string. Collapse that to an explicit
+        # literal here so downstream gates can enumerate exact values rather
+        # than treating "empty" as an implicit false -- an empty value is
+        # indistinguishable from a plumbing failure, and silently trusting it
+        # is precisely the fail-open behaviour these gates exist to prevent.
+        env:
+          RAW: ${{ steps.check.outputs.dedup }}
+        run: |
+          set -euo pipefail
+          VALUE="${RAW:-false}"
+          if [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
+            echo "::error::preflight produced a non-literal dedup value '${VALUE}'. Refusing to continue."
+            exit 1
+          fi
+          echo "dedup=$VALUE" >> "$GITHUB_OUTPUT"
+          echo "dedup=$VALUE (event=${GITHUB_EVENT_NAME}, ref=${GITHUB_REF})"
+
+  # Renamed from `build`. A job named `build` also exists in build.yml, and two
+  # check runs sharing one name make a required context ambiguous: GitHub can
+  # resolve it against either producer, so a failed firmware build could be
+  # masked by a passing one from the other workflow.
+  #
+  # This rename was NOT safe to make in isolation. device-tests.yml used to
+  # trigger on a superset of build.yml's paths (it added tests/**), so on a
+  # tests-only PR build.yml never ran and THIS job was the sole producer of the
+  # required `build` context. Verified on PR #214 (one file, tests/api/
+  # test_api_schema.py): build.yml had 0 runs, and the only `build` check run
+  # came from Device Tests. Renaming before ci.yml existed would have blocked
+  # every tests-only PR permanently.
+  device-firmware-build:
     needs: preflight
     if: needs.preflight.outputs.dedup != 'true'
     runs-on: ubuntu-latest
@@ -222,7 +240,7 @@ jobs:
           echo "Published build/arctic_controller.bin to the ci-nightly prerelease."
 
   device-tests:
-    needs: [preflight, build]
+    needs: [preflight, device-firmware-build]
     if: needs.preflight.outputs.dedup != 'true'
     runs-on: [self-hosted, vm-mi]
     timeout-minutes: 120
@@ -1263,3 +1281,70 @@ jobs:
           name: release-attestation-${{ github.sha }}
           path: release-attestation.json
           retention-days: 90
+
+  # Terminal gate for THIS workflow's own job graph.
+  #
+  # Closes the vacuous-pass hole (H1): `device-tests` needs
+  # [preflight, device-firmware-build], so if either of those FAILS then
+  # `device-tests` is reported as `skipped` -- and branch protection accepts
+  # `skipped` as passing. The hardware gate could therefore go green having
+  # tested nothing at all.
+  #
+  # This gate lives inside device-tests.yml rather than only in ci.yml so the
+  # direct push-to-main path is covered too. That path never goes through
+  # ci.yml, and it is the path create-release.yml consumes to authorise a
+  # release, so it is the one that must not be fakeable.
+  #
+  # The policy ENUMERATES the acceptable combinations. Anything not listed --
+  # including any unexpected, empty or cancelled state -- fails.
+  device-gate:
+    needs: [preflight, device-firmware-build, device-tests, reuse-attestation]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce an acceptable job-graph outcome
+        env:
+          PREFLIGHT: ${{ needs.preflight.result }}
+          BUILD: ${{ needs.device-firmware-build.result }}
+          DEVICE: ${{ needs.device-tests.result }}
+          REUSE: ${{ needs.reuse-attestation.result }}
+          DEDUP: ${{ needs.preflight.outputs.dedup }}
+        run: |
+          set -euo pipefail
+
+          echo "preflight=${PREFLIGHT} dedup=${DEDUP}"
+          echo "device-firmware-build=${BUILD}"
+          echo "device-tests=${DEVICE}"
+          echo "reuse-attestation=${REUSE}"
+
+          fail() {
+            echo "::error::$1"
+            exit 1
+          }
+
+          # preflight always runs and always decides; nothing else is valid.
+          if [ "$PREFLIGHT" != "success" ]; then
+            fail "preflight did not succeed (got '${PREFLIGHT}'), so no validation decision can be trusted."
+          fi
+
+          # dedup is normalized to an explicit literal by preflight.
+          case "$DEDUP" in
+            true|false) ;;
+            *) fail "dedup is '${DEDUP}', expected the literal 'true' or 'false'." ;;
+          esac
+
+          if [ "$DEDUP" = "true" ]; then
+            # Reuse path: the physical suite is intentionally skipped and the
+            # prior attestation is re-emitted for this commit.
+            [ "$BUILD" = "skipped" ] || fail "dedup=true but device-firmware-build is '${BUILD}', expected skipped."
+            [ "$DEVICE" = "skipped" ] || fail "dedup=true but device-tests is '${DEVICE}', expected skipped."
+            [ "$REUSE" = "success" ] || fail "dedup=true but reuse-attestation is '${REUSE}', expected success."
+            echo "Accepted: validated tree reused, attestation re-emitted."
+            exit 0
+          fi
+
+          # Normal path: everything must actually have run and passed.
+          [ "$BUILD" = "success" ] || fail "device-firmware-build is '${BUILD}', expected success. A skipped build must never be read as a pass."
+          [ "$DEVICE" = "success" ] || fail "device-tests is '${DEVICE}', expected success. A skipped hardware suite must never be read as a pass."
+          [ "$REUSE" = "skipped" ] || fail "reuse-attestation is '${REUSE}', expected skipped when dedup=false."
+          echo "Accepted: physical device suite ran and passed."

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -9,15 +9,15 @@ name: Host Tests
 # Intentionally has NO `paths:` filter: a required check that gets skipped by a
 # path filter stays pending forever and blocks the merge queue. Keeping this
 # always-on guarantees it reports a conclusion on every PR and merge group.
+#
+# The PR and merge-queue paths now arrive via ci.yml (`workflow_call`), which
+# is itself unfiltered, so that property is preserved.
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -143,6 +143,42 @@ def test_no_duplicate_check_run_names_across_workflows():
     assert not duplicates, "duplicate job/check-run names: " + "; ".join(duplicates)
 
 
+def test_caller_grants_at_least_the_permissions_the_callee_declares():
+    """A caller can only grant downward.
+
+    If a called workflow declares a permission the caller does not hold, the
+    entire run is rejected with a `startup_failure` before any job is created
+    -- and that produces no check run at all, which is precisely the
+    never-reports condition this migration exists to eliminate.
+    """
+    ci = _workflow("ci.yml")
+    rank = {"none": 0, "read": 1, "write": 2}
+    calls = {
+        job["uses"].rsplit("/", 1)[-1]: (name, job)
+        for name, job in ci["jobs"].items()
+        if "uses" in job
+    }
+    assert calls, "ci.yml must call the heavy suites as reusable workflows"
+
+    problems = []
+    for wf_name, (caller_job, job) in calls.items():
+        granted = {**(ci.get("permissions") or {}), **(job.get("permissions") or {})}
+        callee = _workflow(wf_name)
+        # The callee's requirement is the highest level any of its jobs asks for.
+        required: dict[str, str] = dict(callee.get("permissions") or {})
+        for inner in (callee.get("jobs") or {}).values():
+            for scope, level in (inner.get("permissions") or {}).items():
+                if rank.get(level, 0) > rank.get(required.get(scope, "none"), 0):
+                    required[scope] = level
+        for scope, level in required.items():
+            have = granted.get(scope, "none")
+            if rank.get(have, 0) < rank.get(level, 0):
+                problems.append(
+                    f"{caller_job} -> {wf_name}: needs {scope}:{level}, caller grants {scope}:{have}"
+                )
+    assert not problems, "insufficient permissions: " + "; ".join(problems)
+
+
 def test_ci_gate_depends_on_every_other_job():
     """A gate that does not observe a job cannot enforce anything about it."""
     jobs = _workflow("ci.yml")["jobs"]

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -1,0 +1,354 @@
+"""Policy tests for the CI gating workflows.
+
+These exist because the CI gates encode *safety* policy, not convenience:
+
+* An ``on:``-level ``paths:`` filter creates NO check run, so a required
+  status check never reports and the PR is blocked forever.
+* A job-level ``if:`` skip DOES create a check run, with conclusion
+  ``skipped``, which branch protection ACCEPTS as passing.
+
+That asymmetry previously allowed both a permanent deadlock (a docs-only or
+web-only PR triggered no gating workflow at all) and a vacuous pass (a failed
+firmware build turned ``device-tests`` into ``skipped``, which counted as
+green -- the hardware gate passing having tested nothing).
+
+The gate shell scripts are extracted from the workflow YAML and executed, so
+these tests exercise the real shipped policy rather than a restatement of it.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
+
+pytestmark = [
+    pytest.mark.hostside,
+    pytest.mark.skipif(
+        shutil.which("bash") is None and shutil.which("wsl") is None,
+        reason="needs bash to execute the gate policy",
+    ),
+]
+
+
+def _bash(script_path: Path) -> list[str]:
+    """Build the argv that runs ``script_path`` under a real POSIX bash.
+
+    On Linux (CI) this is simply ``bash <path>``. On Windows the ``bash.exe``
+    on PATH is the WSL launcher, which neither inherits the Windows
+    environment nor understands Windows paths, so the interpreter is invoked
+    through ``wsl`` with a translated path. Scripts are always executed from a
+    file: passing them via ``-c`` would expose them to a second round of
+    command-line parsing by that launcher.
+    """
+    if os.name != "nt":
+        return ["bash", str(script_path)]
+    drive, rest = os.path.splitdrive(script_path)
+    posix = "/mnt/" + drive[0].lower() + rest.replace("\\", "/")
+    return ["wsl", "-e", "bash", posix]
+
+
+def _bash_run(body: str, env: dict[str, str], stdin: str = "") -> subprocess.CompletedProcess:
+    prelude = "".join(f"export {k}={shlex.quote(v)}\n" for k, v in env.items())
+    fd, name = tempfile.mkstemp(suffix=".sh", text=False)
+    path = Path(name)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            # Force LF: a CR would become part of the final token on each line.
+            fh.write((prelude + body + "\n").replace("\r\n", "\n").encode())
+        return subprocess.run(
+            _bash(path), input=stdin, capture_output=True, text=True
+        )
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _workflow(name: str) -> dict:
+    with open(WORKFLOWS / name, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _triggers(doc: dict) -> dict:
+    # PyYAML parses the bare `on:` key as the boolean True.
+    return doc.get(True, doc.get("on"))
+
+
+def _gate_script(workflow: str, job: str) -> str:
+    return _workflow(workflow)["jobs"][job]["steps"][0]["run"]
+
+
+def _run_gate(script: str, env: dict[str, str]) -> int:
+    return _bash_run(script, env).returncode
+
+
+# --------------------------------------------------------------------------
+# Structural invariants
+# --------------------------------------------------------------------------
+
+
+def test_ci_orchestrator_has_no_paths_filter():
+    """ci.yml must always report, or a required ci-gate deadlocks the PR."""
+    triggers = _triggers(_workflow("ci.yml"))
+    for event in ("pull_request", "merge_group"):
+        assert event in triggers, f"ci.yml must trigger on {event}"
+    pr = triggers["pull_request"] or {}
+    assert "paths" not in pr and "paths-ignore" not in pr, (
+        "ci.yml must NOT have a paths filter: an on:-level skip creates no "
+        "check run, so the required ci-gate context would never report and "
+        "the pull request would be blocked permanently."
+    )
+
+
+@pytest.mark.parametrize("name", ["build.yml", "device-tests.yml", "host-tests.yml"])
+def test_called_workflows_do_not_also_trigger_on_pull_request(name):
+    """Double-triggering would run the ~40 min hardware suite twice.
+
+    device-tests.yml has a global concurrency group and there is a single
+    physical controller, so a duplicate run serialises rather than parallelises.
+    """
+    triggers = _triggers(_workflow(name))
+    assert "pull_request" not in triggers, (
+        f"{name} is invoked by ci.yml via workflow_call; a pull_request "
+        "trigger would duplicate it."
+    )
+    assert "workflow_call" in triggers, f"{name} must be callable from ci.yml"
+
+
+def test_device_tests_keeps_direct_push_trigger():
+    """create-release.yml resolves attestations via a top-level push run.
+
+    A workflow_call invocation produces no top-level run entry, so routing the
+    push path through ci.yml would silently break releases.
+    """
+    assert "push" in _triggers(_workflow("device-tests.yml"))
+
+
+def test_no_duplicate_check_run_names_across_workflows():
+    """Two check runs sharing a name make a required context ambiguous."""
+    seen: dict[str, str] = {}
+    duplicates = []
+    for wf in ("build.yml", "device-tests.yml", "host-tests.yml", "ci.yml"):
+        for job in _workflow(wf)["jobs"]:
+            if job in seen:
+                duplicates.append(f"{job!r} in both {seen[job]} and {wf}")
+            seen[job] = wf
+    assert not duplicates, "duplicate job/check-run names: " + "; ".join(duplicates)
+
+
+def test_ci_gate_depends_on_every_other_job():
+    """A gate that does not observe a job cannot enforce anything about it."""
+    jobs = _workflow("ci.yml")["jobs"]
+    gate = jobs["ci-gate"]
+    assert gate["if"] == "always()", "ci-gate must run even when a dependency fails"
+    expected = {j for j in jobs if j != "ci-gate"}
+    assert set(gate["needs"]) == expected
+
+
+def test_device_gate_depends_on_every_other_job():
+    jobs = _workflow("device-tests.yml")["jobs"]
+    gate = jobs["device-gate"]
+    assert gate["if"] == "always()"
+    expected = {j for j in jobs if j != "device-gate"}
+    assert set(gate["needs"]) == expected
+
+
+# --------------------------------------------------------------------------
+# ci-gate policy
+# --------------------------------------------------------------------------
+
+CI_OK = {
+    "CLASSIFY": "success",
+    "HW": "true",
+    "FORK": "false",
+    "BUILD": "success",
+    "HOST": "success",
+    "DEVICE": "success",
+}
+
+
+@pytest.mark.parametrize(
+    "override,reason",
+    [
+        ({}, "hardware-relevant change with everything green"),
+        (
+            {"HW": "false", "DEVICE": "skipped"},
+            "documentation-only change correctly skips the device suite",
+        ),
+    ],
+)
+def test_ci_gate_accepts_valid_outcomes(override, reason):
+    assert _run_gate(_gate_script("ci.yml", "ci-gate"), {**CI_OK, **override}) == 0, reason
+
+
+@pytest.mark.parametrize(
+    "override,reason",
+    [
+        ({"DEVICE": "skipped"}, "VACUOUS PASS: hardware relevant but suite skipped"),
+        ({"DEVICE": "failure"}, "device suite failed"),
+        ({"DEVICE": "cancelled"}, "device suite cancelled"),
+        ({"BUILD": "failure"}, "build failed"),
+        ({"BUILD": "skipped"}, "build skipped"),
+        ({"HOST": "failure"}, "host tests failed"),
+        ({"HOST": "skipped"}, "host tests skipped"),
+        ({"CLASSIFY": "failure"}, "classifier failed"),
+        ({"CLASSIFY": "skipped"}, "classifier skipped"),
+        ({"CLASSIFY": "cancelled"}, "classifier cancelled"),
+        ({"HW": ""}, "empty hw_relevant must not be treated as false"),
+        ({"HW": "yes"}, "non-literal hw_relevant"),
+        ({"FORK": ""}, "empty is_fork"),
+        (
+            {"FORK": "true", "DEVICE": "skipped"},
+            "fork PR touching hardware cannot be validated and must not pass",
+        ),
+        (
+            {"HW": "false", "DEVICE": "success"},
+            "device ran although classified irrelevant: policy disagreement",
+        ),
+    ],
+)
+def test_ci_gate_rejects_invalid_outcomes(override, reason):
+    assert _run_gate(_gate_script("ci.yml", "ci-gate"), {**CI_OK, **override}) != 0, reason
+
+
+# --------------------------------------------------------------------------
+# device-gate policy (also guards the direct push-to-main release path)
+# --------------------------------------------------------------------------
+
+DEV_OK = {
+    "PREFLIGHT": "success",
+    "BUILD": "success",
+    "DEVICE": "success",
+    "REUSE": "skipped",
+    "DEDUP": "false",
+}
+
+DEV_REUSE = {
+    "PREFLIGHT": "success",
+    "BUILD": "skipped",
+    "DEVICE": "skipped",
+    "REUSE": "success",
+    "DEDUP": "true",
+}
+
+
+@pytest.mark.parametrize(
+    "env,reason",
+    [
+        (DEV_OK, "physical suite ran and passed"),
+        (DEV_REUSE, "validated tree reused, attestation re-emitted"),
+    ],
+)
+def test_device_gate_accepts_valid_outcomes(env, reason):
+    assert _run_gate(_gate_script("device-tests.yml", "device-gate"), env) == 0, reason
+
+
+@pytest.mark.parametrize(
+    "override,reason",
+    [
+        (
+            {"BUILD": "failure", "DEVICE": "skipped"},
+            "VACUOUS PASS: build failed so the suite never ran",
+        ),
+        (
+            {"BUILD": "skipped", "DEVICE": "skipped"},
+            "VACUOUS PASS: nothing ran but dedup was not claimed",
+        ),
+        ({"DEVICE": "failure"}, "device suite failed"),
+        ({"DEVICE": "cancelled"}, "device suite cancelled"),
+        ({"PREFLIGHT": "failure"}, "preflight failed"),
+        ({"DEDUP": ""}, "empty dedup must not be treated as false"),
+        ({"DEDUP": "maybe"}, "non-literal dedup"),
+        ({"REUSE": "success"}, "reuse ran although dedup=false"),
+    ],
+)
+def test_device_gate_rejects_invalid_outcomes(override, reason):
+    env = {**DEV_OK, **override}
+    assert _run_gate(_gate_script("device-tests.yml", "device-gate"), env) != 0, reason
+
+
+@pytest.mark.parametrize(
+    "override,reason",
+    [
+        ({"REUSE": "failure"}, "dedup claimed but the attestation was not re-emitted"),
+        ({"BUILD": "success", "DEVICE": "success"}, "dedup claimed but the suite ran"),
+    ],
+)
+def test_device_gate_rejects_invalid_reuse_outcomes(override, reason):
+    env = {**DEV_REUSE, **override}
+    assert _run_gate(_gate_script("device-tests.yml", "device-gate"), env) != 0, reason
+
+
+# --------------------------------------------------------------------------
+# Classifier relevance policy
+# --------------------------------------------------------------------------
+
+
+def _non_hw_regex() -> str:
+    import re
+
+    script = _workflow("ci.yml")["jobs"]["classify"]["steps"][0]["run"]
+    match = re.search(r"NON_HW='([^']*)'", script)
+    assert match, "could not find NON_HW in ci.yml"
+    return match.group(1)
+
+
+def _is_relevant(files: list[str]) -> bool:
+    # The list is emitted by printf rather than piped on stdin: stdin is not
+    # reliably forwarded to the interpreter on every platform, and a silently
+    # empty list would read as "nothing relevant" -- the exact false-negative
+    # this test exists to catch.
+    listing = " ".join(shlex.quote(f) for f in files) or "''"
+    script = (
+        "REL=false\n"
+        f"for f in {listing}; do\n"
+        '  [ -z "$f" ] && continue\n'
+        '  if echo "$f" | grep -Eq "$NON_HW"; then :; else REL=true; fi\n'
+        "done\n"
+        'echo "$REL"\n'
+    )
+    proc = _bash_run(script, {"NON_HW": _non_hw_regex()})
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip() == "true"
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        ["README.md"],
+        ["docs/architecture.md"],
+        ["LICENSE"],
+        [".gitignore"],
+        [".github/ISSUE_TEMPLATE/bug.yml"],
+        ["tests/api/README.md"],
+    ],
+)
+def test_inert_documentation_does_not_require_hardware(files):
+    assert not _is_relevant(files)
+
+
+@pytest.mark.parametrize(
+    "files,reason",
+    [
+        (["main/heatpump_controller.cpp"], "firmware source"),
+        (["tests/api/test_api_schema.py"], "tests-only PR, cf. PR #214"),
+        (["web/index.html"], "web dashboard: absent from BOTH old paths filters"),
+        ([".github/workflows/ci.yml"], "a workflow change must revalidate"),
+        (["CMakeLists.txt"], "build configuration"),
+        (["sdkconfig.defaults"], "sdkconfig"),
+        (["partitions.csv"], "partition table"),
+        (["components/arctic-macon"], "submodule bump"),
+        (["docs/a.md", "main/b.cpp"], "one relevant file in a mixed PR wins"),
+        (["scripts/flash.sh"], "unknown directory must default to relevant"),
+        (["Makefile"], "unrecognised root file must default to relevant"),
+    ],
+)
+def test_source_changes_require_hardware(files, reason):
+    assert _is_relevant(files), reason


### PR DESCRIPTION
## Why

Branch protection required six contexts produced by workflows that carried `on:`-level `paths:` filters. That combination is unsound, because the two ways a job can be omitted are **not** equivalent:

| how the job is omitted | check run created? | branch protection sees |
|---|---|---|
| `on:`-level `paths:` filter excludes the PR | **no** | context never reports → **blocked forever** |
| job-level `if:` evaluates false | **yes**, `skipped` | **accepted as passing** |

Both failure modes were live in this repo:

* **Deadlock.** `web/**` and `docs/**` were in *neither* workflow's paths filter, so those PRs could never satisfy `build` or `device-tests`.
* **Vacuous pass.** A failed firmware build turned the `device-tests` job into `skipped`, which counted as green — the hardware gate reporting success having tested nothing.

## The trap this had to avoid

The required `build` context was load-bearing in a non-obvious way. Two workflows exposed a job named `build`, and device-tests' PR paths filter was a *superset* of build.yml's. I verified this against PR #214 (a single file, `tests/api/test_api_schema.py`): `build.yml` had **0** runs, and the only `build` check run came from the **Device Tests** workflow. Renaming either job in isolation would have permanently blocked every tests-only PR.

So this is deliberately one coordinated change rather than a sequence of smaller ones.

## What changed

* **`ci.yml` (new)** — the only PR-triggered workflow. **No paths filter**, so it always reports. It classifies changed files, calls `build` / `host-tests` / `device-tests` as reusable workflows, and ends in `ci-gate`.
* **`ci-gate`** — enumerates the acceptable outcome combinations and **fails closed** on anything else. A skip now has to be *justified by the classification*, not merely observed.
* **Classification is an exclusion list**, so an unrecognised path defaults to hardware-relevant. An empty file list is an error, not a silent pass. It uses `--paginate` so a >30-file PR isn't truncated.
* **`device-tests.yml` keeps its direct `push` trigger.** `create-release.yml` authorises a release by looking up a **push-event** run for the exact SHA, and a `workflow_call` invocation produces no top-level run entry. Routing the push path through the orchestrator would have quietly broken releases.
* **`dedup` is now always an explicit literal.** It was empty on non-push events, which is indistinguishable from broken plumbing and therefore could not be judged fail-closed.
* **`merge_group` moved to the orchestrator**, so enabling a merge queue later doesn't reintroduce the deadlock.
* **`tests/test_ci_policy.py` (new)** — extracts the gate scripts *from the workflow YAML* and executes them, so the tests exercise the shipped policy rather than a restatement of it.

## Validation

* 54 policy tests pass; the wider hostside suite is unaffected (99 passed, 3 skipped).
* **Mutation-tested**: corrupting the classifier regex so nothing is hardware-relevant makes 11 tests fail, confirming the suite isn't passing vacuously.
* Job graphs verified — no dangling `needs`, no duplicate check-run names, every gate depends on all its siblings.

## Expected: this PR will show as blocked

The old required contexts (`build`, `device-tests`, …) no longer exist on PRs, so they cannot report. That is the intended, controlled consequence of the cutover — not a failure. Once `ci-gate` reports success here, branch protection is switched to require `ci-gate` alone, which then makes this PR mergeable.
