### PR TITLE
fix(api): keep TLS connections alive on 405 responses (#234)

### DIFF
--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -111,6 +111,8 @@ static esp_err_t http_https_required_handler(httpd_req_t* req,
                                              httpd_err_code_t err);
 static esp_err_t https_api_not_found_handler(httpd_req_t* req,
                                              httpd_err_code_t err);
+static esp_err_t https_api_method_not_allowed_handler(httpd_req_t* req,
+                                                      httpd_err_code_t err);
 static esp_err_t web_login_handler(httpd_req_t* req);
 static esp_err_t web_logout_handler(httpd_req_t* req);
 static esp_err_t favicon_handler(httpd_req_t* req);
@@ -1570,6 +1572,30 @@ bool api_server_start(void)
         }
     }
 
+    // Keep wrong-method requests from tearing down the TLS connection. See
+    // https_api_method_not_allowed_handler for why this is load-bearing
+    // (issue #234). Registered on both TLS servers; port 80 is left alone
+    // because a plaintext close costs no handshake and mandatory HTTPS keeps
+    // that port a deliberate dead end.
+    if (server_ssl != NULL) {
+        esp_err_t rerr = httpd_register_err_handler(
+            server_ssl, HTTPD_405_METHOD_NOT_ALLOWED,
+            https_api_method_not_allowed_handler);
+        if (rerr != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to register HTTPS 405 handler: %s",
+                     esp_err_to_name(rerr));
+        }
+    }
+    if (server_integration != NULL) {
+        esp_err_t rerr = httpd_register_err_handler(
+            server_integration, HTTPD_405_METHOD_NOT_ALLOWED,
+            https_api_method_not_allowed_handler);
+        if (rerr != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to register HA 405 handler: %s",
+                     esp_err_to_name(rerr));
+        }
+    }
+
     ESP_LOGI(TAG, "HTTP server started on port 80");
     if (server_ssl != NULL) {
         ESP_LOGI(TAG, "HTTPS server started on port 443");
@@ -1690,6 +1716,50 @@ static esp_err_t https_api_not_found_handler(httpd_req_t* req,
              http_method_str((enum http_method)req->method), req->uri);
 
     httpd_resp_set_status(req, "404 Not Found");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+// 405 handler for the TLS servers. This exists for connection lifetime, not
+// for the response body.
+//
+// With no handler registered for an error code, esp_http_server's default path
+// sends the response and then deliberately closes the connection --
+// components/esp_http_server/src/httpd_txrx.c: "If no handler is registered for
+// this error default behavior is to send the HTTP error response and return
+// failure for closure of underlying socket".
+//
+// On a TLS server that makes every wrong-method request cost a full session
+// handshake for the *next* request, and leaves a device-side TIME_WAIT PCB
+// behind (the device is the active closer). The API schema fuzz walks every
+// endpoint with every method, so this ran at roughly five handshakes per second
+// for minutes. Internal (non-PSRAM) RAM is the scarce resource here, and it
+// drained until mDNS could not allocate its 176-byte receive buffer. mDNS
+// receives on the lwIP tcpip thread, so that starvation stalled the thread
+// itself ("PCB walk TIMED OUT"), at which point the device stopped completing
+// TCP handshakes and unrelated suites failed with ConnectTimeout. That is
+// issue #234.
+//
+// Returning ESP_OK keeps the connection alive, exactly as the two 404 handlers
+// above already do -- 404s never had this problem precisely because they are
+// handled. This is not only a test concern: without it any unauthenticated
+// client can force unbounded TLS renegotiation using nothing but wrong-method
+// requests, which costs the attacker far less than it costs the device.
+static esp_err_t https_api_method_not_allowed_handler(httpd_req_t* req,
+                                                      httpd_err_code_t err)
+{
+    (void)err;
+
+    ESP_LOGW(TAG, "HTTPS 405: method %d not allowed for %s",
+             req->method, req->uri);
+
+    char body[256];
+    snprintf(body, sizeof(body),
+             "{\"error\":\"Method Not Allowed\",\"uri\":\"%.160s\"}",
+             req->uri);
+
+    httpd_resp_set_status(req, "405 Method Not Allowed");
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;

--- a/tests/api/test_error_response_keepalive.py
+++ b/tests/api/test_error_response_keepalive.py
@@ -1,0 +1,140 @@
+"""
+Connection-lifetime contract for HTTP error responses.
+
+An error response must not cost the client its connection. This is not a
+cosmetic concern on this device -- it is issue #234.
+
+esp_http_server's default behaviour, when no handler is registered for an
+error code, is to send the response and then close the socket. Its own source
+says so (components/esp_http_server/src/httpd_txrx.c): "If no handler is
+registered for this error default behavior is to send the HTTP error response
+and return failure for closure of underlying socket".
+
+On a TLS server that means every wrong-method request forces a fresh session
+handshake for the next one, and leaves a device-side TIME_WAIT PCB behind.
+The API schema fuzz walks every endpoint with every method, which ran this at
+roughly five handshakes per second for minutes. Internal (non-PSRAM) RAM is
+the scarce resource on this part, and it drained until mDNS could not
+allocate its 176-byte receive buffer. mDNS receives on the lwIP tcpip thread,
+so that starvation stalled the thread itself, and the device stopped
+completing TCP handshakes -- surfacing as ConnectTimeout in unrelated suites.
+
+These tests use http.client rather than requests deliberately. requests
+transparently opens a replacement connection when the server closes one, which
+would hide exactly the regression being guarded here.
+
+Prerequisites:
+  - Device reachable at ARCTIC_URL
+  - ARCTIC_API_KEY env var set
+"""
+
+import http.client
+import os
+import ssl
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+_env_file = Path(__file__).resolve().parent.parent.parent / ".env"
+if _env_file.exists():
+    from dotenv import load_dotenv
+    load_dotenv(_env_file)
+
+BASE_URL = os.environ.get("ARCTIC_URL", "http://arctic.local")
+API_KEY = os.environ.get("ARCTIC_API_KEY")
+
+# A URI that certainly exists and is GET-only, so a non-GET yields 405 (URI
+# matched, method did not) rather than 404 (URI never matched).
+PROBE_PATH = "/api/health"
+WRONG_METHOD = "DELETE"
+
+
+def _connect():
+    """Open a single connection we control the lifetime of."""
+    parsed = urlparse(BASE_URL)
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if parsed.scheme == "https":
+        ctx = ssl._create_unverified_context()
+        return http.client.HTTPSConnection(host, port, timeout=10, context=ctx)
+    return http.client.HTTPConnection(host, port, timeout=10)
+
+
+def _headers():
+    return {"X-API-Key": API_KEY} if API_KEY else {}
+
+
+def _request(conn, method, path):
+    """Issue one request and fully drain it so the connection stays reusable."""
+    conn.request(method, path, headers=_headers())
+    resp = conn.getresponse()
+    resp.read()
+    return resp.status
+
+
+@pytest.fixture
+def conn():
+    try:
+        c = _connect()
+        c.connect()
+    except OSError as exc:
+        pytest.skip(f"Device unreachable at {BASE_URL}: {exc}")
+    yield c
+    c.close()
+
+
+def test_wrong_method_still_answers_405(conn):
+    """Guard the premise: the probe really does produce a 405, not a 404."""
+    status = _request(conn, WRONG_METHOD, PROBE_PATH)
+    assert status == 405, (
+        f"{WRONG_METHOD} {PROBE_PATH} returned {status}, not 405. This test "
+        "cannot measure 405 connection handling if the probe no longer "
+        "produces one -- pick a different URI/method pair."
+    )
+
+
+def test_405_does_not_close_the_connection(conn):
+    """The connection must survive a 405 and serve the next request.
+
+    Without a registered HTTPD_405_METHOD_NOT_ALLOWED handler that returns
+    ESP_OK, the device closes the socket after the 405 and this second request
+    fails on the dead connection.
+    """
+    assert _request(conn, WRONG_METHOD, PROBE_PATH) == 405
+
+    try:
+        status = _request(conn, "GET", PROBE_PATH)
+    except (http.client.HTTPException, OSError) as exc:
+        pytest.fail(
+            f"The device closed the connection after a 405: reusing it raised "
+            f"{type(exc).__name__}: {exc}. A 405 handler returning ESP_OK is "
+            f"missing, so every wrong-method request now costs a full TLS "
+            f"handshake and a TIME_WAIT PCB. See issue #234."
+        )
+
+    assert status == 200, (
+        f"connection survived the 405 but the follow-up GET returned {status}"
+    )
+
+
+def test_repeated_405s_do_not_churn_connections(conn):
+    """The fuzz sends thousands of these; one connection must absorb them.
+
+    This is the shape that actually exhausted internal RAM: not a single 405,
+    but a sustained stream of them each forcing a new TLS session.
+    """
+    for i in range(20):
+        try:
+            status = _request(conn, WRONG_METHOD, PROBE_PATH)
+        except (http.client.HTTPException, OSError) as exc:
+            pytest.fail(
+                f"Connection died after {i} consecutive 405s "
+                f"({type(exc).__name__}: {exc}). Each wrong-method request is "
+                f"tearing down the connection, which is the internal-RAM "
+                f"drain behind issue #234."
+            )
+        assert status == 405, f"request {i} returned {status}, expected 405"
+
+    # And the connection is still usable for real traffic afterwards.
+    assert _request(conn, "GET", PROBE_PATH) == 200


### PR DESCRIPTION
Targets #234. See https://github.com/sslivins/arctic-controller/issues/234#issuecomment-5605549619 for the full evidence trail, including two earlier analyses of mine that were wrong.

## Mechanism

`esp_http_server` closes the underlying socket after sending an error response when no handler is registered for that error code. From `components/esp_http_server/src/httpd_txrx.c`:

> If no handler is registered for this error default behavior is to send the HTTP error response and return failure for closure of underlying socket

405 was the only remaining error path on this device that closed connections. 404 already has registered handlers on both TLS servers returning `ESP_OK` (`api_server.cpp:1553`, `:1566`, returning at `:1668`, `:1695`), and 401 goes through `send_json_error` as a normal response.

Because the device closes, the device is the **active closer** and accrues a TIME_WAIT PCB held for `2 * CONFIG_LWIP_TCP_MSL` = 120 s. The schema fuzz sends wrong-method requests to existing URIs at roughly 2/sec sustained, which is enough to saturate the 24-entry PCB pool.

Measured in run 34373247509 (post-#236, pre-this-PR):

```
I (428904) netdiag: heap int=34983 | tcp active=2 tw=0  listen=4
I (489493) netdiag: heap int=34423 | tcp active=1 tw=23 listen=4
I (519989) netdiag: heap int=34619 | tcp active=0 tw=24 listen=4     <- pool exhausted
W (550672) netdiag: heap int=23    | tcp PCB walk TIMED OUT (tcpip thread unresponsive)
```

`active=0, tw=24` — every PCB in the pool is a corpse. The 405s cluster in exactly the minutes `tw` climbs from 0 to saturation, and the one test that failed in that run was a `ConnectTimeout` on `GET /api/heatpump/status`, which appears in the 405 burst moments earlier.

## Secondary benefit

The 405 originates in the httpd routing layer before any handler runs, and auth in this codebase lives inside the handlers. So an unauthenticated LAN client could make the device pay a TLS handshake plus a 120 s PCB per cheap malformed request. Low severity for a LAN device, but a poor cost ratio.

## What this does not claim

The internal-heap collapse to 23 B is not fully explained by PCB memory alone — `sizeof(struct tcp_pcb)` is 208 B measured from the ELF, so the whole pool is ~5 KB, and `MEMP_MEM_MALLOC=1` means it is allocated on demand rather than reserved. The collapse *follows* pool exhaustion rather than causing it; what the tcpip thread accumulates once it cannot allocate PCBs is still open.

So this removes a demonstrated churn source, but the falsifiable prediction is what matters: **peak `tw` should stay well below 24 and `PCB walk TIMED OUT` should be 0.** If `tw` still saturates, 405s were not the only source and MSL/pool sizing is the next lever — `2 * TCP_MSL` = 120 s is extremely conservative for a LAN device with sub-millisecond RTT.

## Testing

- Builds clean locally against ESP-IDF 6.1 / GCC 15.2.
- `tests/api/test_error_response_keepalive.py` uses raw `http.client` rather than `requests`, deliberately: `requests` transparently reopens a closed connection and would hide exactly this regression. Three tests — that the probe genuinely yields 405 and not 404 (guarding the premise), that the connection survives a single 405, and that 20 consecutive 405s stay on one connection.
