### PR TITLE
feat(settings): add a web password reset to the touchscreen

### DIFF
--- a/main/auth_manager.cpp
+++ b/main/auth_manager.cpp
@@ -3,6 +3,7 @@
  * Authentication Manager - Session and API Key Implementation
  */
 #include "auth_manager.h"
+#include "setup_pairing.h"
 #include <esp_log.h>
 #include <esp_random.h>
 #include <nvs_flash.h>
@@ -164,24 +165,39 @@ static bool save_to_nvs(void)
     ESP_LOGI(TAG, "Saving to NVS: web_auth=%d, api_auth=%d", 
              state.web_auth_enabled ? 1 : 0, state.api_auth_enabled ? 1 : 0);
     
-    nvs_set_u8(nvs, NVS_KEY_WEB_ENABLED, state.web_auth_enabled ? 1 : 0);
-    nvs_set_u8(nvs, NVS_KEY_API_ENABLED, state.api_auth_enabled ? 1 : 0);
+    // Track every write: a silent failure here would leave the running config
+    // and the persisted config disagreeing, so a reboot would resurrect
+    // credentials the user believes they have already replaced.
+    esp_err_t first_err = ESP_OK;
+    auto record = [&first_err](const char* what, esp_err_t e) {
+        if (e != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to persist %s: %s", what, esp_err_to_name(e));
+            if (first_err == ESP_OK) first_err = e;
+        }
+    };
+
+    record("web_auth_enabled",
+           nvs_set_u8(nvs, NVS_KEY_WEB_ENABLED, state.web_auth_enabled ? 1 : 0));
+    record("api_auth_enabled",
+           nvs_set_u8(nvs, NVS_KEY_API_ENABLED, state.api_auth_enabled ? 1 : 0));
     
     if (state.username[0] != '\0') {
-        nvs_set_str(nvs, NVS_KEY_USERNAME, state.username);
+        record("username", nvs_set_str(nvs, NVS_KEY_USERNAME, state.username));
     }
     
     if (state.password_set) {
-        nvs_set_blob(nvs, NVS_KEY_PASS_HASH, state.password_hash, sizeof(state.password_hash));
+        record("password hash",
+               nvs_set_blob(nvs, NVS_KEY_PASS_HASH, state.password_hash,
+                            sizeof(state.password_hash)));
     }
     
     if (state.api_key[0] != '\0') {
-        nvs_set_str(nvs, NVS_KEY_API_KEY, state.api_key);
+        record("api key", nvs_set_str(nvs, NVS_KEY_API_KEY, state.api_key));
     }
     
-    nvs_commit(nvs);
+    record("commit", nvs_commit(nvs));
     nvs_close(nvs);
-    return true;
+    return first_err == ESP_OK;
 }
 
 static session_t* find_session(const char* token)
@@ -255,9 +271,9 @@ void auth_mgr_init(void)
     // This ensures we don't overwrite user-set credentials
     if (!loaded || (!state.password_set && state.username[0] == '\0')) {
         ESP_LOGI(TAG, "No credentials found in NVS, setting defaults (arctic/arctic)");
-        strncpy(state.username, "arctic", sizeof(state.username) - 1);
+        strncpy(state.username, AUTH_FACTORY_USERNAME, sizeof(state.username) - 1);
         state.username[sizeof(state.username) - 1] = '\0';
-        hash_password("arctic", state.password_hash);
+        hash_password(AUTH_FACTORY_PASSWORD, state.password_hash);
         state.password_set = true;
         save_to_nvs();
     } else {
@@ -343,6 +359,7 @@ bool auth_mgr_set_credentials(const char* username, const char* password)
         // Invalidate all sessions when credentials change for security
         auth_mgr_logout_all();
         ESP_LOGI(TAG, "All sessions invalidated due to credential change");
+        return saved;
     } else {
         ESP_LOGW(TAG, "No credential changes to save");
     }
