### PR TITLE
test(web): wait for the settings panel to load before asserting its controls

### DIFF
--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -7,6 +7,13 @@ def open_settings(page: Page, section: str):
     page.locator('button[aria-label="Settings"]').click()
     page.locator(".settings-nav .nav-link", has_text=section).click()
     page.locator(".settings-nav .nav-link.active", has_text=section).wait_for()
+    # settingsPage() renders the nav immediately but shows only a spinner in
+    # the panel body until state.settingsLoaded flips (see main/web/index.html).
+    # Waiting on the nav link alone therefore races the async load, and the
+    # 5s default expect() timeout would intermittently fire against a panel
+    # that was still spinning rather than one that was genuinely missing.
+    page.locator(".settings-layout .spinner").wait_for(state="detached",
+                                                       timeout=30000)
 
 
 class TestSettingsWorkspace:


### PR DESCRIPTION
## Problem

`TestSettingsWorkspace::test_wifi_controls` fails intermittently. It failed on PR #222 and blocked `ci-gate`.

## Root cause

`open_settings()` waits only for the settings nav link to become `active`:

```python
page.locator(".settings-nav .nav-link.active", has_text=section).wait_for()
```

But `settingsPage()` in `main/web/index.html` renders the shell -- including the nav -- immediately, and shows **only a spinner** in the panel body until `state.settingsLoaded` flips:

```js
if (!state.settingsLoaded) {
  return settingsShell(`<section class="card"><div class="spinner"></div></section>`);
}
```

So the helper can return while the panel is still loading, and the 5s default `expect()` timeout races the async load. The WiFi panel is simply the one that most often loses that race.

This was confirmed from the `failure-screenshots` artifact on the PR #222 run: the device was healthy ("Heat pump online"), the WiFi tab was selected, and the right-hand panel was **still showing its loading spinner** -- i.e. the controls were not missing, they had not rendered yet.

## Fix

Wait for the panel spinner to detach before asserting. This fixes the race for **every** settings section, not just WiFi, since they all share the helper.

Note the spinner class appears in the settings layout only in the not-yet-loaded branch, so the wait cannot be satisfied early or hang on an unrelated spinner.
