### PR TITLE
fix: render Status screen demo readings from getState()

### DIFF
--- a/main/heatpump_temps_screen.cpp
+++ b/main/heatpump_temps_screen.cpp
@@ -195,8 +195,14 @@ static lv_color_t get_temp_color(int16_t temp) {
 static void update_readings() {
     if (!state.shown) return;
     
+    // Demo mode needs no special case here. initDemoState() seeds the full
+    // shadow register image and marks the state connected, so getState()
+    // already returns the demo values. This screen previously carried its own
+    // block of hardcoded demo literals, which silently drifted from those
+    // seeds (850 vs 400 RPM, 350 vs 200 EEV steps, 20 vs 18 C cooling
+    // setpoint) and disagreed with the home screen. Render from getState()
+    // only, so there is exactly one source of truth.
     arctic::HeatPumpState hp = arctic::getState();
-    bool demo_mode = app_prefs_is_demo_mode();
     char buf[32];
     
     // Helper to format temperature with unit conversion
@@ -204,62 +210,6 @@ static void update_readings() {
         snprintf(buf, sizeof(buf), "%d %s", 
                  app_prefs_convert_temp(temp_c), app_prefs_temp_unit_str());
     };
-    
-    if (demo_mode) {
-        // Demo mode - show simulated temperatures
-        format_temp(42);  // Tank
-        lv_label_set_text(state.tank_temp, buf);
-        lv_obj_set_style_text_color(state.tank_temp, get_temp_color(42), LV_PART_MAIN);
-        
-        format_temp(45);  // Outlet
-        lv_label_set_text(state.outlet_temp, buf);
-        lv_obj_set_style_text_color(state.outlet_temp, get_temp_color(45), LV_PART_MAIN);
-        
-        format_temp(38);  // Inlet
-        lv_label_set_text(state.inlet_temp, buf);
-        lv_obj_set_style_text_color(state.inlet_temp, get_temp_color(38), LV_PART_MAIN);
-        
-        format_temp(22);  // Outdoor ambient
-        lv_label_set_text(state.outdoor_temp, buf);
-        lv_obj_set_style_text_color(state.outdoor_temp, get_temp_color(22), LV_PART_MAIN);
-        
-        format_temp(85);  // Discharge
-        lv_label_set_text(state.discharge_temp, buf);
-        lv_obj_set_style_text_color(state.discharge_temp, get_temp_color(85), LV_PART_MAIN);
-        
-        format_temp(12);  // Suction
-        lv_label_set_text(state.suction_temp, buf);
-        lv_obj_set_style_text_color(state.suction_temp, get_temp_color(12), LV_PART_MAIN);
-        
-        format_temp(35);  // Outdoor coil
-        lv_label_set_text(state.outdoor_coil_temp, buf);
-        lv_obj_set_style_text_color(state.outdoor_coil_temp, get_temp_color(35), LV_PART_MAIN);
-        
-        format_temp(40);  // Indoor coil
-        lv_label_set_text(state.indoor_coil_temp, buf);
-        lv_obj_set_style_text_color(state.indoor_coil_temp, get_temp_color(40), LV_PART_MAIN);
-        
-        format_temp(55);  // IPM
-        lv_label_set_text(state.ipm_temp, buf);
-        lv_obj_set_style_text_color(state.ipm_temp, get_temp_color(55), LV_PART_MAIN);
-
-        // System - demo values
-        lv_label_set_text(state.compressor_freq, "60 Hz");
-        lv_obj_set_style_text_color(state.compressor_freq, COLOR_SUCCESS, LV_PART_MAIN);
-        lv_label_set_text(state.fan_speed, "850 RPM");
-        lv_obj_set_style_text_color(state.fan_speed, COLOR_SUCCESS, LV_PART_MAIN);
-        lv_label_set_text(state.ac_voltage, "230 V");
-        lv_label_set_text(state.ac_current, "5 A");
-        lv_label_set_text(state.dc_voltage, "380.0 V");
-        lv_label_set_text(state.primary_eev, "350 steps");
-        snprintf(buf, sizeof(buf), "%d %s", app_prefs_convert_temp(20), app_prefs_temp_unit_str());
-        lv_label_set_text(state.cooling_setpoint, buf);
-        snprintf(buf, sizeof(buf), "%d %s", app_prefs_convert_temp(45), app_prefs_temp_unit_str());
-        lv_label_set_text(state.heating_setpoint, buf);
-        snprintf(buf, sizeof(buf), "%d %s", app_prefs_convert_temp(50), app_prefs_temp_unit_str());
-        lv_label_set_text(state.hotwater_setpoint, buf);
-        return;
-    }
     
     if (!hp.connected) {
         // Disconnected - show placeholders

--- a/tests/device/test_system_screen.py
+++ b/tests/device/test_system_screen.py
@@ -5,27 +5,33 @@ Navigates to the system readings sub-screen and verifies that all sensor
 categories (compressor, electrical, pressures, expansion valves, setpoints)
 are displayed with correct labels and demo-mode values.
 
-Demo mode uses hardcoded values (not set_demo_fields registers).
+Demo-mode values come from the seeded shadow register image
+(initDemoState() in main/heatpump_controller.cpp), the same source the home
+screen renders from. They are asserted here so the two screens cannot drift
+apart again -- this screen used to carry its own hardcoded literals, which
+had diverged (850 vs 400 RPM, 350 vs 200 EEV steps, 20 vs 18 C cooling).
 """
 
 import pytest
 from device_client import DeviceClient
 
-# Demo mode hardcoded system readings (from heatpump_system_screen.cpp)
+# Demo system readings, derived from the initDemoState() seeds. Keep in step
+# with main/heatpump_controller.cpp; a mismatch here means the screen has
+# stopped rendering from getState().
 DEMO_READINGS = {
     # Compressor section
     "Frequency": "60 Hz",
-    "Fan Speed": "850 RPM",
+    "Fan Speed": "400 RPM",
     # Electrical section
     "AC Voltage": "230 V",
     "AC Current": "5 A",
-    "DC Voltage": "380.0 V",
+    "DC Voltage": "380 V",
     # Expansion valves section
-    "Primary EEV": "350 steps",
+    "Primary EEV": "200 steps",
 }
 
 DEMO_SETPOINTS = {
-    "Cooling": "20 °C",
+    "Cooling": "18 °C",
     "Heating": "45 °C",
     "Hot Water": "50 °C",
 }
@@ -163,3 +169,51 @@ class TestSystemSetpoints:
 
         assert _has_text_containing(device, label), \
             f"Setpoint label '{label}' not found on screen"
+
+
+# =========================================================================
+# Cross-screen consistency
+# =========================================================================
+
+class TestCrossScreenAgreement:
+    """The home and Status screens must never disagree about a reading.
+
+    Both render from arctic::getState(), so a divergence means one of them has
+    reintroduced a private data source. That is exactly the bug this guards:
+    the Status screen used to hold its own hardcoded demo literals and showed
+    850 RPM while the home screen showed the seeded 400.
+    """
+
+    # Distinct from every default (400 seeded, 450 FAN_MED) so a stale label
+    # cannot accidentally satisfy the assertion. reg2003 is raw x10, so this
+    # must stay a multiple of 10.
+    PROBE_RPM = 640
+
+    @pytest.fixture(autouse=True)
+    def _restore_seeded_fan(self, device: DeviceClient):
+        yield
+        device.set_demo_fields(fan_speed=400)
+
+    def test_fan_speed_agrees_between_home_and_status(self, device: DeviceClient):
+        device.set_demo_fields(fan_on=1, fan_speed=self.PROBE_RPM)
+        expected = f"{self.PROBE_RPM} RPM"
+
+        device.click(tag="nav_home")
+        assert device.wait_for_screen("main", timeout=5.0), \
+            f"Expected 'main' screen, got '{device.screen}'"
+        device.wait_until(
+            f"home screen fan shows {expected}",
+            lambda: (lambda w: w is not None and w.text is not None
+                     and expected in w.text)(device.find_widget(tag="perf_fan")),
+            timeout=5.0,
+        )
+        home = device.find_widget(tag="perf_fan")
+        assert expected in home.text, \
+            f"Home screen fan shows '{home.text}', expected '{expected}'"
+
+        _open_system(device)
+        _wait_for_text(device, expected)
+        assert _has_text_containing(device, expected), \
+            (f"Status screen does not show '{expected}' while the home screen "
+             f"does; the two screens have diverged.")
+

--- a/tests/device/test_system_screen.py
+++ b/tests/device/test_system_screen.py
@@ -44,6 +44,37 @@ SECTION_HEADERS = [
     "System",
 ]
 
+# The demo shadow image is shared process-wide, and other modules write to it
+# (test_main_screen leaves fan_speed=450 and ac_current=52 behind). The old
+# hardcoded literals made this screen immune to that; now that it renders from
+# getState() it honestly reflects those writes, so this module must establish
+# the state it asserts instead of assuming the pristine initDemoState() seeds.
+# Values must match DEMO_READINGS/DEMO_SETPOINTS above.
+DEMO_FIELD_SEEDS = {
+    "compressor_freq": 60,
+    "fan_on": 1,
+    "fan_speed": 400,
+    "ac_voltage": 230,
+    "ac_current": 5,
+    "dc_voltage": 380,
+    "primary_eev_opening": 200,
+    "cooling_setpoint": 18,
+    "heating_setpoint": 45,
+    "hot_water_setpoint": 50,
+}
+
+
+@pytest.fixture(autouse=True)
+def _seed_demo_readings(device: DeviceClient):
+    """Seed the asserted demo values before each test, and restore after.
+
+    Restoring on teardown keeps a probe value (see TestCrossScreenAgreement)
+    from leaking into modules that run later.
+    """
+    device.set_demo_fields(**DEMO_FIELD_SEEDS)
+    yield
+    device.set_demo_fields(**DEMO_FIELD_SEEDS)
+
 
 def _open_system(device: DeviceClient):
     """Navigate from main to the Status screen (System section)."""
@@ -188,11 +219,6 @@ class TestCrossScreenAgreement:
     # cannot accidentally satisfy the assertion. reg2003 is raw x10, so this
     # must stay a multiple of 10.
     PROBE_RPM = 640
-
-    @pytest.fixture(autouse=True)
-    def _restore_seeded_fan(self, device: DeviceClient):
-        yield
-        device.set_demo_fields(fan_speed=400)
 
     def test_fan_speed_agrees_between_home_and_status(self, device: DeviceClient):
         device.set_demo_fields(fan_on=1, fan_speed=self.PROBE_RPM)


### PR DESCRIPTION
## Symptom

The home screen showed **400 RPM** fan speed while **Status > System** showed **850 RPM**.

## Cause

Not a mismatch with the heat pump. In demo mode `initDemoState()` seeds the *full* shadow register image and marks the state connected, so `arctic::getState()` already returns the demo values -- which is what the home screen renders.

The Status screen carried a **second, independent block of hardcoded demo literals** that bypassed `hp` entirely. Two sources of truth, and they had drifted:

| reading | seeded (`initDemoState`) | Status literal |
| --- | --- | --- |
| fan speed | 400 RPM | **850 RPM** |
| primary EEV | 200 steps | **350 steps** |
| cooling setpoint | 18 °C | **20 °C** |

Every other value in that block was a latent instance of the same bug, so the block is **removed** rather than corrected. The screen now renders from `getState()` like every other screen.

This also drops a formatting divergence: the literal read `380.0 V`, while the real path formats DC voltage with `%.0f`. Demo and live now agree on `380 V`.

## Tests

`tests/device/test_system_screen.py` had encoded the drifted literals as expectations -- it was asserting the bug. Its values now derive from the seeds.

Added `TestCrossScreenAgreement`, which drives a distinctive fan speed (640 RPM, distinct from both defaults) and asserts the home and Status screens agree. That would have caught this originally, and guards the class of bug rather than the one symptom.

## Not included

The home screen renders a genuine 0 RPM as `--` (`heatpump_screen.cpp`), while Status renders `0 RPM`. That is a real inconsistency, but it is deliberate and explicitly tested (`test_fan_rpm_dashes_when_stopped`), so changing it is a UX decision rather than a bug fix and is left for a separate change.