@@ -353,13 +370,30 @@ bool auth_mgr_set_credentials(const char* username, const char* password)
 bool auth_mgr_credentials_change_required(void)
 {
     uint8_t default_hash[32];
-    hash_password("arctic", default_hash);
+    hash_password(AUTH_FACTORY_PASSWORD, default_hash);
     const bool factory_credentials =
         state.password_set &&
         constant_time_equal(
             state.password_hash, default_hash, sizeof(default_hash));
     mbedtls_platform_zeroize(default_hash, sizeof(default_hash));
     return factory_credentials;
+}
+
+bool auth_mgr_reset_credentials_to_factory(void)
+{
+    ESP_LOGW(TAG, "Resetting web credentials to the factory sign-in");
+
+    // Any setup/pairing window opened before the reset must not survive it.
+    // The same six-digit code authorises replacing the administrator
+    // credentials, so leaving one open would let a party who held access
+    // *before* the reset re-secure the controller afterwards.
+    setup_pairing_cancel();
+
+    // Routed through set_credentials() on purpose: it writes the hash,
+    // persists to NVS and invalidates every session, so this recovery path
+    // stays identical to an ordinary password change rather than becoming a
+    // second implementation that can drift.
+    return auth_mgr_set_credentials(AUTH_FACTORY_USERNAME, AUTH_FACTORY_PASSWORD);
 }
 
 const char* auth_mgr_get_username(void)

