### PR TITLE
diag(net): profile the internal-heap dip safely (#234)

### DIFF
--- a/.github/scripts/scan_heap_floor.sh
+++ b/.github/scripts/scan_heap_floor.sh
@@ -60,7 +60,12 @@ fi
 # Matches both the healthy line and the "PCB walk TIMED OUT" variant, since both
 # carry the heap figures:
 #   I (33395) netdiag: heap int=40615 (min 12632) psram=23673156 | tcp active=1 ...
-NETDIAG_RE='netdiag: heap int=[0-9]+ \(min [0-9]+\)'
+# The trailing "[,)]" tolerates the extended form that also reports the largest
+# contiguous block, i.e. "(min 12632, largest 17408)". Both must keep matching:
+# older logs (and archived artifacts) still use the short form, and a regex that
+# silently stops matching makes this gate fail closed with "no samples", which
+# looks like a device fault but is really a log-format drift.
+NETDIAG_RE='netdiag: heap int=[0-9]+ \(min [0-9]+[,)]'
 
 samples="$(grep -cE "$NETDIAG_RE" "$log" || true)"
 if [ "${samples:-0}" -eq 0 ]; then
@@ -77,8 +82,8 @@ min_instant="$(grep -oE 'netdiag: heap int=[0-9]+' "$log" \
     | sort -n | head -1)"
 
 # Context only -- saturates at ~16 bytes on every run, see the note above.
-lowwater="$(grep -oE 'heap int=[0-9]+ \(min [0-9]+\)' "$log" \
-    | grep -oE '\(min [0-9]+\)' \
+lowwater="$(grep -oE 'heap int=[0-9]+ \(min [0-9]+' "$log" \
+    | grep -oE 'min [0-9]+' \
     | grep -oE '[0-9]+' \
     | sort -n | head -1)"
 
@@ -90,7 +95,36 @@ maxtw="${maxtw:-0}"
 timeouts="$(grep -cE 'netdiag: .*PCB walk TIMED OUT' "$log" || true)"
 timeouts="${timeouts:-0}"
 
+# Transient sub-sample dips, reported by the 100ms low-heap profiler (issue
+# #234). These are NOT gated on, deliberately:
+#
+#   - They are real. The profiler observes internal free heap reaching as low as
+#     23 bytes with a largest free block of 0, recovering fully within one 100ms
+#     poll. "MISSED dip" lines record excursions shorter than even that.
+#   - They are also PRE-EXISTING and, so far, present on every run including
+#     runs whose tests all pass. The 30s netdiag cadence simply never sampled
+#     them; the since-boot low-water reading 16 bytes on every historical run
+#     was this same phenomenon, seen without resolution.
+#
+# Gating on them today would therefore fail every run without distinguishing a
+# healthy run from a wedged one -- the exact property that makes the low-water
+# mark useless as a gate. Until the consumer behind the spike is identified and
+# a defensible threshold exists, these are surfaced as data, not verdicts.
+dips="$(grep -cE 'netdiag: LOW HEAP entered' "$log" || true)"
+dips="${dips:-0}"
+missed="$(grep -cE 'netdiag: MISSED dip' "$log" || true)"
+missed="${missed:-0}"
+dipfloor=""
+if [ "$dips" -gt 0 ]; then
+    dipfloor="$(grep -oE 'LOW HEAP recovered: floor=[0-9]+' "$log" \
+        | grep -oE '[0-9]+$' | sort -n | head -1)"
+fi
+
 echo "netdiag samples=${samples} min-instantaneous-internal-heap=${min_instant} bytes (floor=${floor}) since-boot-low-water=${lowwater} peak-TIME_WAIT=${maxtw} pcb-walk-timeouts=${timeouts}"
+
+if [ "$dips" -gt 0 ] || [ "$missed" -gt 0 ]; then
+    echo "::notice title=Transient internal-heap dips (not gated)::The 100ms low-heap profiler recorded ${dips} dip(s) below the watch threshold${dipfloor:+, lowest floor ${dipfloor} bytes} and ${missed} excursion(s) too short to profile. These are reported for issue #234 and do not affect this gate; see the rationale in scan_heap_floor.sh."
+fi
 
 status=0
 

--- a/main/log_persist.cpp
+++ b/main/log_persist.cpp
@@ -275,11 +275,28 @@ static void log_persist_task(void* arg)
     // not immediately trigger a "new severity" flush.
     last_flushed_warn_seq = log_buffer_latest_seq_at_level(ESP_LOG_WARN);
 
+    // The 5s cadence below is still too coarse to catch the transient internal
+    // heap dips seen in #234, so hand that job to a dedicated fast poller.
+    net_diag_start_low_heap_watch();
+
     for (;;) {
         vTaskDelay(pdMS_TO_TICKS(LP_TASK_PERIOD_MS));
         tick++;
 
-        if ((tick % LP_NETDIAG_EVERY) == 0) {
+        // Netdiag cadence is adaptive. At the normal 30s spacing a heap
+        // collapse and its recovery can both fall between two samples, which
+        // is exactly what happened while investigating #234: consecutive
+        // samples read 34415 then 23 then 33959, showing the floor but not the
+        // descent. Once internal heap drops below the attribution threshold we
+        // sample every tick (5s) so the ramp is visible.
+        //
+        // heap_caps_get_free_size is cheap and lock-free enough to poll each
+        // tick; the expensive part of a snapshot is the tcpip PCB walk, which
+        // still only happens when we actually log.
+        const bool heap_low =
+            heap_caps_get_free_size(MALLOC_CAP_INTERNAL) < NET_DIAG_LOW_HEAP_BYTES;
+
+        if (heap_low || (tick % LP_NETDIAG_EVERY) == 0) {
             net_diag_log_snapshot();
         }
 

--- a/main/log_persist.cpp
+++ b/main/log_persist.cpp
@@ -275,28 +275,32 @@ static void log_persist_task(void* arg)
     // not immediately trigger a "new severity" flush.
     last_flushed_warn_seq = log_buffer_latest_seq_at_level(ESP_LOG_WARN);
 
-    // The 5s cadence below is still too coarse to catch the transient internal
-    // heap dips seen in #234, so hand that job to a dedicated fast poller.
+    // The 5s cadence below is far too coarse to catch the transient internal
+    // heap dips seen in #234 (they last under 100ms), so that job belongs to a
+    // dedicated fast poller which reports them on its own LOW HEAP lines.
     net_diag_start_low_heap_watch();
 
     for (;;) {
         vTaskDelay(pdMS_TO_TICKS(LP_TASK_PERIOD_MS));
         tick++;
 
-        // Netdiag cadence is adaptive. At the normal 30s spacing a heap
-        // collapse and its recovery can both fall between two samples, which
-        // is exactly what happened while investigating #234: consecutive
-        // samples read 34415 then 23 then 33959, showing the floor but not the
-        // descent. Once internal heap drops below the attribution threshold we
-        // sample every tick (5s) so the ramp is visible.
+        // Netdiag keeps its fixed 30s cadence. Making it adaptive - sampling
+        // whenever internal heap was low - was tried and reverted, because it
+        // was wrong twice over:
         //
-        // heap_caps_get_free_size is cheap and lock-free enough to poll each
-        // tick; the expensive part of a snapshot is the tcpip PCB walk, which
-        // still only happens when we actually log.
-        const bool heap_low =
-            heap_caps_get_free_size(MALLOC_CAP_INTERNAL) < NET_DIAG_LOW_HEAP_BYTES;
-
-        if (heap_low || (tick % LP_NETDIAG_EVERY) == 0) {
+        //   1. net_diag_log_snapshot() asks the tcpip thread to walk the PCB
+        //      lists. Triggering that *because* internal RAM is nearly gone
+        //      schedules the most expensive diagnostic at the one moment the
+        //      network stack can least afford it, and duly produced "PCB walk
+        //      TIMED OUT" - a symptom manufactured by the instrumentation.
+        //   2. It biases the sample set toward dip moments, so the heap-floor
+        //      gate (which reads exactly these lines) sees a floor no
+        //      unbiased run would report, and fails runs that are no less
+        //      healthy than the ones that pass.
+        //
+        // A fixed cadence keeps this log comparable with every historical run
+        // and with main. Dip resolution is the fast poller's job.
+        if ((tick % LP_NETDIAG_EVERY) == 0) {
             net_diag_log_snapshot();
         }
 

--- a/main/net_diag.cpp
+++ b/main/net_diag.cpp
@@ -7,8 +7,10 @@
 #include <string.h>
 #include <esp_log.h>
 #include <esp_heap_caps.h>
+#include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
+#include <freertos/task.h>
 
 #include "lwip/tcpip.h"
 #include "lwip/priv/tcp_priv.h"   // tcp_active_pcbs, tcp_tw_pcbs, tcp_bound_pcbs, tcp_listen_pcbs
@@ -78,6 +80,8 @@ void net_diag_sample(net_diag_t* out)
 
     out->free_internal     = (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
     out->min_free_internal = (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
+    out->largest_free_internal =
+        (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
     out->free_psram        = (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
 
     out->pcb_valid = sample_pcbs(out);
@@ -90,14 +94,100 @@ void net_diag_log_snapshot(void)
 
     if (d.pcb_valid) {
         ESP_LOGI(TAG,
-                 "heap int=%u (min %u) psram=%u | tcp active=%d tw=%d bound=%d listen=%d",
-                 d.free_internal, d.min_free_internal, d.free_psram,
+                 "heap int=%u (min %u, largest %u) psram=%u | tcp active=%d tw=%d bound=%d listen=%d",
+                 d.free_internal, d.min_free_internal, d.largest_free_internal,
+                 d.free_psram,
                  d.tcp_active, d.tcp_time_wait, d.tcp_bound, d.tcp_listen);
     } else {
         // A timed-out PCB walk is itself a strong wedge signal: the tcpip thread
         // did not service our callback within 1s.
         ESP_LOGW(TAG,
-                 "heap int=%u (min %u) psram=%u | tcp PCB walk TIMED OUT (tcpip thread unresponsive)",
-                 d.free_internal, d.min_free_internal, d.free_psram);
+                 "heap int=%u (min %u, largest %u) psram=%u | tcp PCB walk TIMED OUT (tcpip thread unresponsive)",
+                 d.free_internal, d.min_free_internal, d.largest_free_internal,
+                 d.free_psram);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fast low-heap watch
+// ---------------------------------------------------------------------------
+
+static void net_diag_low_heap_watch_task(void* arg)
+{
+    (void)arg;
+
+    // Everything here must stay cheap. This task runs 10x/sec and fires
+    // precisely when the system is under its heaviest memory pressure, so it
+    // must not allocate, must not take the heap lock for long, and must not
+    // walk the heap. See the header for the interrupt-watchdog panic that
+    // resulted from doing exactly that.
+    bool     in_dip     = false;
+    unsigned dip_floor  = 0;
+    unsigned dip_largest = 0;
+    int64_t  dip_start_us = 0;
+    unsigned last_min   = heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
+
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(NET_DIAG_WATCH_PERIOD_MS));
+
+        const unsigned freeb = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+
+        if (!in_dip && freeb < NET_DIAG_LOW_HEAP_BYTES) {
+            in_dip       = true;
+            dip_start_us = esp_timer_get_time();
+            dip_floor    = freeb;
+            dip_largest  = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+            ESP_LOGW(TAG, "LOW HEAP entered: int=%u largest=%u psram=%u",
+                     freeb, dip_largest,
+                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+        } else if (in_dip) {
+            if (freeb < dip_floor) {
+                dip_floor   = freeb;
+                dip_largest = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+            }
+            // Require a clear recovery before closing the excursion, so a
+            // value oscillating around the threshold reports once rather than
+            // repeatedly.
+            if (freeb > (NET_DIAG_LOW_HEAP_BYTES * 2)) {
+                const int64_t dur_ms = (esp_timer_get_time() - dip_start_us) / 1000;
+                ESP_LOGW(TAG,
+                         "LOW HEAP recovered: floor=%u largest_at_floor=%u duration=%lldms now=%u",
+                         dip_floor, dip_largest, (long long)dur_ms, freeb);
+                in_dip = false;
+            }
+        }
+
+        // Backstop. If the all-time low-water mark moves without this poller
+        // having seen a dip, the excursion was shorter than the poll interval.
+        // Saying so explicitly matters: otherwise a quiet log is ambiguous
+        // between "no dip occurred" and "the dip was too fast to observe".
+        const unsigned now_min = heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
+        if (now_min < last_min) {
+            if (now_min < NET_DIAG_LOW_HEAP_BYTES && !in_dip) {
+                ESP_LOGW(TAG,
+                         "MISSED dip: low-water fell %u -> %u between polls (shorter than %dms)",
+                         last_min, now_min, NET_DIAG_WATCH_PERIOD_MS);
+            }
+            last_min = now_min;
+        }
+    }
+}
+
+void net_diag_start_low_heap_watch(void)
+{
+    static bool started = false;
+    if (started) {
+        return;
+    }
+    started = true;
+
+    // Small stack: this task only reads counters and calls the attribution
+    // dump, which uses static storage. Low priority so it never preempts the
+    // network path it is observing.
+    BaseType_t ok = xTaskCreate(net_diag_low_heap_watch_task, "netdiag_lowheap",
+                                3072, NULL, 1, NULL);
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "failed to start low-heap watch task");
+        started = false;
     }
 }

--- a/main/net_diag.h
+++ b/main/net_diag.h
@@ -22,6 +22,8 @@ typedef struct {
     // Heap (bytes)
     unsigned free_internal;
     unsigned min_free_internal;   // low-water since boot
+    unsigned largest_free_internal; // biggest single block; distinguishes
+                                    // fragmentation from true exhaustion
     unsigned free_psram;
     // lwIP TCP PCB population
     int tcp_active;               // established / in-progress connections
@@ -36,6 +38,44 @@ void net_diag_sample(net_diag_t* out);
 
 // Gather + emit an ESP_LOGI("netdiag", ...) line. Convenience wrapper.
 void net_diag_log_snapshot(void);
+
+// Threshold for treating internal heap as critically low. Healthy runs sit at
+// 30-40 KB free internal; observed excursions collapse to double digits. 12 KB
+// is low enough not to fire in normal operation but high enough to catch the
+// descent rather than only the floor.
+#define NET_DIAG_LOW_HEAP_BYTES 12288
+
+// Start a lightweight task that polls internal free heap every
+// NET_DIAG_WATCH_PERIOD_MS and profiles any excursion below
+// NET_DIAG_LOW_HEAP_BYTES: when it began, how deep it went, how long it
+// lasted, and the largest free block at the floor.
+//
+// Deliberately does NOT attribute the memory to a task. The obvious tool for
+// that, heap_caps_get_per_task_info() under CONFIG_HEAP_TASK_TRACKING, walks
+// every block in every heap while holding the heap spinlock with interrupts
+// disabled. With ~30 MB of PSRAM attached that walk is long enough to trip the
+// interrupt watchdog: calling it from this poller panicked the device with
+// "Interrupt wdt timeout on CPU1" during ESP-Hosted SDIO bring-up and left it
+// in a boot loop that OTA could not recover (see #234). The heap dips exactly
+// when the system is busiest, so a low-heap trigger is the worst possible
+// moment to start a long critical section.
+//
+// Profiling the excursion is safe -- it is only counter reads -- and still
+// narrows the search, because the timestamps can be lined up against what the
+// device was doing.
+//
+// The periodic snapshot cadence is far too slow to see the event: in the
+// post-#249 run every 30s sample read ~37 KB free, yet
+// heap_caps_get_minimum_free_size reported an all-time low of 16 bytes -- the
+// collapse and the recovery both fell between two samples.
+//
+// Safe to call more than once; subsequent calls are ignored.
+void net_diag_start_low_heap_watch(void);
+
+// 100ms is a deliberate compromise. The dips coincide with multi-second
+// screenshot/PSRAM activity, so they are very unlikely to be shorter than
+// this, while the poll itself is only a counter read per heap.
+#define NET_DIAG_WATCH_PERIOD_MS 100
 
 #ifdef __cplusplus
 }

--- a/tests/api/test_heap_floor.py
+++ b/tests/api/test_heap_floor.py
@@ -192,3 +192,38 @@ def test_floor_is_configurable(tmp_path):
     log = _write(tmp_path, "healthy.log", HEALTHY_LINES)  # lowest instantaneous 39880
     assert _run(log, "8192").returncode == 0
     assert _run(log, "50000").returncode == 1
+
+
+# The extended netdiag line, added with the 100ms low-heap profiler (issue #234),
+# reports the largest contiguous free block alongside the low-water mark. The
+# scanner's regex must tolerate BOTH forms. When it did not, every sample stopped
+# matching and the gate failed closed with "no netdiag samples" -- which reads as
+# a device fault but was really log-format drift. That cost a full CI cycle to
+# diagnose, so it is pinned here.
+EXTENDED_LINES = [
+    "I (33395) netdiag: heap int=40615 (min 12632, largest 17408) psram=23673156 | tcp active=1 tw=0 bound=0 listen=4",
+    "I (63840) netdiag: heap int=39880 (min 16, largest 11776) psram=23607152 | tcp active=1 tw=3 bound=0 listen=4",
+]
+
+
+@requires_bash
+def test_extended_netdiag_format_is_still_parsed(tmp_path):
+    r = _run(_write(tmp_path, "extended.log", EXTENDED_LINES))
+    assert r.returncode == 0, (
+        "the extended '(min M, largest L)' form must still be recognised; "
+        f"got {r.returncode}\n{r.stdout}{r.stderr}"
+    )
+    assert "netdiag samples=2" in r.stdout, r.stdout
+    assert "min-instantaneous-internal-heap=39880" in r.stdout, r.stdout
+    assert "since-boot-low-water=16" in r.stdout, r.stdout
+
+
+@requires_bash
+def test_extended_format_still_trips_the_gate_when_exhausted(tmp_path):
+    """Tolerating the new field must not accidentally stop the gate firing."""
+    lines = EXTENDED_LINES + [
+        "W (99000) netdiag: heap int=23 (min 16, largest 0) psram=23637360 | tcp active=1 tw=9 bound=0 listen=4",
+    ]
+    r = _run(_write(tmp_path, "extended_bad.log", lines))
+    assert r.returncode == 1, f"exhausted extended log should fail; got {r.returncode}\n{r.stdout}{r.stderr}"
+    assert "min-instantaneous-internal-heap=23" in r.stdout, r.stdout


### PR DESCRIPTION
## What this is

Instrumentation to characterise the internal-heap excursion still visible on #234, **without** the approach that bricked the device (see below).

## Why it is needed

#249 fixed the TIME_WAIT saturation - confirmed on #240's device run:

| signal | before #249 | after |
|---|---|---|
| peak `tw` | 24 (saturated, `active=0`) | **12** |
| `PCB walk TIMED OUT` | present at wedge | **0** |

But the same clean run shows the internal-heap low-water mark stepping `17456 -> 15964 -> 616 -> 16` bytes while **every** 30s sample still read ~37 KB free. The dip and the recovery both fall between two samples, so we have no idea how deep, how long, or how often.

## What it does

- **100ms poller** that profiles the excursion: entry, floor, largest free block at the floor, and duration.
- **MISSED-dip line** when the low-water mark moves without the dip being seen, so a quiet log is unambiguous between "no dip" and "dip faster than the poll".
- **Largest free block** in the periodic snapshot - separates fragmentation from exhaustion.

## What it deliberately does NOT do, and why

My first attempt used `CONFIG_HEAP_TASK_TRACKING` + `heap_caps_get_per_task_info()` for true per-task attribution. **It bricked the controller.**

That call walks every block in every heap while holding the heap spinlock with interrupts disabled. With ~30 MB of PSRAM attached, the walk is long enough to trip the interrupt watchdog. Because the trigger is *low heap*, it fired during ESP-Hosted SDIO bring-up:

\\\
Guru Meditation Error: Core  1 panic'ed (Interrupt wdt timeout on CPU1).
rst:0xc (SW_CPU_RESET)
\\\

The device boot-looped, so **OTA could not recover it** - it needed a USB reflash on the runner. The rollback guard in device-tests.yml caught this correctly and refused to run the suite against the rolled-back image; that gate did its job.

Lesson: a low-heap condition is the worst possible moment to begin a long critical section.

## Verification

**Boot-tested on the physical controller before pushing** (not just CI): clean boot, zero crashes, zero reboots, netdiag reporting normally. The controller was then restored to the CI firmware and confirmed healthy with `/api/test/*` responding, so device CI is unblocked.

## First result

From that boot test, at idle:

\\\
heap int=56483 (min 30564, largest 17408)
\\\

**56 KB free, but the largest contiguous block is only 17 KB.** An allocation above ~17 KB fails despite ample free bytes - so fragmentation, not just exhaustion, may be the relevant failure mode. That is a new lead this instrumentation exists to pursue.

Refs #234
