### PR TITLE
Fix screenshot write amplification starving internal RAM, and gate on heap headroom

### DIFF
--- a/.github/scripts/scan_heap_floor.sh
+++ b/.github/scripts/scan_heap_floor.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Canonical internal-heap floor scanner for the device-tests serial log.
+#
+# This is the SINGLE SOURCE OF TRUTH for the heap-headroom gate, shared by:
+#   - .github/workflows/device-tests.yml  ("Check internal heap headroom")
+#   - tests/api/test_heap_floor.py        (hostside regression test)
+# so the two can never drift.
+#
+# WHY THIS GATE EXISTS
+#
+# Internal (non-PSRAM) RAM is the controller's scarcest resource. Steady-state
+# free internal heap is only ~30-40 KB while PSRAM sits at ~23 MB, so any log
+# line reporting a generic "free heap" in the megabytes says nothing about
+# health: a 176-byte allocation can still fail because the caller needed
+# internal memory specifically (lwIP PCBs, TLS state, DMA, task stacks).
+#
+# When internal RAM does run out, the device does not crash and does not report
+# a device fault. It stops completing TCP handshakes. To the test suite that
+# appears as ConnectTimeout, ConnectionError, ChunkedEncodingError and websocket
+# TimeoutError scattered across unrelated suites -- indistinguishable from
+# runner flake, and in fact dismissed as flake more than once before issue #234.
+# The gate exists to attribute those symptoms to their real cause.
+#
+# WHICH NUMBER TO GATE ON (this is the subtle part)
+#
+# netdiag prints two figures: instantaneous free internal heap ("heap int=N")
+# and the since-boot low-water mark ("(min M)", heap_caps_get_minimum_free_size).
+#
+# The low-water M is NOT usable as a gate. It is monotonic and never resets, so
+# a single brief early transient pins it near zero for the rest of the boot. In
+# practice it reads 16 bytes on EVERY observed run -- passing and failing alike
+# (7 of 7 sampled) -- which makes it useless for telling good runs from bad.
+# It is reported below as context only.
+#
+# The instantaneous figure separates cleanly. Across 7 sampled runs:
+#     5 healthy runs   min instantaneous free = 24847 .. 32727 bytes
+#     2 wedged runs    min instantaneous free = 23 bytes
+# and both wedged runs also logged "PCB walk TIMED OUT" (the lwIP tcpip thread
+# failing to service a callback within 1s) -- the same event seen from the other
+# side. One of those two wedged runs failed five tests; the other survived but
+# was equally sick. So this gate fires on the condition, not on whether the
+# tests happened to get away with it.
+#
+# Usage:   scan_heap_floor.sh <serial-log> [floor-bytes]
+# Output:  a one-line summary on stdout, plus offending samples on violation.
+# Exit:    0  healthy (instantaneous free stayed >= floor, no PCB-walk timeout)
+#          1  violation (dipped below floor, or the tcpip thread timed out)
+#          2  unusable input (missing log, or no netdiag samples at all)
+set -uo pipefail
+
+log="${1:?usage: scan_heap_floor.sh <serial-log> [floor-bytes]}"
+floor="${2:-8192}"
+
+if [ ! -f "$log" ]; then
+    echo "scan_heap_floor: serial log '$log' not found" >&2
+    exit 2
+fi
+
+# Matches both the healthy line and the "PCB walk TIMED OUT" variant, since both
+# carry the heap figures:
+#   I (33395) netdiag: heap int=40615 (min 12632) psram=23673156 | tcp active=1 ...
+NETDIAG_RE='netdiag: heap int=[0-9]+ \(min [0-9]+\)'
+
+samples="$(grep -cE "$NETDIAG_RE" "$log" || true)"
+if [ "${samples:-0}" -eq 0 ]; then
+    # Fail closed. A run with no netdiag samples has not demonstrated health,
+    # it has only failed to observe. Passing here would recreate the silent
+    # "no data == healthy" bug that once let real crashes ship.
+    echo "::error title=No netdiag samples::'$log' contains no netdiag lines, so internal-heap headroom was never observed. The gate cannot pass on absent data." >&2
+    exit 2
+fi
+
+# The gated metric: lowest instantaneous free internal heap across the run.
+min_instant="$(grep -oE 'netdiag: heap int=[0-9]+' "$log" \
+    | grep -oE '[0-9]+$' \
+    | sort -n | head -1)"
+
+# Context only -- saturates at ~16 bytes on every run, see the note above.
+lowwater="$(grep -oE 'heap int=[0-9]+ \(min [0-9]+\)' "$log" \
+    | grep -oE '\(min [0-9]+\)' \
+    | grep -oE '[0-9]+' \
+    | sort -n | head -1)"
+
+# Peak TIME_WAIT population: internal-RAM-backed PCBs accumulating under churn,
+# governed by CONFIG_LWIP_TCP_MSL. Context for why headroom evaporates.
+maxtw="$(grep -oE 'tw=[0-9]+' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)"
+maxtw="${maxtw:-0}"
+
+timeouts="$(grep -cE 'netdiag: .*PCB walk TIMED OUT' "$log" || true)"
+timeouts="${timeouts:-0}"
+
+echo "netdiag samples=${samples} min-instantaneous-internal-heap=${min_instant} bytes (floor=${floor}) since-boot-low-water=${lowwater} peak-TIME_WAIT=${maxtw} pcb-walk-timeouts=${timeouts}"
+
+status=0
+
+if [ "${min_instant:-0}" -lt "$floor" ]; then
+    echo "::error title=Internal heap exhausted::Instantaneous free internal (non-PSRAM) heap fell to ${min_instant} bytes, below the ${floor}-byte floor. A healthy run on this hardware does not drop below ~24 KB, so this is a genuine wedge: in this state the device stops completing TCP handshakes. Any ConnectTimeout / ConnectionError / premature-response / websocket-timeout failures in this run are almost certainly caused by this and are NOT runner flake. See issue #234. Peak TIME_WAIT was ${maxtw}. Lowest samples:" >&2
+    grep -nE "$NETDIAG_RE" "$log" \
+        | awk 'match($0, /heap int=[0-9]+/) {
+                   v = substr($0, RSTART + 9, RLENGTH - 9) + 0
+                   printf "%d\t%s\n", v, $0
+               }' \
+        | sort -n | head -10 | cut -f2- >&2
+    status=1
+fi
+
+if [ "$timeouts" -gt 0 ]; then
+    echo "::error title=tcpip thread unresponsive::${timeouts} netdiag sample(s) reported 'PCB walk TIMED OUT', meaning the lwIP tcpip thread did not service a callback within 1s. On every run observed so far this coincides with internal-heap exhaustion; it is the same wedge seen from the network-stack side. Treat it as a device fault, not a flaky runner." >&2
+    grep -nE 'netdiag: .*PCB walk TIMED OUT' "$log" | head -5 >&2
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "OK: instantaneous free internal heap stayed at or above the ${floor}-byte floor (lowest ${min_instant})."
+fi
+
+exit "$status"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -924,6 +924,44 @@ jobs:
           fi
           echo "OK: no httpd URI-handler registration failures in serial log."
 
