### PR TITLE
Stop cosmetic publishing failures from blocking merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,29 @@ name: CI
 # create-release.yml resolves release attestations via
 # `actions/workflows/device-tests.yml/runs?event=push`, and a workflow_call
 # invocation produces no top-level run entry for that query to find.
+#
+# OTHER WAYS A PR STALLS WITH NOTHING VISIBLY WRONG
+#
+# The paths-filter trap above is not the only way to end up blocked by a check
+# that will never report. Two more were observed on PRs #231 and #232:
+#
+#   * CONFLICTED HEAD - a `pull_request` workflow needs a mergeable ref to
+#     build, so a PR that conflicts with main (`mergeStateStatus: DIRTY`)
+#     schedules NO runs at all and `statusCheckRollup` comes back EMPTY.
+#     `ci-gate` never reports and the PR is unmergeable with nothing failing
+#     and nothing in flight. This one is inherent to GitHub and cannot be
+#     configured away: merge main into the branch and the runs appear.
+#     A watcher that treats "no failing checks" as "still healthy" will poll
+#     this state until it times out, so watchers must test for DIRTY exactly.
+#
+#   * PUBLISHING FAILURES GATING A GREEN RUN - the dorny/test-reporter steps
+#     that turn JUnit XML into check runs talk to the check-runs API, which
+#     can fail transiently (a bare HttpError, which the action's `fail-on-error`
+#     input does NOT suppress because it is raised from the top-level catch).
+#     That failed a job in which all 100 tests had passed, which failed
+#     ci-gate, which blocked the merge. Every publisher therefore carries
+#     `continue-on-error: true`. Test outcomes are gated by the test steps
+#     themselves, never by whether their results could be published.
 
 on:
   pull_request:

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -992,6 +992,11 @@ jobs:
       - name: Publish UI test results
         uses: dorny/test-reporter@v2
         if: always() && steps.ui_tests.outcome != 'skipped'
+        # Cosmetic, like the other two publishers below: the "Fail the job if
+        # any suite failed" step reads the test steps' own outcomes, so test
+        # failures are gated regardless of whether publishing succeeds. A
+        # transient check-run API error must not block a merge on its own.
+        continue-on-error: true
         with:
           name: Device UI Test Results
           path: test-results.xml
@@ -1001,6 +1006,7 @@ jobs:
       - name: Publish API contract test results
         uses: dorny/test-reporter@v2
         if: always() && steps.api_tests.outcome != 'skipped'
+        continue-on-error: true
         with:
           name: API Contract Test Results
           path: api-test-results.xml
@@ -1010,6 +1016,7 @@ jobs:
       - name: Publish web test results
         uses: dorny/test-reporter@v2
         if: always() && steps.web_tests.outcome != 'skipped'
+        continue-on-error: true
         with:
           name: Web Dashboard Test Results
           path: web-test-results.xml
@@ -1018,7 +1025,16 @@ jobs:
 
       - name: Upload failure screenshots
         uses: actions/upload-artifact@v7
-        if: failure()
+        # NOT `failure()`. The three test steps are continue-on-error, and the
+        # publishers below are too, so at this point the job is not yet marked
+        # failed even when a suite failed -- it only fails later, at the
+        # explicit "fail the job" gate. Screenshots must key off the test
+        # outcomes directly or they silently stop being collected exactly when
+        # they are needed.
+        if: >-
+          always() && (steps.ui_tests.outcome == 'failure'
+          || steps.api_tests.outcome == 'failure'
+          || steps.web_tests.outcome == 'failure')
         with:
           name: failure-screenshots
           path: |

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Publish host-side test results
         uses: dorny/test-reporter@v2
         if: always()
+        # Publishing is cosmetic: it turns the JUnit XML into a check run.
+        # The pytest step above has no continue-on-error, so a real test
+        # failure already fails this job on its own. Without this, a transient
+        # check-run API error (a bare HttpError from the action's top-level
+        # catch, which `fail-on-error` does not suppress) fails a job in which
+        # every test passed, fails ci-gate, and blocks the merge.
+        continue-on-error: true
         with:
           name: Host-Side Test Results
           path: host-test-results.xml


### PR DESCRIPTION
Fixes the third of three ways a PR in this repo stalls with nothing actually wrong. All of them were observed on #231 and #232 in the last day.

### What happened

A `dorny/test-reporter` step failed with a bare `HttpError` while creating a check run, in a job where **all 100 tests had already passed**. The failed step failed the job → failed `ci-gate` → blocked the merge. The identical job with an identical payload succeeded on the same branch's previous SHA 90 minutes earlier, and rerunning it unchanged succeeded. Nothing about the change was at fault.

### Why `fail-on-error: false` is not the fix

That input is consulted only *after* the report parses, and governs whether failed tests **in the report** fail the step. An exception from the Checks API is raised out of the action's top-level `catch` and calls `core.setFailed()` regardless of it. Step-level `continue-on-error` is the only reliable mechanism, so all four publishers get it.

`fail-on-error` is deliberately left at its default, so the reporter's own check runs (`API Contract Test Results`, etc.) still go red for genuine test failures.

### Test outcomes are still fully gated

- `host-tests.yml` — the pytest step has no `continue-on-error`, so a failing test fails the job by itself.
- `device-tests.yml` — the explicit gate reads `steps.ui_tests/api_tests/web_tests.outcome`, never the publishers.

### The trap this exposed

`Upload failure screenshots` used `if: failure()` — and the only reason it ever fired is that a **publisher** failed first. The test steps are themselves `continue-on-error`, and the job isn't marked failed until the explicit gate that runs *after* the upload. Left alone, screenshots would have silently stopped being collected at exactly the moment they're wanted. It now keys off the three test-step outcomes directly.

### Also

Documented the two other stall modes in the `ci.yml` header beside the existing paths-filter lesson: a conflicted head schedules **no runs at all** and reports an empty check rollup, and a publishing failure gating an otherwise green run.

Not included here: whether to keep `strict` (require-branches-up-to-date) on branch protection — that is a policy decision, discussed separately.
