### PR TITLE
Move the one-time code instructions behind an info icon

### DIFF
--- a/main/web/index.html
+++ b/main/web/index.html
@@ -242,6 +242,36 @@
     .hist-nav { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
     .field { display: grid; gap: 6px; margin-bottom: 14px; }
     .field label { color: var(--cp-text-muted); font-size: 13px; font-weight: 600; }
+    /* Inline help disclosure. Toggled by click rather than hover so the same
+       control works with a mouse, a keyboard and a touchscreen -- hover has no
+       equivalent on a phone. The panel sits in normal flow instead of floating,
+       which keeps it from being clipped or pushed off-screen on narrow
+       viewports. */
+    .field-label { display: flex; align-items: center; gap: 6px; }
+    .info-btn {
+      flex: none; width: 18px; height: 18px; padding: 0; line-height: 1;
+      border-radius: 50%; border: 1px solid var(--cp-border-strong);
+      background: transparent; color: var(--cp-text-muted);
+      font-size: 12px; font-weight: 700; font-family: inherit;
+      cursor: pointer; display: inline-flex; align-items: center;
+      justify-content: center;
+    }
+    .info-btn:hover { color: var(--cp-text); border-color: var(--cp-accent); }
+    .info-btn:focus-visible { outline: none; border-color: var(--cp-accent); box-shadow: 0 0 0 3px var(--cp-accent-soft); }
+    .info-btn[aria-expanded="true"] { background: var(--cp-accent); border-color: var(--cp-accent); color: var(--cp-accent-fg); }
+    /* Touch targets must stay finger-sized even though the glyph is small. */
+    @media (pointer: coarse) {
+      .info-btn { width: 28px; height: 28px; font-size: 14px; }
+    }
+    .info-panel {
+      margin: 0 0 8px; padding: 10px 12px; border-radius: 10px;
+      background: var(--cp-surface-soft);
+      border: 1px solid var(--cp-border-strong);
+      color: var(--cp-text-soft); font-size: 13px; line-height: 1.5;
+    }
+    .info-panel[hidden] { display: none; }
+    .info-panel ol { margin: 0; padding-left: 18px; }
+    .info-panel li + li { margin-top: 4px; }
     input, select, textarea {
       width: 100%; border: 1px solid var(--cp-border-strong);
       background: var(--cp-surface); color: var(--cp-text);
@@ -932,9 +962,21 @@
       return `<div class="login"><form class="card login-card" data-form="change-credentials">
         <div class="brand" style="margin-bottom:20px"><div class="brand-mark">A</div><span>Arctic Controller</span></div>
         <h1>${recovering ? "Reset your password" : "Secure this controller"}</h1>
-        <p class="metric-sub">On the controller's screen open Settings → Security, tap Show One-Time Code, and enter the six-digit code below${recovering ? " to choose a new username and password." : " to set your own password."}</p>
+        <p class="metric-sub">Enter the six-digit code from the controller's screen${recovering ? " to choose a new username and password." : " to set your own password."}</p>
         ${state.auth.recoveryError ? `<div class="notice bad" style="margin:0 0 16px">${esc(state.auth.recoveryError)}</div>` : ""}
-        <div class="field"><label>One-time code</label><input name="pairing_code" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" required></div>
+        <div class="field">
+          <div class="field-label"><label for="pairing_code">One-time code</label>
+            <button class="info-btn" type="button" data-action="toggle-code-help" aria-expanded="false" aria-controls="code-help" aria-label="Where do I find the one-time code?">i</button></div>
+          <div class="info-panel" id="code-help" hidden>
+            <ol>
+              <li>Go to the controller itself and wake its screen.</li>
+              <li>Open <strong>Settings</strong>, then <strong>Security</strong>.</li>
+              <li>Tap <strong>Show One-Time Code</strong> and type the six digits here.</li>
+            </ol>
+            <p style="margin:8px 0 0">The code is only shown on the controller, so you have to be standing at it. It expires after five minutes &mdash; if it runs out, just tap the button again for a fresh one.</p>
+          </div>
+          <input id="pairing_code" name="pairing_code" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" required>
+        </div>
         <div class="field"><label>Username</label><input name="username" value="arctic" autocomplete="username" required></div>
         <div class="field"><label>New password</label><input name="password" type="password" minlength="8" autocomplete="new-password" required></div>
         <div class="field"><label>Confirm password</label><input name="confirm_password" type="password" minlength="8" autocomplete="new-password" required></div>
@@ -1384,6 +1426,19 @@
         const meta = n && (NOTIF_META[n.key] || NOTIF_META.unknown);
         if (meta && meta.route) await navigate(meta.route[0], meta.route[1]);
         else render();
+        return;
+      }
+      if (action === "toggle-code-help") {
+        // Toggled directly in the DOM rather than through render(): a
+        // re-render rebuilds the form and would discard whatever the user has
+        // already typed, and opening a help panel has no business clearing a
+        // half-entered password.
+        const panel = $("#" + el.getAttribute("aria-controls"));
+        if (panel) {
+          const willOpen = panel.hidden;
+          panel.hidden = !willOpen;
+          el.setAttribute("aria-expanded", willOpen ? "true" : "false");
+        }
         return;
       }
       if (action === "forgot-password") {

--- a/tests/web/README.md
+++ b/tests/web/README.md
@@ -33,7 +33,7 @@ pytest tests/web/ -v --headed
 | File | Tests | Coverage |
 |------|-------|----------|
 | `test_login.py` | 4 | Login form, success, failure, nav hidden before login |
-| `test_password_recovery.py` | 4 | Forgot password, cancel, bad code rejected, recovery with a one-time code |
+| `test_password_recovery.py` | 7 | Forgot password, one-time code help disclosure (desktop + phone), cancel, bad code rejected, recovery with a one-time code |
 | `test_change_password.py` | 2 | Credentials form, change password then sign in again |
 | `test_dashboard.py` | 9 | Hero card, dots, perf strip, panels, polling |
 | `test_navigation.py` | 9 | 6-page nav, logs page, events page, params page |
@@ -43,7 +43,7 @@ pytest tests/web/ -v --headed
 | `test_i18n.py` | 3 | Language selector, EN→FR→ES switching, persistence |
 | `test_tls.py` | 3 | TLS auth prerequisite, cert install/delete, PEM validation |
 
-**Total: 49 tests**
+**Total: 52 tests**
 
 ## Architecture
 

--- a/tests/web/test_password_recovery.py
+++ b/tests/web/test_password_recovery.py
@@ -66,12 +66,96 @@ def cleanup():
     restore_password()
 
 
+@pytest.fixture
+def mobile_page(playwright, browser, base_url):
+    """A page in a touch-emulating phone context.
+
+    Uses a real device descriptor rather than just a small viewport so that
+    `(pointer: coarse)` matches and `tap()` is available -- a narrow desktop
+    window would silently keep the fine-pointer styling and prove nothing
+    about the phone experience.
+    """
+    from conftest import _enable_web_auth, _ensure_auth_disabled
+
+    _enable_web_auth(base_url)
+    context = browser.new_context(
+        **playwright.devices["iPhone 13"], ignore_https_errors=True
+    )
+    page = context.new_page()
+    page.goto(base_url, wait_until="domcontentloaded")
+    page.wait_for_selector(".login-card", timeout=10000)
+    yield page
+    context.close()
+    _ensure_auth_disabled(base_url)
+
+
 class TestPasswordRecovery:
     def test_forgot_password_opens_the_recovery_form(self, login_page: Page):
         login_page.locator('[data-action="forgot-password"]').click()
         form = login_page.locator('form[data-form="change-credentials"]')
         expect(form).to_be_visible()
         expect(form.locator('input[name="pairing_code"]')).to_be_visible()
+
+    def test_code_help_is_collapsed_until_the_info_icon_is_tapped(
+        self, login_page: Page
+    ):
+        """The instructions live behind (i) so the form stays short on a phone."""
+        login_page.locator('[data-action="forgot-password"]').click()
+        info = login_page.locator('[data-action="toggle-code-help"]')
+        panel = login_page.locator("#code-help")
+
+        expect(info).to_be_visible()
+        expect(panel).to_be_hidden()
+        expect(info).to_have_attribute("aria-expanded", "false")
+
+        info.click()
+        expect(panel).to_be_visible()
+        expect(info).to_have_attribute("aria-expanded", "true")
+        expect(panel).to_contain_text("Show One-Time Code")
+
+        info.click()
+        expect(panel).to_be_hidden()
+        expect(info).to_have_attribute("aria-expanded", "false")
+
+    def test_code_help_does_not_discard_what_was_already_typed(
+        self, login_page: Page
+    ):
+        """Toggling help must not go through render(), which rebuilds the form."""
+        login_page.locator('[data-action="forgot-password"]').click()
+        form = login_page.locator('form[data-form="change-credentials"]')
+        form.locator('input[name="password"]').fill("part-way-through")
+
+        login_page.locator('[data-action="toggle-code-help"]').click()
+        expect(login_page.locator("#code-help")).to_be_visible()
+        expect(form.locator('input[name="password"]')).to_have_value(
+            "part-way-through"
+        )
+
+    def test_code_help_is_tappable_on_a_phone_viewport(self, mobile_page: Page):
+        """A phone has no hover, so the control must work by tap alone.
+
+        This runs in a real touch-emulating context rather than just a narrow
+        window, so the `(pointer: coarse)` rule that enlarges the icon to a
+        finger-sized target is actually exercised.
+        """
+        mobile_page.locator('[data-action="forgot-password"]').click()
+
+        info = mobile_page.locator('[data-action="toggle-code-help"]')
+        box = info.bounding_box()
+        assert box is not None, "info icon is not laid out"
+        assert box["width"] >= 24 and box["height"] >= 24, (
+            f"touch target is only {box['width']}x{box['height']}"
+        )
+
+        info.tap()
+        expect(mobile_page.locator("#code-help")).to_be_visible()
+
+        # The panel must not force the page sideways on a narrow screen.
+        overflow = mobile_page.evaluate(
+            "() => document.documentElement.scrollWidth"
+            " - document.documentElement.clientWidth"
+        )
+        assert overflow <= 1, f"page overflows horizontally by {overflow}px"
 
     def test_cancel_returns_to_sign_in(self, login_page: Page):
         login_page.locator('[data-action="forgot-password"]').click()


### PR DESCRIPTION
## What

Collapses the one-time code instructions on the password recovery form into an **(i) info disclosure** next to the field label.

Before, the form led with three lines of prose about where to find the code, pushing the actual inputs down the page — worst on a phone, where it was most of the first screen. Most people opening this form are standing at the controller already and just need somewhere to type six digits.

## Web *and* mobile

The control is **click-toggled, not hover-toggled**. A hover tooltip has no equivalent on a touchscreen and would be unreachable on a phone.

- Real `<button>` with `aria-expanded` / `aria-controls`, so keyboard and screen-reader users get it too
- `@media (pointer: coarse)` grows the 18px glyph to a **28px finger target** on touch devices
- The panel sits in **normal flow rather than floating**, so it can't be clipped or pushed off-screen on a narrow viewport

## Notable implementation detail

The panel is toggled **directly in the DOM, not through `render()`**. `render()` rebuilds the form from state, so routing this through it would silently discard a half-typed password just because someone tapped the help icon. There's a test for exactly that.

Also sets `autocomplete="one-time-code"` and gives the input an `id` so the label is properly associated.

## Tests

Three new web tests in `tests/web/test_password_recovery.py` (7 total in the file):

| Test | Covers |
|---|---|
| `test_code_help_is_collapsed_until_the_info_icon_is_tapped` | Starts collapsed, toggles both ways, `aria-expanded` tracks state |
| `test_code_help_does_not_discard_what_was_already_typed` | The render() hazard above |
| `test_code_help_is_tappable_on_a_phone_viewport` | Runs in a real touch-emulating iPhone context so `(pointer: coarse)` actually applies; asserts a ≥24px target and no horizontal overflow |

The phone test uses a device descriptor rather than just a narrow window — a small desktop viewport would keep fine-pointer styling and prove nothing about the phone experience.

Built clean against `espressif/idf:v6.1`; 100 hostside tests pass.