+      - name: Check internal heap headroom
+        if: always()
+        # Internal (non-PSRAM) RAM is the controller's scarcest resource:
+        # steady-state free internal heap is ~30-40 KB, while PSRAM sits at
+        # ~23 MB. That asymmetry is what makes this failure mode deceptive -- a
+        # 176-byte allocation can fail while any "free heap" number in the log
+        # still reads in the tens of megabytes, because the caller needed
+        # internal memory specifically (lwIP PCBs, TLS state, DMA, task stacks).
+        #
+        # When internal RAM runs out the device does not crash and does not
+        # report a fault; it simply stops completing TCP handshakes. To the
+        # suite that looks like ConnectTimeout, ConnectionError,
+        # ChunkedEncodingError and websocket TimeoutError spread across
+        # unrelated suites, plus (seen once) a bogus "brute-force throttling is
+        # broken" assertion that was really a dropped 5th connection. All of it
+        # is indistinguishable from runner flake and was dismissed as flake more
+        # than once. This gate is less about the threshold than about
+        # attribution: it names the cause so those symptoms cannot be waved off.
+        #
+        # NOTE the gate deliberately reads the INSTANTANEOUS figure
+        # ("heap int=N"), not netdiag's since-boot low-water ("(min M)"). The
+        # low-water never resets, so one early transient pins it near zero: it
+        # reads 16 bytes on every run observed so far, healthy and wedged alike,
+        # and gating on it would fail 100% of runs while distinguishing nothing.
+        # The instantaneous figure separates cleanly -- healthy runs stay above
+        # ~24 KB, wedged runs collapse to 23 bytes. See issue #234 and
+        # tests/api/test_heap_floor.py.
+        #
+        # HARD FAILURE, and fails closed when there is no netdiag data at all:
+        # absence of evidence is not evidence of headroom.
+        env:
+          # Healthy runs bottom out around 24-33 KB, so 8 KB is a wide margin.
+          # This is a "the device is wedged" alarm, not a regression tripwire.
+          HEAP_FLOOR_BYTES: "8192"
+        run: |
+          set -euo pipefail
+          bash .github/scripts/scan_heap_floor.sh controller-serial.log "$HEAP_FLOOR_BYTES"
+
       - name: Detect firmware crashes on device
         if: always()
         # Distinguish a *crash* reboot from an *intentional* reboot (OTA /

