### PR TITLE
Test the history flash layout against real NOR semantics (T10/T14)

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -141,8 +141,8 @@ jobs:
         run: |
           COUNT=$(ctest --test-dir build-main-tests -N | sed -n 's/^Total Tests: //p')
           echo "ctest reports ${COUNT:-0} registered tests"
-          if [ -z "${COUNT}" ] || [ "${COUNT}" -lt 2 ]; then
-            echo "::error::Only ${COUNT:-0} main/ native tests were registered (expected at least 2). Tests were dropped, or the suite failed to configure."
+          if [ -z "${COUNT}" ] || [ "${COUNT}" -lt 3 ]; then
+            echo "::error::Only ${COUNT:-0} main/ native tests were registered (expected at least 3). Tests were dropped, or the suite failed to configure."
             exit 1
           fi
 
@@ -151,11 +151,13 @@ jobs:
         # stubs and the test file, and nothing from main/ at all", which would
         # still link and still pass. Check the object files exist.
         run: |
-          if ! find build-main-tests -name 'i18n.cpp.o' | grep -q .; then
-            echo "::error::main/i18n/i18n.cpp was not compiled by the host build — MAIN_HOST_SRCS has probably been emptied."
-            find build-main-tests -name '*.o' -print
-            exit 1
-          fi
+          for OBJ in i18n.cpp.o history_storage.cpp.o; do
+            if ! find build-main-tests -name "$OBJ" | grep -q .; then
+              echo "::error::$OBJ was not compiled by the host build — MAIN_HOST_SRCS has probably been emptied."
+              find build-main-tests -name '*.o' -print
+              exit 1
+            fi
+          done
           echo "Host build compiled:"
           find build-main-tests -name '*.o' -printf '  %f\n'
 