--- a/main/auth_manager.h
+++ b/main/auth_manager.h
@@ -25,6 +25,11 @@ extern "C" {
 #define AUTH_MAX_USERNAME_LEN 32
 // Maximum password length
 #define AUTH_MAX_PASSWORD_LEN 64
+// Factory sign-in. Shipping units boot with these, and
+// auth_mgr_credentials_change_required() reports true while they are in place
+// so the web UI forces a replacement before anything else can be done.
+#define AUTH_FACTORY_USERNAME "arctic"
+#define AUTH_FACTORY_PASSWORD "arctic"
 
 /**
  * @brief Initialize authentication manager
@@ -55,6 +60,28 @@ void auth_mgr_set_web_auth_enabled(bool enabled);
  * @return true on success
  */
 bool auth_mgr_set_credentials(const char* username, const char* password);
+
+/**
+ * @brief Restore the factory sign-in (arctic/arctic).
+ *
+ * Recovery path for a controller whose web password has been lost. Physical
+ * presence at the touchscreen is the authorization, exactly as it is for the
+ * factory-reset button that sits beside it in the settings menu -- so this
+ * deliberately adds no HTTP endpoint and does not relax the authentication on
+ * the existing credentials endpoint.
+ *
+ * Far less destructive than a factory reset: WiFi, Home Assistant pairing,
+ * TLS certificates and event history are all preserved. All sessions are
+ * invalidated, and auth_mgr_credentials_change_required() becomes true again,
+ * which re-arms the web "Secure this controller" flow. Any outstanding
+ * setup/pairing window is cancelled, since the code it issued would otherwise
+ * authorise re-securing the controller after the reset.
+ *
+ * @return true if the factory credentials were persisted to NVS. On false the
+ *         running configuration has changed but a reboot would restore the
+ *         previous (unknown) password, so the caller must not report success.
+ */
+bool auth_mgr_reset_credentials_to_factory(void);
 
 /**
  * @brief Check whether the factory credentials still need replacement.

--- a/main/i18n/i18n.cpp
+++ b/main/i18n/i18n.cpp
@@ -429,6 +429,14 @@ static const char* strings_en[STR_COUNT] = {
     [STR_FACTORY_RESET_CONFIRM] = "Erase & Reset",
     [STR_FACTORY_RESET_ERASING] = "Erasing...",
     [STR_FACTORY_RESET_START_FAILED] = "Unable to start reset. Please try again.",
+
+    [STR_SETTINGS_PASSWORD_RESET] = "Reset web password",
+    [STR_PASSWORD_RESET_TITLE] = "Reset web password",
+    [STR_PASSWORD_RESET_DESCRIPTION] = "Restores the factory sign-in (arctic / arctic).",
+    [STR_PASSWORD_RESET_WARNING] = "Anyone on this network can claim the controller until you set a new password. WiFi, Home Assistant pairing, certificates and history are kept.",
+    [STR_PASSWORD_RESET_CONFIRM] = "Reset password",
+    [STR_PASSWORD_RESET_DONE] = "Password reset. Sign in with arctic / arctic.",
+    [STR_PASSWORD_RESET_FAILED] = "Could not save the reset. Try again.",
 };
 
 // French strings
@@ -840,6 +848,14 @@ static const char* strings_fr[STR_COUNT] = {
     [STR_FACTORY_RESET_CONFIRM] = "Effacer et réinitialiser",
     [STR_FACTORY_RESET_ERASING] = "Effacement...",
     [STR_FACTORY_RESET_START_FAILED] = "Impossible de démarrer la réinitialisation. Réessayez.",
+
+    [STR_SETTINGS_PASSWORD_RESET] = "Réinitialiser le mot de passe web",
+    [STR_PASSWORD_RESET_TITLE] = "Réinitialiser le mot de passe web",
+    [STR_PASSWORD_RESET_DESCRIPTION] = "Rétablit la connexion d'usine (arctic / arctic).",
+    [STR_PASSWORD_RESET_WARNING] = "Toute personne sur ce réseau peut s'approprier le contrôleur tant qu'aucun nouveau mot de passe n'est défini. Le WiFi, l'association Home Assistant, les certificats et l'historique sont conservés.",
+    [STR_PASSWORD_RESET_CONFIRM] = "Réinitialiser",
+    [STR_PASSWORD_RESET_DONE] = "Mot de passe réinitialisé. Connectez-vous avec arctic / arctic.",
+    [STR_PASSWORD_RESET_FAILED] = "Impossible d'enregistrer la réinitialisation. Réessayez.",
 };
 
 // Spanish strings
@@ -1251,6 +1267,14 @@ static const char* strings_es[STR_COUNT] = {
     [STR_FACTORY_RESET_CONFIRM] = "Borrar y restablecer",
     [STR_FACTORY_RESET_ERASING] = "Borrando...",
     [STR_FACTORY_RESET_START_FAILED] = "No se pudo iniciar el restablecimiento. Inténtelo de nuevo.",
+
+    [STR_SETTINGS_PASSWORD_RESET] = "Restablecer la contraseña web",
+    [STR_PASSWORD_RESET_TITLE] = "Restablecer la contraseña web",
+    [STR_PASSWORD_RESET_DESCRIPTION] = "Restaura el inicio de sesión de fábrica (arctic / arctic).",
+    [STR_PASSWORD_RESET_WARNING] = "Cualquier persona en esta red puede reclamar el controlador hasta que establezca una nueva contraseña. Se conservan el WiFi, la vinculación con Home Assistant, los certificados y el historial.",
+    [STR_PASSWORD_RESET_CONFIRM] = "Restablecer",
+    [STR_PASSWORD_RESET_DONE] = "Contraseña restablecida. Inicie sesión con arctic / arctic.",
+    [STR_PASSWORD_RESET_FAILED] = "No se pudo guardar el restablecimiento. Inténtelo de nuevo.",
 };
 
 // Language names in their own language (native names)

--- a/main/i18n/strings.h
+++ b/main/i18n/strings.h
@@ -466,6 +466,18 @@ typedef enum {
     STR_FACTORY_RESET_START_FAILED,
 
     // ========================================================================
+    // Web password reset (far less destructive than a factory reset: keeps
+    // WiFi, Home Assistant pairing, certificates and history)
+    // ========================================================================
+    STR_SETTINGS_PASSWORD_RESET,
+    STR_PASSWORD_RESET_TITLE,
+    STR_PASSWORD_RESET_DESCRIPTION,
+    STR_PASSWORD_RESET_WARNING,
+    STR_PASSWORD_RESET_CONFIRM,
+    STR_PASSWORD_RESET_DONE,
+    STR_PASSWORD_RESET_FAILED,
+
+    // ========================================================================
     // Must be last - used for array sizing
     // ========================================================================
     STR_COUNT

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -69,9 +69,9 @@ void app_navigation_return_home(void)
         heatpump_errors_hide();
     }
 
-    // Message boxes use the top layer rather than the active screen.
-    lv_obj_clean(lv_layer_top());
-
+    // Owners of top-layer dialogs get to tear their own down first: they hold
+    // raw pointers to those objects, so sweeping the top layer before they run
+    // would leave them deleting dangling pointers.
     if (settings_menu_is_visible()) {
         settings_menu_force_close(main_screen);
     } else {
@@ -84,6 +84,9 @@ void app_navigation_return_home(void)
             lv_screen_load_anim(main_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);
         }
     }
+
+    // Anything left on the top layer has no owner to close it.
+    lv_obj_clean(lv_layer_top());
 
     tab_shell_select(NAV_TAB_HOME);
 }

--- a/main/settings/settings_menu.cpp
+++ b/main/settings/settings_menu.cpp
@@ -20,6 +20,7 @@
 #include "../app_preferences.h"
 #include "../status_bar.h"
 #include "../factory_reset.h"
+#include "../auth_manager.h"
 #include "../system_restart.h"
 #include "../heatpump_screen.h"
 #include "i18n/i18n.h"
@@ -89,6 +90,12 @@ typedef struct {
     lv_obj_t* factory_reset_overlay;
     lv_obj_t* factory_reset_confirm_btn;
     lv_obj_t* factory_reset_confirm_label;
+
+    // Web password reset confirmation overlay
+    lv_obj_t* password_reset_overlay;
+    lv_obj_t* password_reset_confirm_btn;
+    lv_obj_t* password_reset_confirm_label;
+    lv_obj_t* password_reset_cancel_label;
     
     // Track which sub-screen is active
     settings_item_t active_sub_screen;
@@ -115,6 +122,10 @@ static void reboot_cancel_cb(lv_event_t* e);
 static void show_factory_reset_confirmation(void);
 static void factory_reset_confirm_cb(lv_event_t* e);
 static void factory_reset_cancel_cb(lv_event_t* e);
+static void show_password_reset_confirmation(void);
+static void password_reset_confirm_cb(lv_event_t* e);
+static void password_reset_cancel_cb(lv_event_t* e);
+static void dismiss_password_reset_overlay(void);
 
 // ============================================================================
 // Helper Functions
@@ -401,6 +412,8 @@ static void row_click_cb(lv_event_t* e)
         web_screen_create(&web_cfg);
         state.sub_screen_active = true;
         state.active_sub_screen = SETTINGS_WEB;
+    } else if (strcmp(tag, "settings_password_reset") == 0) {
+        show_password_reset_confirmation();
     } else if (strcmp(tag, "settings_factory_reset") == 0) {
         show_factory_reset_confirmation();
     }
@@ -470,6 +483,86 @@ static void show_factory_reset_confirmation(void)
         factory_reset_confirm_cb);
     state.factory_reset_confirm_btn = confirm_btn;
     state.factory_reset_confirm_label =
+        confirm_btn ? lv_obj_get_child(confirm_btn, 0) : NULL;
+}
+
+static void dismiss_password_reset_overlay(void)
+{
+    if (state.password_reset_overlay) {
+        lv_obj_delete(state.password_reset_overlay);
+        state.password_reset_overlay = NULL;
+        state.password_reset_confirm_btn = NULL;
+        state.password_reset_confirm_label = NULL;
+        state.password_reset_cancel_label = NULL;
+    }
+}
+
+static void password_reset_cancel_cb(lv_event_t* e)
+{
+    (void)e;
+    dismiss_password_reset_overlay();
+}
+
+static void password_reset_confirm_cb(lv_event_t* e)
+{
+    (void)e;
+    if (!state.password_reset_confirm_btn) return;
+
+    // Physical presence at the touchscreen is the authorization, exactly as
+    // it is for the factory-reset button above.
+    const bool persisted = auth_mgr_reset_credentials_to_factory();
+
+    if (!persisted) {
+        // The running config now accepts the factory sign-in but NVS rejected
+        // the write, so a reboot would resurrect the unknown password. Leave
+        // the button live so the user can retry rather than walk away
+        // believing the controller is recovered.
+        if (state.password_reset_confirm_label) {
+            lv_label_set_text(state.password_reset_confirm_label,
+                              i18n_get(STR_PASSWORD_RESET_FAILED));
+        }
+        return;
+    }
+
+    lv_obj_add_state(state.password_reset_confirm_btn, LV_STATE_DISABLED);
+    if (state.password_reset_confirm_label) {
+        lv_label_set_text(state.password_reset_confirm_label,
+                          i18n_get(STR_PASSWORD_RESET_DONE));
+    }
+    // The reset has already happened, so "Cancel" would be a lie -- the button
+    // now only dismisses the dialog.
+    if (state.password_reset_cancel_label) {
+        lv_label_set_text(state.password_reset_cancel_label, i18n_get(STR_CLOSE));
+    }
+}
+
+static void show_password_reset_confirmation(void)
+{
+    if (!state.screen) return;
+    dismiss_password_reset_overlay();
+
+    state.password_reset_overlay = ui_dialog_create_ex(
+        i18n_get(STR_PASSWORD_RESET_TITLE),
+        i18n_get(STR_PASSWORD_RESET_DESCRIPTION),
+        UI_DIALOG_LAYOUT_SHEET, "password_reset_overlay", "password_reset_panel");
+    if (!state.password_reset_overlay) return;
+
+    ui_dialog_set_title_color(state.password_reset_overlay, lv_color_hex(0xff5a5f));
+    ui_dialog_add_text(state.password_reset_overlay,
+                       i18n_get(STR_PASSWORD_RESET_WARNING));
+
+    lv_obj_t* cancel_btn = ui_dialog_add_action(
+        state.password_reset_overlay, i18n_get(STR_CANCEL),
+        "password_reset_cancel", UI_DIALOG_ACTION_SECONDARY,
+        password_reset_cancel_cb);
+    state.password_reset_cancel_label =
+        cancel_btn ? lv_obj_get_child(cancel_btn, 0) : NULL;
+    lv_obj_t* confirm_btn = ui_dialog_add_action(
+        state.password_reset_overlay, i18n_get(STR_PASSWORD_RESET_CONFIRM),
+        "password_reset_confirm", UI_DIALOG_ACTION_DANGER,
+        password_reset_confirm_cb);
+    state.password_reset_confirm_btn = confirm_btn;
+    state.password_reset_confirm_label =
         confirm_btn ? lv_obj_get_child(confirm_btn, 0) : NULL;
 }
 
@@ -635,6 +728,11 @@ static void create_menu_list(void)
         state.temp_unit_switch = sw;
     }
 
+    lv_obj_t* password_row = create_settings_row(
+        state.list_container, LV_SYMBOL_KEYBOARD,
+        i18n_get(STR_SETTINGS_PASSWORD_RESET), "settings_password_reset");
+    (void)password_row;
+
     lv_obj_t* reset_row = create_settings_row(
         state.list_container, LV_SYMBOL_WARNING,
         i18n_get(STR_SETTINGS_FACTORY_RESET), "settings_factory_reset");
@@ -724,6 +822,7 @@ void settings_menu_force_close(lv_obj_t* return_screen)
     // screen no longer takes them with it.
     dismiss_reboot_overlay();
     dismiss_factory_reset_overlay();
+    dismiss_password_reset_overlay();
 
     // A settings sub-screen leaves the settings root allocated but hidden.
     if (state.screen && state.screen != active_screen) {
@@ -737,6 +836,10 @@ void settings_menu_force_close(lv_obj_t* return_screen)
     state.factory_reset_overlay = NULL;
     state.factory_reset_confirm_btn = NULL;
     state.factory_reset_confirm_label = NULL;
+    state.password_reset_overlay = NULL;
+    state.password_reset_confirm_btn = NULL;
+    state.password_reset_confirm_label = NULL;
+    state.password_reset_cancel_label = NULL;
 
     if (return_screen && active_screen != return_screen) {
         lv_screen_load_anim(return_screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, true);

--- a/tests/api/test_ha_security_contract.py
+++ b/tests/api/test_ha_security_contract.py
@@ -85,9 +85,19 @@ def test_factory_credential_replacement_requires_physical_tls_flow() -> None:
     pairing = (ROOT / "main" / "setup_pairing.cpp").read_text(
         encoding="utf-8"
     )
+    auth_header = (ROOT / "main" / "auth_manager.h").read_text(
+        encoding="utf-8"
+    )
 
-    assert 'hash_password("arctic", default_hash)' in auth
+    # The factory sign-in is detected by hashing the factory password, never
+    # by comparing the username. The password itself now lives in a single
+    # named constant, so pin the constant's value as well -- otherwise the
+    # indirection would let the factory password change without this contract
+    # noticing.
+    assert '#define AUTH_FACTORY_PASSWORD "arctic"' in auth_header
+    assert "hash_password(AUTH_FACTORY_PASSWORD, default_hash)" in auth
     assert 'strcmp(state.username, "arctic")' not in auth
+    assert "strcmp(state.username, AUTH_FACTORY_USERNAME)" not in auth
     assert "setup_pairing_authorize(code)" in api
     assert "persistent device identity" in api
     assert "Failed to start mandatory HTTPS server" in api

--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -160,7 +160,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`test_time_format.py`](test_time_format.py) | 5 | 12h/24h toggle, status bar display |
 | [`test_wifi.py`](test_wifi.py) | 4 | Password dialog, show/hide toggle, open network bypass |
 | [`test_demo_mode.py`](test_demo_mode.py) | 3 | Demo mode toggle, reboot confirmation panel, cancel revert |
-| [`test_settings_menu.py`](test_settings_menu.py) | 3 | Open/close settings, close button |
+| [`test_settings_menu.py`](test_settings_menu.py) | 6 | Open/close settings, close button, web password reset |
 | [`test_display_brightness.py`](test_display_brightness.py) | 3 | Brightness slider control and label |
 | [`test_temperature_unit.py`](test_temperature_unit.py) | 2 | °C/°F toggle and preferences |
 | [`test_error_history_duration.py`](test_error_history_duration.py) | 1 | Error history duration format ("3s") |

--- a/tests/device/test_settings_menu.py
+++ b/tests/device/test_settings_menu.py
@@ -5,6 +5,11 @@ Verifies that pressing the settings button opens the settings menu
 and that the settings screen contains the expected UI elements.
 """
 
+import os
+
+import pytest
+import requests
+
 from device_client import DeviceClient
 
 
@@ -72,3 +77,135 @@ def test_factory_reset_requires_confirmation_and_can_be_cancelled(
     )
     assert not device.has_widget(tag="factory_reset_overlay")
     assert device.screen == "settings"
+
+
+# =========================================================================
+# Web password reset
+#
+# Recovery path for a lost web password. Physical presence at the
+# touchscreen is the authorization, exactly as it is for the factory reset
+# above -- there is deliberately no HTTP endpoint for this.
+# =========================================================================
+
+FACTORY_USERNAME = "arctic"
+FACTORY_PASSWORD = "arctic"
+
+
+def _login_succeeds(base_url: str, username: str, password: str) -> bool:
+    """Attempt a fresh web login, isolated from the client's own session."""
+    session = requests.Session()
+    session.verify = False
+    try:
+        r = session.post(
+            f"{base_url}/login",
+            json={"username": username, "password": password},
+            timeout=10,
+        )
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
+    finally:
+        session.close()
+
+
+def _open_password_reset_dialog(device: DeviceClient):
+    device.click(tag="settings")
+    assert device.wait_for_screen("settings", timeout=3.0)
+
+    device.click(tag="settings_password_reset")
+    assert device.wait_for_widget(tag="password_reset_overlay", timeout=5.0)
+
+
+def test_password_reset_requires_confirmation_and_can_be_cancelled(
+    device: DeviceClient,
+):
+    """The reset is destructive, so it never runs on the first tap."""
+    _open_password_reset_dialog(device)
+
+    assert device.has_widget(tag="password_reset_panel")
+    assert device.has_widget(tag="password_reset_confirm")
+    assert device.has_widget(tag="password_reset_cancel")
+
+    device.click(tag="password_reset_cancel")
+    device.wait_until(
+        "password reset overlay dismissed",
+        lambda: not device.has_widget(tag="password_reset_overlay"),
+        timeout=5.0,
+    )
+    assert not device.has_widget(tag="password_reset_overlay")
+    assert device.screen == "settings"
+
+
+@pytest.fixture
+def restore_test_credentials(device: DeviceClient):
+    """Put the suite's credentials back after a destructive auth test.
+
+    Skips rather than running unrestorable damage: without a known password
+    to restore, confirming the reset would leave the controller on the
+    factory sign-in for every later suite.
+    """
+    username = os.environ.get("ARCTIC_USERNAME", FACTORY_USERNAME)
+    password = os.environ.get("ARCTIC_PASSWORD", "")
+    if not password or password == FACTORY_PASSWORD:
+        pytest.skip(
+            "ARCTIC_PASSWORD is not provisioned, so the web password could "
+            "not be restored after the reset"
+        )
+
+    # Prove the restore path works *before* breaking anything. Writing the
+    # credentials the controller already has is a no-op, but a non-200 here
+    # means the teardown below would have failed too -- and by then the
+    # controller would already be on the factory sign-in.
+    preflight = device.session.post(
+        f"{device.base_url}/api/test/credentials",
+        json={"username": username, "password": password},
+        timeout=device.timeout,
+    )
+    if preflight.status_code != 200:
+        pytest.skip(
+            f"/api/test/credentials is not usable (HTTP "
+            f"{preflight.status_code}), so the reset could not be undone"
+        )
+
+    yield
+
+    r = device.session.post(
+        f"{device.base_url}/api/test/credentials",
+        json={"username": username, "password": password},
+        timeout=device.timeout,
+    )
+    assert r.status_code == 200, (
+        f"Could not restore test credentials (HTTP {r.status_code}); the "
+        f"controller may be left on the factory sign-in"
+    )
+
+
+def test_password_reset_restores_the_factory_signin(
+    device: DeviceClient, restore_test_credentials
+):
+    """Confirming the reset really does restore arctic/arctic.
+
+    This is the whole point of the feature: a controller whose web password
+    has been lost is recoverable from the touchscreen, without the factory
+    reset that would also erase WiFi, Home Assistant pairing, certificates
+    and history.
+    """
+    assert not _login_succeeds(device.base_url, FACTORY_USERNAME, FACTORY_PASSWORD), \
+        "Factory sign-in already works; the test cannot prove the reset did it"
+
+    _open_password_reset_dialog(device)
+    device.click(tag="password_reset_confirm")
+
+    device.wait_until(
+        "factory sign-in accepted after reset",
+        lambda: _login_succeeds(
+            device.base_url, FACTORY_USERNAME, FACTORY_PASSWORD),
+        timeout=10.0,
+    )
+
+    device.click(tag="password_reset_cancel")
+    device.wait_until(
+        "password reset overlay dismissed",
+        lambda: not device.has_widget(tag="password_reset_overlay"),
+        timeout=5.0,
+    )


### PR DESCRIPTION
## Why

Recovering a controller whose web password has been lost currently means a **full factory reset** — which also erases WiFi, the Home Assistant pairing, TLS certificates and event history — or a USB reflash. This is exactly what happened to the dev controller on `192.168.1.21`.

This adds a much less destructive recovery path: **Reset web password** in the settings menu (directly above Factory Reset) restores the factory sign-in `arctic / arctic` and leaves everything else intact.

## Security model

Physical presence at the touchscreen is the authorization — identical to the factory-reset button beside it. Deliberately:

- **no new HTTP endpoint**, and no relaxation of the auth on the existing credentials endpoint;
- the **Home Assistant integration token is left alone**, so an existing HA pairing survives the recovery;
- after the reset `auth_mgr_credentials_change_required()` becomes true again, which re-arms the web *"Secure this controller"* flow and blocks API-key access until a new password is set.

I traced the recovery flow end-to-end to confirm the reset cannot brick remote access: `/login` accepts the factory credentials, `/api/auth/status` is public, and `/api/auth/credentials` gates on the factory-login **session** (not `check_api_auth()`), so the change-credentials path stays reachable while a change is required.

## Three defects fixed alongside

Each of these is directly load-bearing for the new dialog, so they are in the same PR rather than stacked behind another ~20-minute device run.

1. **A pairing code could outlive the reset.** The same six-digit setup code authorises replacing the administrator credentials, so a code issued *before* the reset would let a party who held access beforehand re-secure the controller afterwards. The reset now calls `setup_pairing_cancel()`.

2. **`save_to_nvs()` ignored every NVS result** and returned `true` whenever the namespace opened — so a failed write was reported as a successful credential change and would silently revert on reboot. It now propagates failure through `auth_mgr_set_credentials()`, and the dialog reports it instead of claiming a reset that would not survive a restart.

3. **Dangling deletes on display idle.** `app_navigation_return_home()` swept `lv_obj_clean(lv_layer_top())` *before* `settings_menu_force_close()`, whose `dismiss_*_overlay()` calls then deleted already-freed objects. This already affected the reboot and factory-reset dialogs. Owners now tear their own dialogs down first and the sweep collects the remainder.

## Tests

`tests/device/test_settings_menu.py` gains:

- `test_password_reset_requires_confirmation_and_can_be_cancelled` — safe; proves the reset never fires on the first tap.
- `test_password_reset_restores_the_factory_signin` — **destructive**: it really does reset the web password on the shared controller.

⚠️ **Reviewer note on the destructive test.** It self-restores via the `restore_test_credentials` fixture, which:

- **skips** unless `ARCTIC_PASSWORD` is provisioned and non-factory, so it can never do damage it cannot undo;
- **pre-flights `/api/test/credentials` before the destructive action**, writing back the credentials the controller already has. A non-200 there skips the test — otherwise the teardown would have failed too, and by then the controller would already be sitting on the factory sign-in;
- restores in teardown, which runs before the next test's setup.

CI also re-provisions credentials at the start of each device-test stage, so the blast radius is contained even in the worst case.

## Verification

- Built clean against **ESP-IDF v6.1** (the CI version) in the `espressif/idf:v6.1` container — `0x23a220` bytes, 44 % of the app partition free.
- i18n strings added for **EN, FR and ES**.
- `tests/device/README.md` test count updated.
