### PR TITLE
ci: make device-test concurrency merge-queue safe

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -30,10 +30,27 @@ on:
   # NOTE: `merge_group` is likewise driven by ci.yml, so that the merge queue
   # sees exactly one always-reporting required context.
 
-# Only one device-test run at a time (single device on the network)
 concurrency:
-  group: device-tests
-  cancel-in-progress: false  # queue new runs rather than cancelling in-progress
+  # Serialising physical-device access is NOT this group's job. `ghr-mi` is the
+  # repository's only [self-hosted, vm-mi] runner and it is the only runner that
+  # touches the controller (see the single `runs-on: [self-hosted, vm-mi]` job
+  # below). A runner executes one job at a time, so two hardware jobs can never
+  # overlap no matter how these runs are grouped.
+  #
+  # What the group actually does is collapse superseded pull-request runs. Even
+  # with `cancel-in-progress: false`, GitHub cancels any previously *pending* run
+  # when a newer one joins the same group, so pushing repeatedly to a PR discards
+  # the stale queued runs instead of executing a ~40-minute hardware suite for
+  # every intermediate commit.
+  #
+  # The key detail is that the group is keyed by event and PR number. A
+  # `merge_group` or `push` run lands in a group of its own and therefore cannot
+  # be evicted by later pull-request activity. That matters because a cancelled
+  # `ci-gate` ejects the entry from the merge queue, which is the same class of
+  # silent stall documented at the top of ci.yml. Those runs queue at the runner
+  # instead of cancelling one another.
+  group: device-tests-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Keys the device-test concurrency group by event and PR number instead of using one static `device-tests` group.

## Why

Physical-device serialisation does not come from this group. `ghr-mi` is the repository's only `[self-hosted, vm-mi]` runner, it owns the single `runs-on: [self-hosted, vm-mi]` job that touches the controller, and a runner executes one job at a time. Two hardware jobs cannot overlap regardless of grouping.

So the static group added no safety, but it did add a hazard. Even with `cancel-in-progress: false`, GitHub cancels any previously **pending** run when a newer run joins the same group. For a superseded PR commit that is desirable. For a merge queue it is disqualifying: a cancelled `ci-gate` **ejects the entry from the queue**, which is the same family of silent stall documented at the top of `ci.yml` and fixed in #233.

## What changes in practice

| Event | Group | Behaviour |
|---|---|---|
| `pull_request` | `device-tests-pull_request-<PR>` | unchanged: a newer push still discards the stale pending run, so iterating on a branch does not burn a ~40 min hardware suite per commit |
| `merge_group` | `device-tests-merge_group-<run_id>` | **new:** unique per run, so it can never be evicted by later PR activity; queues at the runner instead |
| `push` | `device-tests-push-<run_id>` | **new:** same, protecting the release attestation chain |

`cancel-in-progress` stays `false`. Cancelling an in-progress hardware job is genuinely unsafe (it can interrupt an OTA mid-flash), and nothing here changes that.

## Prerequisite for

Enabling the merge queue on `main`, which also lets `strict` (require branches up to date) be turned off, since the queue validates the merged state itself.

## Validation

- YAML parses; `concurrency.group` resolves to the intended expression.
- Confirmed via the API that `ghr-mi` is the only runner and that `device-tests` is the only workflow using it, so runner-level serialisation is sufficient.
- No line-ending churn (this file is already CRLF in-repo).