--- a/main/tests/CMakeLists.txt
+++ b/main/tests/CMakeLists.txt
@@ -33,11 +33,16 @@ set(MAIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 # hollowed-out version of it.
 set(MAIN_HOST_SRCS
   ${MAIN_DIR}/i18n/i18n.cpp
+  ${MAIN_DIR}/history_storage.cpp
 )
 
 add_library(arctic_main_host STATIC
   ${MAIN_HOST_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/host_stubs/nvs_fake.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/host_stubs/esp_partition_fake.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/host_stubs/esp_crc.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/host_stubs/heap_fake.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/host_stubs/esp_err.cpp
 )
 
 # host_stubs must come first so its esp_log.h/nvs.h shadow nothing real; there
@@ -59,3 +64,7 @@ add_test(NAME i18n COMMAND test_i18n)
 add_executable(test_nvs_fake test_nvs_fake.cpp)
 target_link_libraries(test_nvs_fake PRIVATE arctic_main_host)
 add_test(NAME nvs_fake COMMAND test_nvs_fake)
+
+add_executable(test_history_storage test_history_storage.cpp)
+target_link_libraries(test_history_storage PRIVATE arctic_main_host)
+add_test(NAME history_storage COMMAND test_history_storage)

--- a/main/tests/host_stubs/esp_crc.cpp
+++ b/main/tests/host_stubs/esp_crc.cpp
@@ -1,0 +1,35 @@
+/*
+ * Host stub for esp_crc.h. See the header for why this matches IDF's
+ * algorithm rather than being any convenient hash.
+ */
+
+#include "esp_crc.h"
+
+namespace {
+
+uint32_t table[256];
+bool built = false;
+
+void build_table() {
+    for (uint32_t i = 0; i < 256; ++i) {
+        uint32_t c = i;
+        for (int k = 0; k < 8; ++k) {
+            c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+        }
+        table[i] = c;
+    }
+    built = true;
+}
+
+}  // namespace
+
+extern "C" uint32_t esp_crc32_le(uint32_t crc, const uint8_t *buf, uint32_t len) {
+    if (!built) {
+        build_table();
+    }
+    uint32_t c = ~crc;
+    for (uint32_t i = 0; i < len; ++i) {
+        c = table[(c ^ buf[i]) & 0xff] ^ (c >> 8);
+    }
+    return ~c;
+}

--- a/main/tests/host_stubs/esp_crc.h
+++ b/main/tests/host_stubs/esp_crc.h
@@ -1,0 +1,28 @@
+/*
+ * Host stub for ESP-IDF's esp_crc.h.
+ *
+ * Implements the same CRC-32 that IDF's esp_crc32_le() computes: reflected,
+ * polynomial 0xEDB88320, with the input crc inverted on entry and the result
+ * inverted on exit -- so esp_crc32_le(0, ...) is the usual zlib crc32.
+ *
+ * Exactness matters here in one direction only. The host tests both write and
+ * verify records with this function, so they would be self-consistent under
+ * any hash; what they would NOT catch is a change that makes the host and the
+ * device disagree. Matching the real algorithm keeps a stored CRC comparable
+ * with one computed on the device, which is what makes a test like "a record
+ * written by an older firmware still validates" meaningful.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t esp_crc32_le(uint32_t crc, const uint8_t *buf, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/esp_err.cpp
+++ b/main/tests/host_stubs/esp_err.cpp
@@ -1,0 +1,33 @@
+/*
+ * Host stub for esp_err_to_name(). Names the codes the host-built sources can
+ * actually produce; anything else formats as hex so a log line stays useful.
+ */
+
+#include "esp_err.h"
+
+#include <cstdio>
+
+extern "C" const char *esp_err_to_name(esp_err_t code) {
+    switch (code) {
+        case ESP_OK: return "ESP_OK";
+        case ESP_FAIL: return "ESP_FAIL";
+        case ESP_ERR_NO_MEM: return "ESP_ERR_NO_MEM";
+        case ESP_ERR_INVALID_ARG: return "ESP_ERR_INVALID_ARG";
+        case ESP_ERR_INVALID_STATE: return "ESP_ERR_INVALID_STATE";
+        case ESP_ERR_INVALID_SIZE: return "ESP_ERR_INVALID_SIZE";
+        case ESP_ERR_NOT_FOUND: return "ESP_ERR_NOT_FOUND";
+        case ESP_ERR_NOT_SUPPORTED: return "ESP_ERR_NOT_SUPPORTED";
+        case ESP_ERR_TIMEOUT: return "ESP_ERR_TIMEOUT";
+        case ESP_ERR_INVALID_CRC: return "ESP_ERR_INVALID_CRC";
+        case ESP_ERR_NVS_NOT_FOUND: return "ESP_ERR_NVS_NOT_FOUND";
+        case ESP_ERR_NVS_INVALID_HANDLE: return "ESP_ERR_NVS_INVALID_HANDLE";
+        case ESP_ERR_NVS_READ_ONLY: return "ESP_ERR_NVS_READ_ONLY";
+        case ESP_ERR_NVS_NOT_ENOUGH_SPACE: return "ESP_ERR_NVS_NOT_ENOUGH_SPACE";
+        case ESP_ERR_NVS_INVALID_LENGTH: return "ESP_ERR_NVS_INVALID_LENGTH";
+        default: {
+            static char buf[24];
+            std::snprintf(buf, sizeof(buf), "ESP_ERR(0x%x)", (unsigned)code);
+            return buf;
+        }
+    }
+}

--- a/main/tests/host_stubs/esp_err.h
+++ b/main/tests/host_stubs/esp_err.h
@@ -18,7 +18,11 @@ typedef int esp_err_t;
 #define ESP_ERR_NO_MEM 0x101
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERR_INVALID_SIZE 0x104
 #define ESP_ERR_NOT_FOUND 0x105
+#define ESP_ERR_NOT_SUPPORTED 0x106
+#define ESP_ERR_TIMEOUT 0x107
+#define ESP_ERR_INVALID_CRC 0x10c
 
 #define ESP_ERR_NVS_BASE 0x1100
 #define ESP_ERR_NVS_NOT_FOUND (ESP_ERR_NVS_BASE + 0x02)
@@ -26,3 +30,15 @@ typedef int esp_err_t;
 #define ESP_ERR_NVS_READ_ONLY (ESP_ERR_NVS_BASE + 0x04)
 #define ESP_ERR_NVS_NOT_ENOUGH_SPACE (ESP_ERR_NVS_BASE + 0x05)
 #define ESP_ERR_NVS_INVALID_LENGTH (ESP_ERR_NVS_BASE + 0x0a)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Returns a stable, human-readable name. Sources pass the result to a log
+ * call, so it must never be NULL. */
+const char *esp_err_to_name(esp_err_t code);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/esp_heap_caps.h
+++ b/main/tests/host_stubs/esp_heap_caps.h
@@ -1,0 +1,33 @@
+/*
+ * Host stub for ESP-IDF's esp_heap_caps.h.
+ *
+ * Capability flags are accepted and ignored -- there is no PSRAM on the host,
+ * and none of the host-tested sources depend on which pool they landed in.
+ * What IS modelled is allocation failure, because code that does not check a
+ * NULL from heap_caps_malloc crashes on a device under memory pressure and
+ * nowhere else. See heap_fake.h.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MALLOC_CAP_8BIT (1 << 2)
+#define MALLOC_CAP_DMA (1 << 3)
+#define MALLOC_CAP_SPIRAM (1 << 10)
+#define MALLOC_CAP_INTERNAL (1 << 11)
+#define MALLOC_CAP_DEFAULT (1 << 12)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *heap_caps_malloc(size_t size, uint32_t caps);
+void *heap_caps_calloc(size_t n, size_t size, uint32_t caps);
+void heap_caps_free(void *ptr);
+size_t heap_caps_get_free_size(uint32_t caps);
+size_t heap_caps_get_minimum_free_size(uint32_t caps);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/esp_partition.h
+++ b/main/tests/host_stubs/esp_partition.h
@@ -1,0 +1,55 @@
+/*
+ * Host stub for ESP-IDF's esp_partition.h, backed by a RAM image with NOR
+ * flash semantics. See esp_partition_fake.h for the test-facing controls.
+ *
+ * The point of modelling NOR rather than plain memory: on real flash a write
+ * can only clear bits, so writing over a region that was not erased first
+ * silently ANDs into whatever was there. That bug is invisible against a
+ * memcpy-style fake -- the data reads back exactly as written -- and shows up
+ * on the device as corrupt records much later.
+ */
+#pragma once
+
+#include "esp_err.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ESP_PARTITION_TYPE_APP = 0x00,
+    ESP_PARTITION_TYPE_DATA = 0x01,
+    ESP_PARTITION_TYPE_ANY = 0xff,
+} esp_partition_type_t;
+
+typedef enum {
+    ESP_PARTITION_SUBTYPE_ANY = 0xff,
+} esp_partition_subtype_t;
+
+typedef struct {
+    esp_partition_type_t type;
+    esp_partition_subtype_t subtype;
+    uint32_t address;
+    uint32_t size;
+    uint32_t erase_size;
+    char label[17];
+    bool encrypted;
+} esp_partition_t;
+
+const esp_partition_t *esp_partition_find_first(esp_partition_type_t type,
+                                                esp_partition_subtype_t subtype,
+                                                const char *label);
+
+esp_err_t esp_partition_read(const esp_partition_t *partition, size_t src_offset,
+                             void *dst, size_t size);
+esp_err_t esp_partition_write(const esp_partition_t *partition, size_t dst_offset,
+                              const void *src, size_t size);
+esp_err_t esp_partition_erase_range(const esp_partition_t *partition,
+                                    size_t offset, size_t size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/esp_partition_fake.cpp
+++ b/main/tests/host_stubs/esp_partition_fake.cpp
@@ -1,0 +1,348 @@
+/*
+ * RAM-backed implementation of the flash fake. See esp_partition_fake.h.
+ */
+
+#include "esp_partition_fake.h"
+
+#include <sys/mman.h>
+
+#include <cstring>
+#include <cstdio>
+#include <map>
+
+namespace {
+
+constexpr size_t SECTOR = 4096;
+constexpr size_t ARENA_DATA_SIZE = 8u * 1024 * 1024;
+constexpr size_t MAX_SLOTS = 4;
+
+// The backing store lives in shared anonymous memory, not the heap.
+//
+// Tests run each phase in a forked child so that history_storage.cpp's
+// file-scope statics start cold (its init() early-returns once s_partition is
+// set, so an in-process "reboot" is a no-op and every persistence assertion
+// would pass vacuously). A reboot is only meaningful if the medium outlives
+// the process, so the image has to be shared memory: fresh RAM, same flash.
+struct SharedSlot {
+    char label[17];  // matches esp_partition_t::label
+    uint8_t subtype;
+    uint32_t size;
+    uint32_t data_off;
+};
+
+struct SharedArena {
+    uint32_t slot_count;
+    uint32_t bump;
+    SharedSlot slots[MAX_SLOTS];
+    uint8_t data[ARENA_DATA_SIZE];
+};
+
+SharedArena *g_arena = nullptr;
+
+SharedArena &arena() {
+    if (g_arena == nullptr) {
+        void *p = mmap(nullptr, sizeof(SharedArena), PROT_READ | PROT_WRITE,
+                       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        if (p == MAP_FAILED) {
+            std::fprintf(stderr, "flash_fake: mmap failed\n");
+            std::abort();
+        }
+        g_arena = static_cast<SharedArena *>(p);
+        g_arena->slot_count = 0;
+        g_arena->bump = 0;
+    }
+    return *g_arena;
+}
+
+SharedSlot *slot_for(const char *label) {
+    SharedArena &a = arena();
+    for (uint32_t i = 0; i < a.slot_count; ++i) {
+        if (std::strcmp(a.slots[i].label, label) == 0) {
+            return &a.slots[i];
+        }
+    }
+    return nullptr;
+}
+
+uint8_t *image_of(SharedSlot *s) { return arena().data + s->data_off; }
+
+// Descriptors are process-local so the pointers handed to production code stay
+// valid for the life of the process.
+std::map<std::string, esp_partition_t> g_descs;
+
+const esp_partition_t *desc_for(SharedSlot *s) {
+    auto it = g_descs.find(s->label);
+    if (it == g_descs.end()) {
+        esp_partition_t d;
+        std::memset(&d, 0, sizeof(d));
+        d.type = ESP_PARTITION_TYPE_DATA;
+        d.subtype = static_cast<esp_partition_subtype_t>(s->subtype);
+        d.address = 0;
+        d.size = s->size;
+        d.erase_size = SECTOR;
+        std::snprintf(d.label, sizeof(d.label), "%s", s->label);
+        d.encrypted = false;
+        it = g_descs.emplace(s->label, d).first;
+    }
+    return &it->second;
+}
+
+struct Injection {
+    esp_err_t err;
+    int remaining;
+};
+std::map<int, Injection> g_injections;
+std::map<int, int> g_calls;
+
+int g_power_loss_countdown = -1;  // <0 == powered
+bool g_powered = true;
+size_t g_bytes_written = 0;
+size_t g_bytes_erased = 0;
+
+int key_of(flash_fake::Op op) { return static_cast<int>(op); }
+
+esp_err_t take_injection(flash_fake::Op op) {
+    g_calls[key_of(op)] += 1;
+    auto it = g_injections.find(key_of(op));
+    if (it == g_injections.end()) {
+        return ESP_OK;
+    }
+    esp_err_t err = it->second.err;
+    if (it->second.remaining > 0 && --it->second.remaining == 0) {
+        g_injections.erase(it);
+    }
+    return err;
+}
+
+// Count a completed medium-touching operation and decide whether the device
+// still has power for the next one.
+void tick_power() {
+    if (g_power_loss_countdown < 0) {
+        return;
+    }
+    if (g_power_loss_countdown == 0) {
+        g_powered = false;
+        return;
+    }
+    --g_power_loss_countdown;
+    if (g_power_loss_countdown == 0) {
+        g_powered = false;
+    }
+}
+
+struct Located {
+    SharedSlot *slot;
+    uint8_t *image;
+    size_t size;
+};
+
+bool locate(const esp_partition_t *p, Located *out) {
+    if (!p) {
+        return false;
+    }
+    SharedSlot *s = slot_for(p->label);
+    if (!s) {
+        return false;
+    }
+    out->slot = s;
+    out->image = image_of(s);
+    out->size = s->size;
+    return true;
+}
+
+}  // namespace
+
+extern "C" {
+
+const esp_partition_t *esp_partition_find_first(esp_partition_type_t type,
+                                                esp_partition_subtype_t subtype,
+                                                const char *label) {
+    SharedArena &a = arena();
+    for (uint32_t i = 0; i < a.slot_count; ++i) {
+        SharedSlot *s = &a.slots[i];
+        if (type != ESP_PARTITION_TYPE_ANY && type != ESP_PARTITION_TYPE_DATA) {
+            continue;
+        }
+        if (subtype != ESP_PARTITION_SUBTYPE_ANY && s->subtype != subtype) {
+            continue;
+        }
+        if (label != nullptr && std::strcmp(label, s->label) != 0) {
+            continue;
+        }
+        return desc_for(s);
+    }
+    return nullptr;
+}
+
+esp_err_t esp_partition_read(const esp_partition_t *partition, size_t src_offset,
+                             void *dst, size_t size) {
+    esp_err_t injected = take_injection(flash_fake::Op::Read);
+    if (injected != ESP_OK) {
+        return injected;
+    }
+    Located loc{};
+    if (!locate(partition, &loc) || !dst) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (src_offset + size > loc.size) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    std::memcpy(dst, loc.image + src_offset, size);
+    return ESP_OK;
+}
+
+esp_err_t esp_partition_write(const esp_partition_t *partition, size_t dst_offset,
+                              const void *src, size_t size) {
+    esp_err_t injected = take_injection(flash_fake::Op::Write);
+    if (injected != ESP_OK) {
+        return injected;
+    }
+    Located loc{};
+    if (!locate(partition, &loc) || !src) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (dst_offset + size > loc.size) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if (!g_powered) {
+        // Power is gone: the call "succeeds" from the caller's point of view
+        // but nothing reaches the medium. This is the interesting case.
+        return ESP_OK;
+    }
+    const uint8_t *in = static_cast<const uint8_t *>(src);
+    for (size_t i = 0; i < size; ++i) {
+        // NOR: programming can only clear bits.
+        loc.image[dst_offset + i] &= in[i];
+    }
+    g_bytes_written += size;
+    tick_power();
+    return ESP_OK;
+}
+
+esp_err_t esp_partition_erase_range(const esp_partition_t *partition, size_t offset,
+                                    size_t size) {
+    esp_err_t injected = take_injection(flash_fake::Op::Erase);
+    if (injected != ESP_OK) {
+        return injected;
+    }
+    Located loc{};
+    if (!locate(partition, &loc)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    // The real driver rejects unaligned erases; a fake that accepted them
+    // would hide a class of bug that only appears on hardware.
+    if ((offset % SECTOR) != 0 || (size % SECTOR) != 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (offset + size > loc.size) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if (!g_powered) {
+        return ESP_OK;
+    }
+    std::memset(loc.image + offset, 0xff, size);
+    g_bytes_erased += size;
+    tick_power();
+    return ESP_OK;
+}
+
+}  // extern "C"
+
+namespace flash_fake {
+
+void install(const std::string &label, uint8_t subtype, uint32_t size) {
+    SharedArena &a = arena();
+    SharedSlot *s = slot_for(label.c_str());
+    if (s == nullptr) {
+        if (a.slot_count >= MAX_SLOTS || a.bump + size > ARENA_DATA_SIZE) {
+            std::fprintf(stderr, "flash_fake: arena exhausted\n");
+            std::abort();
+        }
+        s = &a.slots[a.slot_count++];
+        std::snprintf(s->label, sizeof(s->label), "%s", label.c_str());
+        s->data_off = a.bump;
+        a.bump += size;
+    }
+    s->subtype = subtype;
+    s->size = size;
+    std::memset(image_of(s), 0xff, size);
+    g_descs.erase(label);
+}
+
+void install_history_partition() {
+    // Matches partitions.csv: history,data,0x40,0x910000,2M
+    install("history", 0x40, 2 * 1024 * 1024);
+}
+
+void reset() {
+    SharedArena &a = arena();
+    a.slot_count = 0;
+    a.bump = 0;
+    g_descs.clear();
+    g_injections.clear();
+    g_calls.clear();
+    g_power_loss_countdown = -1;
+    g_powered = true;
+    g_bytes_written = 0;
+    g_bytes_erased = 0;
+}
+
+void power_loss_after(int n) {
+    g_power_loss_countdown = n;
+    g_powered = (n != 0);
+}
+
+void fail_next(Op op, esp_err_t err, int count) {
+    g_injections[key_of(op)] = Injection{err, count};
+}
+
+void clear_failures() { g_injections.clear(); }
+
+int call_count(Op op) {
+    auto it = g_calls.find(key_of(op));
+    return it == g_calls.end() ? 0 : it->second;
+}
+
+size_t bytes_written() { return g_bytes_written; }
+size_t bytes_erased() { return g_bytes_erased; }
+
+bool peek(const std::string &label, size_t offset, void *dst, size_t size) {
+    SharedSlot *s = slot_for(label.c_str());
+    if (!s || offset + size > s->size) {
+        return false;
+    }
+    std::memcpy(dst, image_of(s) + offset, size);
+    return true;
+}
+
+void poke(const std::string &label, size_t offset, const void *src, size_t size) {
+    SharedSlot *s = slot_for(label.c_str());
+    if (!s || offset + size > s->size) {
+        return;
+    }
+    std::memcpy(image_of(s) + offset, src, size);
+}
+
+void corrupt_byte(const std::string &label, size_t offset, uint8_t and_mask) {
+    SharedSlot *s = slot_for(label.c_str());
+    if (!s || offset >= s->size) {
+        return;
+    }
+    image_of(s)[offset] &= and_mask;
+}
+
+bool is_erased(const std::string &label, size_t offset, size_t size) {
+    SharedSlot *s = slot_for(label.c_str());
+    if (!s || offset + size > s->size) {
+        return false;
+    }
+    const uint8_t *img = image_of(s);
+    for (size_t i = 0; i < size; ++i) {
+        if (img[offset + i] != 0xff) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace flash_fake

--- a/main/tests/host_stubs/esp_partition_fake.h
+++ b/main/tests/host_stubs/esp_partition_fake.h
@@ -1,0 +1,73 @@
+/*
+ * Test-only controls for the RAM-backed flash fake.
+ *
+ * Kept out of esp_partition.h so production sources cannot reach them.
+ *
+ * The power-loss control is the reason this fake exists. history_storage.cpp
+ * claims that "the old committed bank remains valid until the replacement bank
+ * is fully written and committed" -- an atomicity claim that can only be tested
+ * by cutting power in the middle of a compaction. On the physical controller
+ * that means pulling the plug at exactly the right microsecond, thousands of
+ * times, and reflashing after each attempt. Here it is one function call.
+ *
+ * Partition images live in shared anonymous memory, so they survive a fork.
+ * That is deliberate: history_storage.cpp's init() early-returns once it has a
+ * partition, so an in-process "reboot" is a no-op and any persistence
+ * assertion written that way passes without ever reading flash. Tests get a
+ * real power cycle by running each phase in a forked child -- cold statics,
+ * same medium.
+ */
+#pragma once
+
+#include "esp_partition.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace flash_fake {
+
+// Install a partition table entry backed by `size` bytes of RAM, erased
+// (0xff). Replaces any partition already registered under `label`.
+void install(const std::string &label, uint8_t subtype, uint32_t size);
+
+// The production layout: a 2 MB "history" partition, subtype 0x40, matching
+// partitions.csv. Use this unless a test is specifically about sizing.
+void install_history_partition();
+
+// Drop all partitions and clear every counter and injected fault.
+void reset();
+
+// --- fault and power-loss injection ------------------------------------
+// After `n` more successful flash operations (writes + erases), every
+// subsequent write and erase silently does nothing while still returning
+// ESP_OK. This models the device losing power mid-sequence: the code believes
+// it completed, but the bytes never reached the medium.
+void power_loss_after(int n);
+
+// Make the next `count` calls of the given operation return `err`, without
+// touching the medium. `count < 0` means until reset or cleared.
+enum class Op { Read, Write, Erase };
+void fail_next(Op op, esp_err_t err, int count = 1);
+void clear_failures();
+
+// --- inspection ---------------------------------------------------------
+int call_count(Op op);
+// Bytes actually erased / written since reset. Lets a test show a code path
+// really did rewrite a bank rather than passing because it did nothing.
+size_t bytes_written();
+size_t bytes_erased();
+
+// Raw access to the backing image, bypassing all injection.
+bool peek(const std::string &label, size_t offset, void *dst, size_t size);
+void poke(const std::string &label, size_t offset, const void *src, size_t size);
+
+// Flip bits in the image to model bit rot / a corrupt sector. Unlike poke this
+// is honest about NOR: it can only clear bits, never set them.
+void corrupt_byte(const std::string &label, size_t offset, uint8_t and_mask);
+
+// True when every byte in the range is 0xff.
+bool is_erased(const std::string &label, size_t offset, size_t size);
+
+}  // namespace flash_fake

--- a/main/tests/host_stubs/esp_system.h
+++ b/main/tests/host_stubs/esp_system.h
@@ -1,0 +1,35 @@
+/*
+ * Host stub for ESP-IDF's esp_system.h. Only what the host-built sources use.
+ */
+#pragma once
+
+#include "esp_err.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ESP_RST_UNKNOWN,
+    ESP_RST_POWERON,
+    ESP_RST_EXT,
+    ESP_RST_SW,
+    ESP_RST_PANIC,
+    ESP_RST_INT_WDT,
+    ESP_RST_TASK_WDT,
+    ESP_RST_WDT,
+    ESP_RST_DEEPSLEEP,
+    ESP_RST_BROWNOUT,
+    ESP_RST_SDIO,
+} esp_reset_reason_t;
+
+esp_reset_reason_t esp_reset_reason(void);
+uint32_t esp_get_free_heap_size(void);
+void esp_restart(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/freertos/FreeRTOS.h
+++ b/main/tests/host_stubs/freertos/FreeRTOS.h
@@ -1,0 +1,23 @@
+/*
+ * Host stub for freertos/FreeRTOS.h.
+ *
+ * The host tests are single-threaded, so the scheduler types exist only to let
+ * the sources compile and to make mutex misuse visible (see semphr.h).
+ */
+#pragma once
+
+#include <stdint.h>
+
+typedef uint32_t TickType_t;
+typedef int BaseType_t;
+
+#define pdTRUE 1
+#define pdFALSE 0
+#define pdPASS 1
+#define pdFAIL 0
+
+#define portMAX_DELAY ((TickType_t)0xffffffffUL)
+#define portTICK_PERIOD_MS 1U
+#define pdMS_TO_TICKS(ms) ((TickType_t)(ms))
+
+#define configTICK_RATE_HZ 1000

--- a/main/tests/host_stubs/freertos/semphr.h
+++ b/main/tests/host_stubs/freertos/semphr.h
@@ -1,0 +1,62 @@
+/*
+ * Host stub for freertos/semphr.h.
+ *
+ * Single-threaded, so a mutex cannot actually contend -- but it still counts
+ * depth, so double-take and give-without-take are detectable rather than
+ * silently fine. Those are exactly the mistakes that deadlock or corrupt state
+ * on the device and are invisible in a stub that does nothing.
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+
+#include <stdlib.h>
+
+typedef struct sem_impl {
+    int depth;
+    int takes;
+    int gives;
+    int max_depth;
+} *SemaphoreHandle_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline SemaphoreHandle_t xSemaphoreCreateMutex(void) {
+    SemaphoreHandle_t s = (SemaphoreHandle_t)calloc(1, sizeof(struct sem_impl));
+    return s;
+}
+
+static inline void vSemaphoreDelete(SemaphoreHandle_t s) { free(s); }
+
+static inline BaseType_t xSemaphoreTake(SemaphoreHandle_t s, TickType_t ticks) {
+    (void)ticks;
+    if (!s) {
+        return pdFALSE;
+    }
+    // A recursive take on a plain mutex blocks forever on the device. Report
+    // failure here so a test can assert on it instead of hanging.
+    if (s->depth > 0) {
+        return pdFALSE;
+    }
+    s->depth++;
+    s->takes++;
+    if (s->depth > s->max_depth) {
+        s->max_depth = s->depth;
+    }
+    return pdTRUE;
+}
+
+static inline BaseType_t xSemaphoreGive(SemaphoreHandle_t s) {
+    if (!s || s->depth == 0) {
+        return pdFALSE;
+    }
+    s->depth--;
+    s->gives++;
+    return pdTRUE;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/tests/host_stubs/heap_fake.cpp
+++ b/main/tests/host_stubs/heap_fake.cpp
@@ -1,0 +1,88 @@
+/*
+ * Host heap stub. See heap_fake.h.
+ */
+
+#include "heap_fake.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+int g_fail_remaining = 0;
+int g_allocs = 0;
+int g_frees = 0;
+
+bool should_fail() {
+    if (g_fail_remaining == 0) {
+        return false;
+    }
+    if (g_fail_remaining > 0) {
+        --g_fail_remaining;
+    }
+    return true;
+}
+}  // namespace
+
+extern "C" {
+
+void *heap_caps_malloc(size_t size, uint32_t caps) {
+    (void)caps;
+    if (should_fail()) {
+        return nullptr;
+    }
+    void *p = std::malloc(size);
+    if (p) {
+        ++g_allocs;
+    }
+    return p;
+}
+
+void *heap_caps_calloc(size_t n, size_t size, uint32_t caps) {
+    (void)caps;
+    if (should_fail()) {
+        return nullptr;
+    }
+    void *p = std::calloc(n, size);
+    if (p) {
+        ++g_allocs;
+    }
+    return p;
+}
+
+void heap_caps_free(void *ptr) {
+    if (ptr) {
+        ++g_frees;
+    }
+    std::free(ptr);
+}
+
+// Fixed plausible values: nothing host-tested reasons about the real numbers,
+// and returning 0 would make callers believe the device is out of memory.
+size_t heap_caps_get_free_size(uint32_t caps) {
+    (void)caps;
+    return 200 * 1024;
+}
+
+size_t heap_caps_get_minimum_free_size(uint32_t caps) {
+    (void)caps;
+    return 100 * 1024;
+}
+
+}  // extern "C"
+
+namespace heap_fake {
+
+void fail_next_alloc(int count) { g_fail_remaining = count; }
+void clear_failures() { g_fail_remaining = 0; }
+
+void reset() {
+    g_fail_remaining = 0;
+    g_allocs = 0;
+    g_frees = 0;
+}
+
+int alloc_count() { return g_allocs; }
+int free_count() { return g_frees; }
+int outstanding() { return g_allocs - g_frees; }
+
+}  // namespace heap_fake

--- a/main/tests/host_stubs/heap_fake.h
+++ b/main/tests/host_stubs/heap_fake.h
@@ -1,0 +1,27 @@
+/*
+ * Test-only controls for the host heap stub.
+ *
+ * An unchecked heap_caps_malloc is a device-only crash: on the host malloc
+ * effectively never fails, so the NULL branch is never taken and never tested.
+ * fail_next_alloc() makes that branch reachable.
+ */
+#pragma once
+
+#include "esp_heap_caps.h"
+
+#include <cstddef>
+
+namespace heap_fake {
+
+// Fail the next `count` allocations by returning NULL.
+void fail_next_alloc(int count = 1);
+void clear_failures();
+
+// Allocation bookkeeping since reset(). outstanding() > 0 after an operation
+// that should have cleaned up is a leak.
+void reset();
+int alloc_count();
+int free_count();
+int outstanding();
+
+}  // namespace heap_fake

--- a/main/tests/test_history_storage.cpp
+++ b/main/tests/test_history_storage.cpp
@@ -1,0 +1,635 @@
+// Native unit tests for main/history_storage.cpp -- the dual-bank event
+// journal and the telemetry ring, run against a flash image with real NOR
+// semantics.
+//
+// What existed before: tests/api/test_temperature_history.py, which opens
+// history_storage.cpp as TEXT and asserts that certain strings appear in it.
+// It would pass with the flash layout completely broken. Everything else was a
+// black-box HTTP call to the one physical controller, which cannot erase and
+// refill a 2 MB partition per assertion, and certainly cannot lose power in
+// the middle of a compaction.
+//
+// The claims under test are the ones the header makes and nothing verified:
+//   * "the old committed bank remains valid until the replacement bank is
+//     fully written and committed"  (history_storage.h, replace_events)
+//   * records survive a reboot, and a corrupt record is rejected rather than
+//     returned as plausible garbage
+//   * the telemetry ring wraps without losing the ordering guarantee
+//
+// HOW A REBOOT IS MODELLED (this matters -- see run_scenario below):
+// history_storage.cpp holds its state in file-scope statics and its init()
+// early-returns once s_partition is set. So calling init() a second time in
+// the same process does nothing, and any "survives a reboot" assertion written
+// that way passes vacuously -- it re-reads RAM, never flash. A reboot here is
+// therefore a new process (fork, cold statics) over a flash image held in
+// shared memory (the medium outlives the process, exactly like real hardware).
+//
+// Refs #217 (T10, T14).
+
+#include "esp_partition_fake.h"
+#include "heap_fake.h"
+#include "history_storage.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);  \
+            ++g_failures;                                                  \
+        }                                                                  \
+    } while (0)
+
+#define CHECK_ERR(expr, expected)                                              \
+    do {                                                                       \
+        esp_err_t e_ = (expr);                                                 \
+        if (e_ != (expected)) {                                                \
+            std::printf("  FAIL %s:%d: %s -> %s, expected %s\n", __FILE__,     \
+                        __LINE__, #expr, esp_err_to_name(e_),                  \
+                        esp_err_to_name(expected));                            \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+namespace {
+
+constexpr size_t EVENT_REGION = HISTORY_EVENT_REGION_SIZE;
+
+event_entry_t make_event(uint32_t ts, uint32_t payload) {
+    event_entry_t e{};
+    e.timestamp = ts;
+    e.boot_id = 0xABCD1234;
+    e.uptime_ms = ts * 1000ull;
+    e.type = (event_type_t)1;
+    e.payload = payload;
+    return e;
+}
+
+history_telemetry_sample_t make_sample(uint32_t ts, uint32_t seq, int16_t inlet) {
+    history_telemetry_sample_t s{};
+    s.timestamp = ts;
+    s.sequence = seq;
+    s.inlet_deci_c = inlet;
+    s.outlet_deci_c = (int16_t)(inlet + 20);
+    s.setpoint_deci_c = 450;
+    s.mode = HISTORY_TELEMETRY_MODE_HEATING;
+    s.flags = HISTORY_TELEMETRY_CONNECTED | HISTORY_TELEMETRY_INLET_VALID;
+    return s;
+}
+
+// First boot of a device whose history partition has never been written.
+void fresh_device() {
+    flash_fake::install_history_partition();
+    CHECK_ERR(history_storage_init(), ESP_OK);
+}
+
+// A later boot: the image is whatever the previous phase left behind.
+void boot() { CHECK_ERR(history_storage_init(), ESP_OK); }
+
+struct LoadResult {
+    std::vector<event_entry_t> entries;
+    std::vector<uint32_t> ids;
+    size_t count = 0;
+    uint32_t next_id = 0;
+};
+
+LoadResult load_events(size_t capacity = 64) {
+    LoadResult r;
+    r.entries.resize(capacity);
+    r.ids.resize(capacity);
+    CHECK_ERR(history_storage_load_events(r.entries.data(), r.ids.data(), capacity,
+                                          &r.count, &r.next_id),
+              ESP_OK);
+    return r;
+}
+
+size_t telemetry_count() {
+    std::vector<history_telemetry_sample_t> out(4096);
+    size_t count = 0;
+    CHECK_ERR(history_storage_query_telemetry(0, 0xffffffff, out.data(), out.size(),
+                                              &count),
+              ESP_OK);
+    return count;
+}
+
+// ------------------------------------------------------------------------
+// Initialisation
+// ------------------------------------------------------------------------
+void init_requires_the_partition() {
+    // No partition installed at all.
+    CHECK_ERR(history_storage_init(), ESP_ERR_NOT_FOUND);
+}
+
+void init_rejects_a_partition_that_is_too_small() {
+    flash_fake::install("history", 0x40, EVENT_REGION - 4096);
+    CHECK_ERR(history_storage_init(), ESP_ERR_INVALID_SIZE);
+}
+
+void blank_device_yields_an_empty_journal() {
+    fresh_device();
+    CHECK(load_events().count == 0);
+}
+
+void init_formats_the_journal_rather_than_trusting_erased_flash() {
+    // A blank device must end up with a committed bank header, otherwise the
+    // first append after a power cut would have nothing to attach to.
+    fresh_device();
+    CHECK(flash_fake::bytes_written() > 0);
+    CHECK(!flash_fake::is_erased("history", 0, 32));
+}
+
+// ------------------------------------------------------------------------
+// Append / reload
+// ------------------------------------------------------------------------
+void write_two_events() {
+    fresh_device();
+    event_entry_t a = make_event(1000, 11);
+    event_entry_t b = make_event(2000, 22);
+    CHECK_ERR(history_storage_append_event(1, &a), ESP_OK);
+    CHECK_ERR(history_storage_append_event(2, &b), ESP_OK);
+    CHECK(load_events().count == 2);
+}
+
+void expect_two_events_after_reboot() {
+    boot();
+    LoadResult r = load_events();
+    CHECK(r.count == 2);
+    if (r.count == 2) {
+        CHECK(r.entries[0].timestamp == 1000 && r.entries[0].payload == 11);
+        CHECK(r.entries[1].timestamp == 2000 && r.entries[1].payload == 22);
+        CHECK(r.ids[0] == 1 && r.ids[1] == 2);
+    }
+}
+
+void events_load_oldest_first() {
+    fresh_device();
+    for (uint32_t i = 1; i <= 5; ++i) {
+        event_entry_t e = make_event(i * 100, i);
+        CHECK_ERR(history_storage_append_event(i, &e), ESP_OK);
+    }
+    LoadResult r = load_events();
+    CHECK(r.count == 5);
+    for (size_t i = 0; i + 1 < r.count; ++i) {
+        CHECK(r.entries[i].timestamp < r.entries[i + 1].timestamp);
+    }
+}
+
+void write_event_then_backfill_its_timestamp() {
+    // The header calls this out: updating an existing event reuses the event
+    // ID so a timestamp backfill does not rewrite flash.
+    fresh_device();
+    event_entry_t e = make_event(0, 7);  // time not synced yet
+    CHECK_ERR(history_storage_append_event(42, &e), ESP_OK);
+    e.timestamp = 1700000000;            // backfilled after NTP
+    CHECK_ERR(history_storage_append_event(42, &e), ESP_OK);
+}
+
+void expect_one_backfilled_event_after_reboot() {
+    boot();
+    LoadResult r = load_events();
+    CHECK(r.count == 1);
+    if (r.count == 1) {
+        CHECK(r.ids[0] == 42);
+        CHECK(r.entries[0].timestamp == 1700000000);
+    }
+}
+
+void write_event_with_id_nine() {
+    fresh_device();
+    event_entry_t e = make_event(500, 1);
+    CHECK_ERR(history_storage_append_event(9, &e), ESP_OK);
+}
+
+void expect_next_event_id_past_nine() {
+    boot();
+    CHECK(load_events().next_id > 9);
+}
+
+void load_respects_caller_capacity() {
+    fresh_device();
+    for (uint32_t i = 1; i <= 10; ++i) {
+        event_entry_t e = make_event(i * 10, i);
+        CHECK_ERR(history_storage_append_event(i, &e), ESP_OK);
+    }
+    CHECK(load_events(4).count <= 4);
+}
+
+// ------------------------------------------------------------------------
+// Corruption
+// ------------------------------------------------------------------------
+void write_two_events_then_corrupt_the_first_record() {
+    fresh_device();
+    event_entry_t a = make_event(1000, 11);
+    event_entry_t b = make_event(2000, 22);
+    CHECK_ERR(history_storage_append_event(1, &a), ESP_OK);
+    CHECK_ERR(history_storage_append_event(2, &b), ESP_OK);
+    CHECK(load_events().count == 2);
+
+    // Clear bits inside the first record. NOR can only clear bits, so this is
+    // a physically possible corruption and the CRC must notice.
+    for (size_t off = 4096; off < 4096 + 64; ++off) {
+        flash_fake::corrupt_byte("history", off, 0x7f);
+    }
+}
+
+void expect_corrupt_record_rejected_after_reboot() {
+    boot();
+    LoadResult r = load_events();
+    // The corrupted record must not be handed back as if it were valid.
+    CHECK(r.count < 2);
+    for (size_t i = 0; i < r.count; ++i) {
+        CHECK(r.entries[i].timestamp == 2000);
+        CHECK(r.entries[i].payload == 22);
+    }
+}
+
+void write_an_event_then_wipe_the_journal() {
+    fresh_device();
+    event_entry_t a = make_event(1000, 11);
+    CHECK_ERR(history_storage_append_event(1, &a), ESP_OK);
+
+    // Both bank headers destroyed, as after a bad flash or a factory erase.
+    std::vector<uint8_t> blank(EVENT_REGION, 0xff);
+    flash_fake::poke("history", 0, blank.data(), blank.size());
+}
+
+void expect_wiped_journal_reinitialises_and_is_usable() {
+    boot();
+    CHECK(load_events().count == 0);  // empty, but not broken
+    event_entry_t b = make_event(3000, 33);
+    CHECK_ERR(history_storage_append_event(1, &b), ESP_OK);
+    CHECK(load_events().count == 1);
+}
+
+// ------------------------------------------------------------------------
+// Compaction atomicity -- the claim that motivated this whole harness
+// ------------------------------------------------------------------------
+void compact_eight_events() {
+    fresh_device();
+    std::vector<event_entry_t> entries;
+    std::vector<uint32_t> ids;
+    for (uint32_t i = 0; i < 8; ++i) {
+        entries.push_back(make_event(1000 + i, i));
+        ids.push_back(i + 1);
+    }
+    CHECK_ERR(history_storage_replace_events(entries.data(), ids.data(),
+                                             entries.size(), 0, entries.size()),
+              ESP_OK);
+    CHECK(load_events().count == 8);
+}
+
+void expect_eight_events_after_reboot() {
+    boot();
+    CHECK(load_events().count == 8);
+}
+
+void lose_power_partway_through_a_compaction() {
+    // history_storage.h: "The old committed bank remains valid until the
+    // replacement bank is fully written and committed."
+    //
+    // This is THE atomicity claim, and it is unreachable on hardware without
+    // cutting power at an exact instant. Here it is one function call -- but a
+    // SINGLE cut point is not enough. The first version of this test cut power
+    // after exactly 2 flash operations, and a mutant that committed the
+    // replacement bank before writing any records into it still passed,
+    // because at that one instant the two behaved alike. The cut point is
+    // swept by the caller (see HS_POWER_LOSS_AFTER) so every step of the
+    // sequence is exercised.
+    const char *env = getenv("HS_POWER_LOSS_AFTER");
+    const int cut = env ? atoi(env) : 2;
+
+    fresh_device();
+    for (uint32_t i = 1; i <= 4; ++i) {
+        event_entry_t e = make_event(i * 100, i);
+        CHECK_ERR(history_storage_append_event(i, &e), ESP_OK);
+    }
+    CHECK(load_events().count == 4);
+
+    std::vector<event_entry_t> entries;
+    std::vector<uint32_t> ids;
+    for (uint32_t i = 0; i < 4; ++i) {
+        entries.push_back(make_event(9000 + i, 90 + i));
+        ids.push_back(100 + i);
+    }
+
+    flash_fake::power_loss_after(cut);
+    history_storage_replace_events(entries.data(), ids.data(), entries.size(), 0,
+                                   entries.size());
+}
+
+void expect_old_bank_intact_after_interrupted_compaction() {
+    boot();
+    LoadResult r = load_events();
+
+    // The four original events, or the four replacements -- never a mixture,
+    // never a truncated journal, never an empty one.
+    bool old_intact = (r.count == 4 && r.entries[0].timestamp == 100 &&
+                       r.entries[3].timestamp == 400);
+    bool new_committed = (r.count == 4 && r.entries[0].payload == 90 &&
+                          r.entries[3].payload == 93);
+    if (!old_intact && !new_committed) {
+        const char *env = getenv("HS_POWER_LOSS_AFTER");
+        std::printf("  FAIL: power lost after %s flash op(s): the journal held "
+                    "%zu event(s); expected the old 4 or the new 4\n",
+                    env ? env : "?", r.count);
+        for (size_t i = 0; i < r.count && i < 8; ++i) {
+            std::printf("        [%zu] ts=%u payload=%u\n", i,
+                        (unsigned)r.entries[i].timestamp,
+                        (unsigned)r.entries[i].payload);
+        }
+        ++g_failures;
+    }
+}
+
+void fail_the_erase_that_starts_a_compaction() {
+    fresh_device();
+    for (uint32_t i = 1; i <= 3; ++i) {
+        event_entry_t e = make_event(i * 100, i);
+        CHECK_ERR(history_storage_append_event(i, &e), ESP_OK);
+    }
+    std::vector<event_entry_t> entries{make_event(7000, 70)};
+    std::vector<uint32_t> ids{55};
+
+    flash_fake::fail_next(flash_fake::Op::Erase, ESP_FAIL, -1);
+    esp_err_t err =
+        history_storage_replace_events(entries.data(), ids.data(), 1, 0, 1);
+    flash_fake::clear_failures();
+    CHECK(err != ESP_OK);  // the failure must be reported, not swallowed
+}
+
+void expect_three_events_after_failed_compaction() {
+    boot();
+    CHECK(load_events().count == 3);  // untouched
+}
+
+// ------------------------------------------------------------------------
+// Telemetry ring
+// ------------------------------------------------------------------------
+void telemetry_round_trips() {
+    fresh_device();
+    for (uint32_t i = 0; i < 10; ++i) {
+        history_telemetry_sample_t s =
+            make_sample(1000 + i * 30, i + 1, (int16_t)(200 + i));
+        CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+    }
+    std::vector<history_telemetry_sample_t> out(64);
+    size_t count = 0;
+    CHECK_ERR(history_storage_query_telemetry(0, 0xffffffff, out.data(), out.size(),
+                                              &count),
+              ESP_OK);
+    CHECK(count == 10);
+    for (size_t i = 0; i + 1 < count; ++i) {
+        CHECK(out[i].timestamp <= out[i + 1].timestamp);
+    }
+}
+
+void write_five_telemetry_samples() {
+    fresh_device();
+    for (uint32_t i = 0; i < 5; ++i) {
+        history_telemetry_sample_t s =
+            make_sample(5000 + i * 30, i + 1, (int16_t)(300 + i));
+        CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+    }
+    CHECK(telemetry_count() == 5);
+}
+
+void expect_five_telemetry_samples_after_reboot() {
+    boot();
+    CHECK(telemetry_count() == 5);
+}
+
+void telemetry_query_filters_by_time_window() {
+    fresh_device();
+    for (uint32_t i = 0; i < 20; ++i) {
+        history_telemetry_sample_t s =
+            make_sample(1000 + i * 30, i + 1, (int16_t)(100 + i));
+        CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+    }
+    std::vector<history_telemetry_sample_t> out(64);
+    size_t count = 0;
+    CHECK_ERR(history_storage_query_telemetry(1300, 1450, out.data(), out.size(),
+                                              &count),
+              ESP_OK);
+    CHECK(count > 0);
+    CHECK(count < 20);  // it really filtered, rather than returning everything
+    for (size_t i = 0; i < count; ++i) {
+        CHECK(out[i].timestamp >= 1300 && out[i].timestamp <= 1450);
+    }
+}
+
+void latest_telemetry_timestamp_tracks_the_newest_sample() {
+    fresh_device();
+    for (uint32_t i = 0; i < 6; ++i) {
+        history_telemetry_sample_t s = make_sample(2000 + i * 30, i + 1, 150);
+        CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+    }
+    uint32_t ts = 0;
+    CHECK_ERR(history_storage_latest_telemetry_timestamp(&ts), ESP_OK);
+    CHECK(ts == 2000 + 5 * 30);
+}
+
+void telemetry_ring_wraps_without_losing_ordering() {
+    // Fill past one page so the ring has to roll over. The failure this guards
+    // against is a wrapped ring returning samples out of order, which renders
+    // the history graph as a sawtooth.
+    fresh_device();
+    const uint32_t n = HISTORY_TELEMETRY_PAGE_CAPACITY + 250;
+    for (uint32_t i = 0; i < n; ++i) {
+        history_telemetry_sample_t s =
+            make_sample(10000 + i * 30, i + 1, (int16_t)(100 + (i % 50)));
+        CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+    }
+    std::vector<history_telemetry_sample_t> out(n + 16);
+    size_t count = 0;
+    CHECK_ERR(history_storage_query_telemetry(0, 0xffffffff, out.data(), out.size(),
+                                              &count),
+              ESP_OK);
+    CHECK(count > HISTORY_TELEMETRY_PAGE_CAPACITY);
+    for (size_t i = 0; i + 1 < count; ++i) {
+        CHECK(out[i].timestamp <= out[i + 1].timestamp);
+    }
+    // The newest sample must still be the newest after wrapping.
+    if (count > 0) {
+        CHECK(out[count - 1].timestamp == 10000 + (n - 1) * 30);
+    }
+}
+
+void telemetry_write_failure_is_reported_not_swallowed() {
+    fresh_device();
+    flash_fake::fail_next(flash_fake::Op::Write, ESP_FAIL, -1);
+    history_telemetry_sample_t s = make_sample(4000, 1, 210);
+    esp_err_t err = history_storage_append_telemetry(&s);
+    flash_fake::clear_failures();
+    CHECK(err != ESP_OK);
+}
+
+// ------------------------------------------------------------------------
+// Shutdown paths
+// ------------------------------------------------------------------------
+void begin_reboot_stops_accepting_writes() {
+    // The comment on history_storage_begin_reboot explains that an in-flight
+    // SPI-flash op during esp_restart_noos() faults in ROM. So once it is
+    // called, nothing may reach the medium again.
+    fresh_device();
+    history_telemetry_sample_t s = make_sample(6000, 1, 220);
+    CHECK_ERR(history_storage_append_telemetry(&s), ESP_OK);
+
+    size_t before = flash_fake::bytes_written();
+    history_storage_begin_reboot();
+
+    history_telemetry_sample_t s2 = make_sample(6030, 2, 221);
+    history_storage_append_telemetry(&s2);
+    event_entry_t e = make_event(6060, 5);
+    history_storage_append_event(77, &e);
+
+    CHECK(flash_fake::bytes_written() == before);
+}
+
+void no_leaks_across_a_full_cycle() {
+    fresh_device();
+    for (uint32_t i = 1; i <= 12; ++i) {
+        event_entry_t e = make_event(i * 100, i);
+        CHECK_ERR(history_storage_append_event(i, &e), ESP_OK);
+    }
+    std::vector<event_entry_t> entries;
+    std::vector<uint32_t> ids;
+    for (uint32_t i = 0; i < 6; ++i) {
+        entries.push_back(make_event(20000 + i, i));
+        ids.push_back(200 + i);
+    }
+    CHECK_ERR(history_storage_replace_events(entries.data(), ids.data(),
+                                             entries.size(), 0, entries.size()),
+              ESP_OK);
+    (void)load_events();
+    CHECK(heap_fake::outstanding() == 0);
+}
+
+using Phase = void (*)();
+
+// Run one scenario. Each phase executes in its own forked child, so its
+// firmware-side statics start cold, while the flash image (shared memory)
+// carries over -- a genuine power cycle rather than a re-entrant init() call.
+int run_scenario(const char *name, std::vector<Phase> phases) {
+    flash_fake::reset();
+    heap_fake::reset();
+
+    for (size_t i = 0; i < phases.size(); ++i) {
+        std::fflush(stdout);
+        pid_t pid = fork();
+        if (pid == 0) {
+            g_failures = 0;
+            phases[i]();
+            std::fflush(stdout);
+            _exit(g_failures == 0 ? 0 : 1);
+        }
+        if (pid < 0) {
+            std::printf("FAIL [%s]: fork failed\n", name);
+            return 1;
+        }
+        int status = 0;
+        waitpid(pid, &status, 0);
+        if (WIFSIGNALED(status)) {
+            std::printf("FAIL [%s] phase %zu: crashed with signal %d\n", name, i + 1,
+                        WTERMSIG(status));
+            return 1;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            std::printf("FAIL [%s] phase %zu\n", name, i + 1);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    int failed = 0;
+    int total = 0;
+
+#define SCENARIO(name, ...)                              \
+    do {                                                 \
+        ++total;                                         \
+        failed += run_scenario(name, {__VA_ARGS__});     \
+    } while (0)
+
+    SCENARIO("init requires the partition", init_requires_the_partition);
+    SCENARIO("init rejects an undersized partition",
+             init_rejects_a_partition_that_is_too_small);
+    SCENARIO("blank device yields an empty journal",
+             blank_device_yields_an_empty_journal);
+    SCENARIO("init formats the journal",
+             init_formats_the_journal_rather_than_trusting_erased_flash);
+
+    SCENARIO("events survive a reboot", write_two_events,
+             expect_two_events_after_reboot);
+    SCENARIO("events load oldest first", events_load_oldest_first);
+    SCENARIO("a timestamp backfill reuses the event id",
+             write_event_then_backfill_its_timestamp,
+             expect_one_backfilled_event_after_reboot);
+    SCENARIO("next event id advances past what is stored",
+             write_event_with_id_nine, expect_next_event_id_past_nine);
+    SCENARIO("load respects caller capacity", load_respects_caller_capacity);
+
+    SCENARIO("a corrupt record is rejected, not returned",
+             write_two_events_then_corrupt_the_first_record,
+             expect_corrupt_record_rejected_after_reboot);
+    SCENARIO("a wiped journal reinitialises instead of failing",
+             write_an_event_then_wipe_the_journal,
+             expect_wiped_journal_reinitialises_and_is_usable);
+
+    SCENARIO("compaction moves events into the other bank", compact_eight_events,
+             expect_eight_events_after_reboot);
+
+    // Sweep the instant of power loss across the whole compaction sequence.
+    // Any single cut point can accidentally agree with a broken
+    // implementation; the invariant has to hold at every one of them.
+    for (int cut = 0; cut <= 12; ++cut) {
+        char value[8];
+        std::snprintf(value, sizeof(value), "%d", cut);
+        setenv("HS_POWER_LOSS_AFTER", value, 1);
+        char name[96];
+        std::snprintf(name, sizeof(name),
+                      "power loss after %d flash op(s) keeps the old bank", cut);
+        SCENARIO(name, lose_power_partway_through_a_compaction,
+                 expect_old_bank_intact_after_interrupted_compaction);
+    }
+    unsetenv("HS_POWER_LOSS_AFTER");
+
+    SCENARIO("a failed erase does not destroy the committed bank",
+             fail_the_erase_that_starts_a_compaction,
+             expect_three_events_after_failed_compaction);
+
+    SCENARIO("telemetry round trips", telemetry_round_trips);
+    SCENARIO("telemetry survives a reboot", write_five_telemetry_samples,
+             expect_five_telemetry_samples_after_reboot);
+    SCENARIO("telemetry query filters by time window",
+             telemetry_query_filters_by_time_window);
+    SCENARIO("latest telemetry timestamp tracks the newest sample",
+             latest_telemetry_timestamp_tracks_the_newest_sample);
+    SCENARIO("telemetry ring wraps without losing ordering",
+             telemetry_ring_wraps_without_losing_ordering);
+    SCENARIO("telemetry write failure is reported",
+             telemetry_write_failure_is_reported_not_swallowed);
+
+    SCENARIO("no leaks across a full cycle", no_leaks_across_a_full_cycle);
+    SCENARIO("begin_reboot stops accepting writes",
+             begin_reboot_stops_accepting_writes);
+
+#undef SCENARIO
+
+    if (failed) {
+        std::printf("%d of %d history_storage scenario(s) failed\n", failed, total);
+        return 1;
+    }
+    std::printf("history_storage: %d scenarios passed\n", total);
+    return 0;
+}


### PR DESCRIPTION
Stacked on #240 (the native host harness). GitHub will retarget this to `main` when #240 merges.

## Why

`main/history_storage.cpp` owns the dual-bank event journal and the telemetry ring in the 2 MB history partition. Nothing verified it.

The only test that names it, `tests/api/test_temperature_history.py`, opens the file **as text** and asserts that certain strings appear in it. It passes with the flash layout completely broken. Everything else that touches history is a black-box HTTP call to the one physical controller, which cannot erase and refill a 2 MB partition per assertion — and certainly cannot lose power in the middle of a compaction.

## What is now tested

34 scenarios: append/reload, oldest-first ordering, timestamp backfill reusing an event id, CRC rejection of a corrupt record, recovery from a wiped journal, compaction, telemetry round-trip, time-window filtering, ring wraparound, and the shutdown paths.

The interesting one is the claim in `history_storage.h`:

> The old committed bank remains valid until the replacement bank is fully written and committed.

That is now tested by **cutting power at every step of the compaction sequence** (0..12 flash operations) and asserting the journal afterwards holds either the old four events or the new four — never a mixture, never an empty journal. The real implementation passes at all 13 cut points.

## Two things worth reviewing

**1. The flash fake models NOR, not memcpy.** Writes AND bits rather than overwriting them, and unaligned erases are rejected. A memcpy-style fake reads back exactly what was written, so "wrote without erasing first" is invisible on the host and only shows up as corruption on hardware, much later and somewhere else.

**2. A reboot is a fork, not a second `init()` call.** `history_storage_init()` early-returns once `s_partition` is set, so calling it twice in one process does nothing — a "survives a reboot" test written that way re-reads RAM and never touches flash. Each scenario phase runs in a forked child with cold statics over a flash image in shared memory, which is what a reboot actually is.

The first draft did neither and produced 39 failures that were all cross-test contamination and no real defect.

## Evidence it works

Mutation testing — eight plausible defects in `history_storage.cpp`, all caught:

| mutant | caught by |
|---|---|
| commit the replacement bank **before** writing its records | power loss after 3 ops |
| compact into the **active** bank | power loss after 1 op |
| skip the erase before writing the replacement bank | failed-erase scenario |
| ignore the record CRC | corrupt-record scenario |
| ignore the bank header CRC | init-formats-journal scenario |
| swallow telemetry write errors | telemetry-write-failure scenario |
| let writes through after `begin_reboot()` | begin_reboot scenario |
| accept an undersized partition | init-rejects-undersized scenario |

The first mutant is why power loss is **swept** rather than fired at one point: with the original single cut after two operations it **survived**, because at that exact instant it was indistinguishable from correct code.

## CI

`history_storage.cpp` joins `MAIN_HOST_SRCS`, the ctest floor rises 2 → 3, and the object-file guard now also requires `history_storage.cpp.o`, so the job cannot quietly degrade into compiling only the stubs.

No firmware behaviour changes — this PR adds tests and host stubs only.

Refs #217 (T10, T14).