--- a/main/png_uncompressed.c
+++ b/main/png_uncompressed.c
@@ -1,5 +1,5 @@
 /*
- * Minimal uncompressed PNG encoder — streaming, zero-allocation.
+ * Minimal uncompressed PNG encoder — streaming.
  *
  * PNG structure emitted:
  *   [8-byte signature]
@@ -11,10 +11,18 @@
  * (compression method 0).  Each stored block carries one scanline
  * (filter byte 0x00 + w*3 pixel bytes).  This avoids all compression
  * work — the CPU cost is just CRC32 + Adler32 over the raw data.
+ *
+ * Output is coalesced through a PSRAM staging buffer before reaching the write
+ * callback; see the note above png_buf_writer_t for why that matters so much
+ * when the callback is an HTTPS chunked-response writer.
  */
 
 #include "png_uncompressed.h"
 #include <string.h>
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+
+static const char *PNG_TAG = "png_enc";
 
 /* ── CRC-32 (ISO 3309 / PNG spec) ─────────────────────────────────────── */
 
@@ -109,18 +117,78 @@ static void put_le16(uint8_t *p, uint16_t v)
     p[1] = (uint8_t)(v >> 8);
 }
 
+/* ── Buffered output ───────────────────────────────────────────────────
+ *
+ * The encoder naturally emits many small pieces: per scanline it produces a
+ * 5-byte DEFLATE stored-block header, a 1-byte filter byte, and the row
+ * pixels. Passing each of those straight to the write callback is
+ * catastrophic over HTTPS, because the callback is httpd_resp_send_chunk()
+ * and every call becomes its own HTTP chunk *and* its own TLS record (each
+ * with chunk-size header, CRLF, TLS header, MAC and padding, plus the
+ * internal-RAM buffers mbedTLS needs to build it).
+ *
+ * For a 720x1280 screen that was 1280*3 = 3840 callback invocations, 2560 of
+ * them carrying 1 to 5 bytes. Measured cost: ~40 s to stream one screenshot,
+ * while holding an httpd worker and a socket, and applying sustained pressure
+ * to the scarce internal heap. That correlated with device-wide TCP wedges in
+ * CI (issue #234).
+ *
+ * Coalescing into a single staging buffer turns those thousands of tiny
+ * records into a few hundred full-size ones. The buffer lives in PSRAM: it is
+ * only a memcpy source for the TLS layer, so it does not need to be internal,
+ * and internal RAM is exactly the resource under pressure.
+ */
+#define PNG_OUT_BUF_SIZE 16384
+
+typedef struct {
+    png_write_fn_t fn;
+    void          *ctx;
+    uint8_t       *buf;
+    size_t         cap;
+    size_t         len;
+} png_buf_writer_t;
+
+static esp_err_t bw_flush(png_buf_writer_t *bw)
+{
+    if (bw->len == 0) return ESP_OK;
+    esp_err_t ret = bw->fn(bw->ctx, bw->buf, bw->len);
+    bw->len = 0;
+    return ret;
+}
+
+static esp_err_t bw_write(png_buf_writer_t *bw, const uint8_t *data, size_t len)
+{
+    /* No staging buffer (allocation failed): fall back to direct writes so the
+     * screenshot still works, just as slowly as it did before. */
+    if (!bw->buf) return bw->fn(bw->ctx, data, len);
+
+    while (len > 0) {
+        if (bw->len == bw->cap) {
+            esp_err_t ret = bw_flush(bw);
+            if (ret != ESP_OK) return ret;
+        }
+        size_t n = bw->cap - bw->len;
+        if (n > len) n = len;
+        memcpy(bw->buf + bw->len, data, n);
+        bw->len += n;
+        data += n;
+        len  -= n;
+    }
+    return ESP_OK;
+}
+
 /**
  * Write a complete PNG chunk: length(4) + type(4) + data(len) + crc(4).
  * For small chunks (IHDR, IEND) where the data fits in a single buffer.
  */
