### PR TITLE
fix(ui): show 0 RPM for a stopped fan instead of --

### DIFF
--- a/main/heatpump_screen.cpp
+++ b/main/heatpump_screen.cpp
@@ -879,12 +879,17 @@ void heatpump_screen_update(void) {
         lv_obj_set_style_text_color(state.perf_cop_value, COLOR_TEXT_DIM, LV_PART_MAIN);
     }
     
-    // Fan speed
-    if (hp.connected && hp.fan_speed > 0) {
+    // Fan speed. "--" is reserved for "no data" (disconnected); a genuine
+    // 0 RPM is data, so it renders as "0 RPM" dimmed to convey idle -- the
+    // same convention the power reading already uses ("0 W"), and the one the
+    // Status screen has always used.
+    if (hp.connected) {
         char fan_buf[16];
         snprintf(fan_buf, sizeof(fan_buf), "%u RPM", hp.fan_speed);
         lv_label_set_text(state.perf_fan_value, fan_buf);
-        lv_obj_set_style_text_color(state.perf_fan_value, COLOR_TEXT, LV_PART_MAIN);
+        lv_obj_set_style_text_color(state.perf_fan_value,
+                                    hp.fan_speed > 0 ? COLOR_TEXT : COLOR_TEXT_DIM,
+                                    LV_PART_MAIN);
     } else {
         lv_label_set_text(state.perf_fan_value, "--");
         lv_obj_set_style_text_color(state.perf_fan_value, COLOR_TEXT_DIM, LV_PART_MAIN);

--- a/tests/device/test_main_screen.py
+++ b/tests/device/test_main_screen.py
@@ -360,15 +360,22 @@ class TestPerformanceStrip:
         assert "450" in fan.text, f"Expected '450' in fan text, got '{fan.text}'"
         assert "RPM" in fan.text, f"Expected 'RPM' in fan text, got '{fan.text}'"
 
-    def test_fan_rpm_dashes_when_stopped(self, device: DeviceClient):
-        """Fan speed should show '--' when the fan is not running."""
+    def test_fan_rpm_zero_when_stopped(self, device: DeviceClient):
+        """A stopped fan shows '0 RPM', not '--'.
+
+        '--' means "no data" (disconnected or invalid); a genuine 0 RPM is
+        data, so conflating the two would lose information. This matches the
+        Status screen and the power reading, which already shows '0 W'.
+        """
         device.clear_all_faults()
         _running(device, fan_on=0, fan_speed=0)
-        _wait(device, lambda: _text_has(device, "perf_fan", "--"),
-              "perf_fan shows -- when stopped")
+        _wait(device, lambda: _text_has(device, "perf_fan", "0 RPM"),
+              "perf_fan shows 0 RPM when stopped")
         fan = device.find_widget(tag="perf_fan")
         assert fan is not None
-        assert "--" in fan.text, f"Expected '--' in fan text, got '{fan.text}'"
+        assert "0 RPM" in fan.text, f"Expected '0 RPM' in fan text, got '{fan.text}'"
+        assert "--" not in fan.text, \
+            f"'--' is reserved for no-data, got '{fan.text}'"
 
     def test_power_displayed(self, device: DeviceClient):
         """Power consumption should be displayed when compressor is running."""


### PR DESCRIPTION
## Problem

A genuine **0 RPM** rendered as `--` on the home screen:

```cpp
if (hp.connected && hp.fan_speed > 0) {   // 0 RPM falls through to "--"
```

`--` is used everywhere else to mean **"no data"** (disconnected or invalid), so this conflated *"the fan is stopped"* with *"we have no reading"* and threw away real information.

It also disagreed with the Status screen, which has always printed `0 RPM` for the same state — the two screens showed different things for one value.

Note the home screen already shows `0 W` for power, so `--`-for-zero was not even an internally consistent convention.

## Fix

`--` is now reserved for the disconnected case. A connected fan always shows its speed, dimmed (`COLOR_TEXT_DIM`) when zero so the idle state stays obvious at a glance.

## Test change — please read

`tests/device/test_main_screen.py::test_fan_rpm_dashes_when_stopped` explicitly asserted the dashes, i.e. the old behaviour was deliberate, not accidental. That test is renamed to `test_fan_rpm_zero_when_stopped` and now asserts `0 RPM` **and** that `--` is absent.

This is a visible UX change, so it is deliberately a small, self-contained commit that is easy to revert if you disagree with the convention.

## Verification

Built against **ESP-IDF v6.1** (the version CI uses) in the `espressif/idf:v6.1` container — clean build, 44% of the app partition free.