-static esp_err_t write_chunk(png_write_fn_t fn, void *ctx,
+static esp_err_t write_chunk(png_buf_writer_t *bw,
                               const char type[4], const uint8_t *data, uint32_t len)
 {
     uint8_t header[8];
     put_be32(header, len);
     memcpy(header + 4, type, 4);
 
-    esp_err_t ret = fn(ctx, header, 8);
+    esp_err_t ret = bw_write(bw, header, 8);
     if (ret != ESP_OK) return ret;
 
     /* CRC covers type + data */
@@ -129,13 +197,13 @@ static esp_err_t write_chunk(png_write_fn_t fn, void *ctx,
 
     if (len > 0) {
         crc = crc32_update(crc, data, len);
-        ret = fn(ctx, data, len);
+        ret = bw_write(bw, data, len);
         if (ret != ESP_OK) return ret;
     }
 
     uint8_t crc_buf[4];
     put_be32(crc_buf, ~crc);
-    return fn(ctx, crc_buf, 4);
+    return bw_write(bw, crc_buf, 4);
 }
 
 /* ── Public API ────────────────────────────────────────────────────────── */
@@ -149,10 +217,27 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
 
     esp_err_t ret;
 
+    /* Staging buffer so the many small pieces below coalesce into a few large
+     * writes. Allocation failure is non-fatal: bw_write() then falls back to
+     * unbuffered behaviour. */
+    png_buf_writer_t bw = {
+        .fn  = write_fn,
+        .ctx = ctx,
+        .buf = (uint8_t *)heap_caps_malloc(PNG_OUT_BUF_SIZE, MALLOC_CAP_SPIRAM),
+        .cap = PNG_OUT_BUF_SIZE,
+        .len = 0,
+    };
+    if (!bw.buf) {
+        ESP_LOGW(PNG_TAG, "no PSRAM for PNG staging buffer; streaming unbuffered (slow)");
+    }
+
+/* Every exit past this point must release the staging buffer. */
+#define PNG_RETURN(r) do { esp_err_t _r = (r); heap_caps_free(bw.buf); return _r; } while (0)
+
     /* ── 1. PNG signature ──────────────────────────────────────────────── */
     static const uint8_t png_sig[8] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-    ret = write_fn(ctx, png_sig, 8);
-    if (ret != ESP_OK) return ret;
+    ret = bw_write(&bw, png_sig, 8);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* ── 2. IHDR chunk ─────────────────────────────────────────────────── */
     uint8_t ihdr[13];
@@ -163,8 +248,8 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
     ihdr[10] = 0;               /* compression: deflate */
     ihdr[11] = 0;               /* filter: adaptive */
     ihdr[12] = 0;               /* interlace: none */
-    ret = write_chunk(write_fn, ctx, "IHDR", ihdr, 13);
-    if (ret != ESP_OK) return ret;
+    ret = write_chunk(&bw, "IHDR", ihdr, 13);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* ── 3. IDAT chunk — streamed ──────────────────────────────────────
      *
@@ -190,8 +275,8 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
     uint8_t idat_hdr[8];
     put_be32(idat_hdr, (uint32_t)idat_data_size);
     memcpy(idat_hdr + 4, "IDAT", 4);
-    ret = write_fn(ctx, idat_hdr, 8);
-    if (ret != ESP_OK) return ret;
+    ret = bw_write(&bw, idat_hdr, 8);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* Running CRC over "IDAT" + all IDAT data */
     uint32_t idat_crc = 0xFFFFFFFF;
@@ -203,8 +288,8 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
     /* Zlib header: CMF=0x78 (deflate, 32K window), FLG=0x01 (no dict, check bits) */
     uint8_t zlib_hdr[2] = { 0x78, 0x01 };
     idat_crc = crc32_update(idat_crc, zlib_hdr, 2);
-    ret = write_fn(ctx, zlib_hdr, 2);
-    if (ret != ESP_OK) return ret;
+    ret = bw_write(&bw, zlib_hdr, 2);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* ── Emit one DEFLATE stored block per scanline ───────────────────
      *
@@ -223,14 +308,14 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
         put_le16(blk + 3, (uint16_t)~scanline);
 
         idat_crc = crc32_update(idat_crc, blk, 5);
-        ret = write_fn(ctx, blk, 5);
-        if (ret != ESP_OK) return ret;
+        ret = bw_write(&bw, blk, 5);
+        if (ret != ESP_OK) PNG_RETURN(ret);
 
         /* Filter byte (0x00 = None) */
         idat_crc = crc32_update(idat_crc, &filter_byte, 1);
         adler = adler32_update(adler, &filter_byte, 1);
-        ret = write_fn(ctx, &filter_byte, 1);
-        if (ret != ESP_OK) return ret;
+        ret = bw_write(&bw, &filter_byte, 1);
+        if (ret != ESP_OK) PNG_RETURN(ret);
 
         /* Pixel data for this row */
         const uint8_t *row = pixels + (uint64_t)y * w * 3;
@@ -238,23 +323,29 @@ esp_err_t png_encode_uncompressed_rgb888(const uint8_t *pixels, uint32_t w, uint
 
         idat_crc = crc32_update(idat_crc, row, row_bytes);
         adler = adler32_update(adler, row, row_bytes);
-        ret = write_fn(ctx, row, row_bytes);
-        if (ret != ESP_OK) return ret;
+        ret = bw_write(&bw, row, row_bytes);
+        if (ret != ESP_OK) PNG_RETURN(ret);
     }
 
     /* Adler-32 checksum (big-endian, per zlib spec) */
     uint8_t adler_buf[4];
     put_be32(adler_buf, adler);
     idat_crc = crc32_update(idat_crc, adler_buf, 4);
-    ret = write_fn(ctx, adler_buf, 4);
-    if (ret != ESP_OK) return ret;
+    ret = bw_write(&bw, adler_buf, 4);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* IDAT CRC */
     uint8_t idat_crc_buf[4];
     put_be32(idat_crc_buf, ~idat_crc);
-    ret = write_fn(ctx, idat_crc_buf, 4);
-    if (ret != ESP_OK) return ret;
+    ret = bw_write(&bw, idat_crc_buf, 4);
+    if (ret != ESP_OK) PNG_RETURN(ret);
 
     /* ── 4. IEND chunk ─────────────────────────────────────────────────── */
-    return write_chunk(write_fn, ctx, "IEND", NULL, 0);
+    ret = write_chunk(&bw, "IEND", NULL, 0);
+    if (ret != ESP_OK) PNG_RETURN(ret);
+
+    /* Nothing may remain buffered once the image is complete. */
+    PNG_RETURN(bw_flush(&bw));
 }
+
+#undef PNG_RETURN

--- a/main/png_uncompressed.h
+++ b/main/png_uncompressed.h
@@ -8,7 +8,14 @@
  * several seconds.
  *
  * Designed for streaming over HTTP chunked transfer — the write callback
- * is invoked incrementally so no second buffer allocation is needed.
+ * is invoked incrementally so no second copy of the image is needed.
+ *
+ * Output is coalesced through a ~16 KB PSRAM staging buffer so that the many
+ * small pieces the format requires (a 5-byte block header and a 1-byte filter
+ * byte per scanline) do not each become their own HTTP chunk and TLS record.
+ * Without it a 720x1280 screenshot cost ~3840 write callbacks and ~40 s over
+ * HTTPS, and the resulting internal-RAM pressure was implicated in device-wide
+ * TCP wedges (issue #234).
  */
 
 #pragma once
@@ -37,8 +44,9 @@ typedef esp_err_t (*png_write_fn_t)(void *ctx, const void *buf, size_t len);
  * Pixels must be row-major, no stride padding, 3 bytes per pixel (R,G,B).
  * The write callback is called multiple times with chunks of the PNG file.
  *
- * Memory usage: only a small stack buffer (~16 bytes) beyond the input
- * pixel buffer — no heap allocation.
+ * Memory usage: a single ~16 KB staging buffer allocated from PSRAM for the
+ * duration of the call (plus a few bytes of stack). If that allocation fails
+ * the encoder still succeeds, falling back to unbuffered writes.
  *
  * @param pixels    w×h×3 bytes of RGB888 data
  * @param w         Image width in pixels

--- a/tests/api/test_heap_floor.py
+++ b/tests/api/test_heap_floor.py
@@ -1,0 +1,194 @@
+"""Pin the internal-heap-floor contract used by the device-tests CI gate.
+
+``.github/scripts/scan_heap_floor.sh`` is the single source of truth for the
+heap-headroom gate. It exists because internal (non-PSRAM) RAM exhaustion does
+not present as a device fault -- it presents as a flaky network. See issue #234:
+the device stopped completing TCP handshakes, and five tests across four
+unrelated suites failed with ``ConnectTimeout`` / ``ConnectionError`` /
+``ChunkedEncodingError`` / websocket ``TimeoutError``, plus a bogus "throttling
+is broken" assertion (401 != 429) caused purely by a dropped connection. Every
+symptom was indistinguishable from runner flake, and was dismissed as such more
+than once.
+
+THE SUBTLE PART, which these tests exist to protect:
+
+netdiag reports two heap figures, and only one of them is a usable signal.
+
+  * ``(min M)`` -- the since-boot low-water (``heap_caps_get_minimum_free_size``)
+    -- is monotonic and never resets, so one brief early transient pins it near
+    zero for the whole boot. It measured **16 bytes on 7 of 7 sampled runs**,
+    passing and failing alike. Gating on it would fail every run and block the
+    repository while distinguishing nothing.
+  * ``heap int=N`` -- the instantaneous free internal heap -- separates cleanly:
+    5 healthy runs stayed in 24847..32727 bytes, while the 2 wedged runs dropped
+    to 23 bytes and also logged ``PCB walk TIMED OUT``.
+
+``test_since_boot_low_water_alone_does_not_trip_the_gate`` pins that distinction
+directly, because getting it wrong is the difference between a useful gate and
+one that has to be switched off.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.hostside
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "scripts" / "scan_heap_floor.sh"
+
+# A comfortable run: instantaneous free stays ~40 KB (lowest 39880).
+# Note the "(min ...)" values are deliberately low-ish -- that is realistic and
+# must not by itself trip the gate.
+HEALTHY_LINES = [
+    "I (33395) netdiag: heap int=40615 (min 12632) psram=23673156 | tcp active=1 tw=0 bound=0 listen=4",
+    "I (63840) netdiag: heap int=40279 (min 12120) psram=23607152 | tcp active=1 tw=3 bound=0 listen=4",
+    "I (94001) netdiag: heap int=39880 (min 11788) psram=23600000 | tcp active=2 tw=5 bound=0 listen=4",
+]
+
+# Realistic "every run looks like this" samples: the since-boot low-water has
+# already bottomed out at 16, yet the device is perfectly healthy because
+# instantaneous free heap is still ~35 KB. Observed on all 7 sampled runs.
+SATURATED_LOWWATER_LINES = [
+    "I (338034) netdiag: heap int=39047 (min 16) psram=23620608 | tcp active=2 tw=0 bound=0 listen=4",
+    "I (368496) netdiag: heap int=35023 (min 16) psram=23620608 | tcp active=2 tw=4 bound=0 listen=4",
+]
+
+# A genuine wedge: instantaneous free internal heap collapses below the floor.
+# TIME_WAIT is saturated at 23 (CONFIG_LWIP_MAX_ACTIVE_TCP is 24).
+EXHAUSTED_LINES = [
+    "I (1309000) netdiag: heap int=12000 (min 16) psram=23670000 | tcp active=1 tw=19 bound=0 listen=4",
+    "I (1339386) netdiag: heap int=512 (min 16) psram=23670940 | tcp active=1 tw=23 bound=0 listen=4",
+]
+
+# Verbatim from the issue #234 run: 23 bytes free and the lwIP tcpip thread
+# unresponsive -- the same wedge observed from the network-stack side.
+PCB_TIMEOUT_LINE = (
+    "W (1581248) netdiag: heap int=23 (min 16) psram=23637360 "
+    "| tcp PCB walk TIMED OUT (tcpip thread unresponsive)"
+)
+
+FLOOR = "8192"
+
+
+def _write(tmp_path, name, lines):
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), f"missing heap-floor scanner: {SCRIPT}"
+
+
+def test_scanner_has_no_crlf_line_endings():
+    """The scanner MUST be LF-only.
+
+    CRLF silently breaks bash on the Linux runner (it errors on every ``\\r``),
+    and a gate that errors out instead of evaluating protects nothing. This is
+    the same failure that once disabled the crash gate, so it is pinned here as
+    a plain byte check that runs on every platform.
+    """
+    raw = SCRIPT.read_bytes()
+    assert b"\r" not in raw, "scan_heap_floor.sh contains CR bytes (CRLF) - bash on CI will break"
+
+
+def test_workflow_invokes_the_shared_scanner():
+    """CI must call this script rather than reimplementing the parsing inline,
+    so the gate and its tests cannot drift apart."""
+    wf = (ROOT / ".github" / "workflows" / "device-tests.yml").read_text(encoding="utf-8")
+    assert "scan_heap_floor.sh" in wf, (
+        "device-tests.yml does not invoke scan_heap_floor.sh - the heap gate is not wired up"
+    )
+
+
+_BASH = shutil.which("bash")
+# As with the crash scanner: on Windows ``bash`` is usually the WSL launcher,
+# which cannot accept Windows-style paths, so execute only on Linux CI.
+_SKIP_BASH = _BASH is None or sys.platform.startswith("win")
+requires_bash = pytest.mark.skipif(_SKIP_BASH, reason="bash-execution check runs on Linux CI only")
+
+
+def _run(log, floor=FLOOR):
+    return subprocess.run([_BASH, str(SCRIPT), str(log), floor], capture_output=True, text=True)
+
+
+@requires_bash
+def test_healthy_run_passes(tmp_path):
+    r = _run(_write(tmp_path, "healthy.log", HEALTHY_LINES))
+    assert r.returncode == 0, f"healthy log should pass; got {r.returncode}\n{r.stdout}{r.stderr}"
+    assert "min-instantaneous-internal-heap=39880" in r.stdout, r.stdout
+
+
+@requires_bash
+def test_since_boot_low_water_alone_does_not_trip_the_gate(tmp_path):
+    """The regression that would render this gate useless.
+
+    ``(min 16)`` appeared on 7 of 7 sampled runs, healthy and wedged alike,
+    because the since-boot low-water never resets. If the gate keys off that
+    number it fails every device run and has to be disabled. Only the
+    instantaneous figure may decide the outcome.
+    """
+    r = _run(_write(tmp_path, "saturated.log", SATURATED_LOWWATER_LINES))
+    assert r.returncode == 0, (
+        "a run whose since-boot low-water bottomed out at 16 but whose "
+        f"instantaneous heap stayed ~35 KB must PASS; got {r.returncode}\n{r.stdout}{r.stderr}"
+    )
+    assert "since-boot-low-water=16" in r.stdout, r.stdout
+
+
+@requires_bash
+def test_exhausted_run_fails(tmp_path):
+    """The whole point: instantaneous heap below the floor must fail loudly."""
+    r = _run(_write(tmp_path, "exhausted.log", HEALTHY_LINES + EXHAUSTED_LINES))
+    assert r.returncode == 1, f"exhausted log should fail; got {r.returncode}\n{r.stdout}{r.stderr}"
+    assert "min-instantaneous-internal-heap=512" in r.stdout, r.stdout
+    # The operator must be told this is not flake, and where to look.
+    assert "Internal heap exhausted" in r.stderr, r.stderr
+    assert "#234" in r.stderr, r.stderr
+    # Peak TIME_WAIT points at the accumulation mechanism.
+    assert "peak-TIME_WAIT=23" in r.stdout, r.stdout
+
+
+@requires_bash
+def test_pcb_walk_timeout_fails_even_with_healthy_heap(tmp_path):
+    """A wedged tcpip thread is a failure on its own terms.
+
+    The heap figure is raised above the floor here so that the timeout signal is
+    the only thing that can trip the gate.
+    """
+    line = PCB_TIMEOUT_LINE.replace("heap int=23 (min 16)", "heap int=40000 (min 16)")
+    r = _run(_write(tmp_path, "timeout.log", HEALTHY_LINES + [line]))
+    assert r.returncode == 1, f"PCB-walk timeout should fail; got {r.returncode}\n{r.stdout}{r.stderr}"
+    assert "tcpip thread unresponsive" in r.stderr, r.stderr
+
+
+@requires_bash
+def test_run_without_netdiag_samples_fails_closed(tmp_path):
+    """No data is not the same as good data.
+
+    A run that never emitted netdiag has not demonstrated headroom; passing here
+    would recreate the silent "no evidence == healthy" bug.
+    """
+    log = _write(tmp_path, "nodata.log", ["I (100) boot: starting", "I (200) wifi: connected"])
+    r = _run(log)
+    assert r.returncode == 2, f"missing netdiag data should exit 2; got {r.returncode}\n{r.stdout}{r.stderr}"
+    assert "No netdiag samples" in r.stderr, r.stderr
+
+
+@requires_bash
+def test_missing_log_fails_closed(tmp_path):
+    r = _run(tmp_path / "absent.log")
+    assert r.returncode == 2, f"missing log should exit 2; got {r.returncode}\n{r.stdout}{r.stderr}"
+
+
+@requires_bash
+def test_floor_is_configurable(tmp_path):
+    """The same log passes or fails purely on the configured floor, so the
+    threshold can be tightened as headroom improves."""
+    log = _write(tmp_path, "healthy.log", HEALTHY_LINES)  # lowest instantaneous 39880
+    assert _run(log, "8192").returncode == 0
+    assert _run(log, "50000").returncode == 1


### PR DESCRIPTION
Fixes the device-wide network wedge in #234, and adds a CI gate that will catch it if it comes back.

## The correction that matters

My first read of this was wrong, and I want that on the record because the wrong metric nearly became a CI gate.

I originally blamed the since-boot heap low-water figure (`min M=16`), a burst of ~330 `httpd_accept_conn` failures, and an mbedTLS `-0x7280`. Before arming a hard gate I pulled the serial logs from six **passing** runs to sanity-check the threshold. All six showed low-water of **exactly 16** and peak TIME_WAIT of **exactly 23** — identical to the failing run. The ~300 accept failures are baseline on every run, and they are `-0x7780`, a *client* fatal alert (Chromium rejecting the self-signed cert), not a device-side failure.

A gate on that metric would have failed 100% of device runs.

The cause of the red herring: `heap_caps_get_minimum_free_size()` is monotonic and never resets, so one early transient pins it near zero for the whole boot.

## The real discriminator

| Metric | Passing runs (6) | Failing run | |
|---|---|---|---|
| since-boot low-water | 16 in all six | 16 | no signal |
| peak TIME_WAIT | 23 in all six | 23 | no signal |
| accept failures | 252–326 | 330 | baseline |
| **min instantaneous `heap int=`** | **24,847 – 32,727 B** | **23 B** | **← this** |
| `PCB walk TIMED OUT` | 0 | 1 | tracks it exactly |

Worth noting: run `33998646649` is recorded as a **pass** but had min-instantaneous heap of 23 B and two tcpip-thread timeouts. It was equally sick and got lucky. The gate in this PR correctly fails it.

## Root cause

`png_uncompressed.c` called its write callback three times per scanline — a 5-byte block header, a 1-byte filter byte, and the row. That callback is `httpd_resp_send_chunk`, so over HTTPS each became its own HTTP chunk and TLS record, each demanding internal-RAM buffers from mbedTLS.

720×1280 ⇒ **3,840 callback invocations, 2,560 carrying 1–5 bytes**. From the failing log:

```
PNG streaming failed: ESP_ERR_HTTPD_RESP_SEND
Screenshot streamed: 720x1280 in 40708 ms
```

40 seconds holding an httpd worker and a socket. `heap int=23` appears immediately after. (The 2.7 MB pixel buffer is already in PSRAM and was never the problem.)

## The fix

Coalesce through a 16 KB PSRAM staging buffer.

|  | write calls | calls ≤ 8 B | output |
|---|---|---|---|
| before | 3,850 | 2,569 | 2,772,543 B |
| after | **170** | **0** | 2,772,543 B — **byte-identical** |

Validated by compiling the old and new encoder on the host against identical input:

- byte-identical output for 1×1, 1×1000, **8000×3** (row wider than the staging buffer, exercising the split path), 719×1279, and in the allocation-failure fallback
- emitted PNG decodes with correct chunk CRCs and pixel-exact rows across all 1,280 scanlines
- if the PSRAM allocation fails it falls back to the old unbuffered path, so a screenshot is never lost to a failed optimisation
- firmware builds clean for esp32p4

## The gate

`scan_heap_floor.sh` fails on minimum **instantaneous** free internal heap below 8 KB, or on any `PCB walk TIMED OUT`. It reports the since-boot low-water as context only, and `test_heap_floor.py` has a regression test pinning that distinction specifically so the red herring cannot be reintroduced. Fail-closed (exit 2) on a missing log or zero netdiag samples.

Validated against all seven real serial logs: the five healthy runs pass, both wedged runs fail.

## What this PR does *not* prove

The fix is verified on the host, not on hardware. The device run on this PR is the real test. Success criteria: screenshot time well under 40 s, and minimum instantaneous internal heap staying above 8 KB — which is exactly what the new gate measures, so **if the fix is insufficient this PR will fail its own check.** That is intentional.
