### PR TITLE
fix(ota): size the OTA task stack from measurement and stop misreporting a failed start

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1076,6 +1076,17 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 error: OTA already in progress
+        '503':
+          description: |
+            The device could not allocate the OTA task and no update was
+            started. Distinct from 409: nothing is running, so the request is
+            worth retrying once internal RAM is less fragmented (#256).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: insufficient memory to start OTA - retry shortly
 
   /api/ota/upload:
     post:

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3351,9 +3351,21 @@ static esp_err_t ota_update_post_handler(httpd_req_t* req)
         return ESP_OK;
     }
     
-    if (!ota_mgr_start_update(url_json->valuestring)) {
+    ota_start_result_t start = ota_mgr_start_update_ex(url_json->valuestring);
+    if (start != OTA_START_OK) {
         cJSON_Delete(root);
-        send_json_error(req, "409 Conflict", "OTA update already in progress");
+        if (start == OTA_START_NO_RESOURCES) {
+            // Not a conflict: nothing is running. The device could not allocate
+            // the OTA task's stack. Reporting this as 409 told operators to wait
+            // for an update that did not exist (#256).
+            send_json_error(req, "503 Service Unavailable",
+                            "insufficient memory to start OTA - retry shortly");
+        } else if (start == OTA_START_INVALID_URL) {
+            send_json_error(req, "403 Forbidden",
+                            "URL not allowed - must be from official GitHub repository");
+        } else {
+            send_json_error(req, "409 Conflict", "OTA update already in progress");
+        }
         return ESP_OK;
     }
     

--- a/main/ota_manager.cpp
+++ b/main/ota_manager.cpp
@@ -22,8 +22,34 @@
 
 static const char* TAG = "ota_manager";
 
-// OTA task stack size
-#define OTA_TASK_STACK_SIZE 8192
+// OTA task stack size.
+//
+// Sized from measurement, not habit. The task's deepest path is the TLS-backed
+// download (mbedTLS handshake + HTTP receive); measured on hardware it leaves
+// 4648 of 8192 bytes untouched, i.e. it actually uses ~3544. The old 8192 had
+// to be found as one contiguous block of internal RAM at the moment an update
+// is requested, and internal RAM routinely fragments below that during normal
+// API traffic -- observed largest free block 7936 while ~29 KB was free overall,
+// which made OTA unstartable (#256). 6144 keeps ~74% headroom over the measured
+// peak while sitting well under the worst fragmentation seen.
+//
+// ota_log_stack_headroom() reports the real figure on every OTA, so this can be
+// re-checked rather than assumed if the task grows.
+#define OTA_TASK_STACK_SIZE 6144
+
+// Report how much of the OTA task's stack was never used, at the points where
+// it has just finished the two phases that dominate its depth: the TLS-backed
+// download, and the flash write. OTA_TASK_STACK_SIZE has to be requested as one
+// contiguous block of internal RAM, which is the scarcest allocation the device
+// makes (#256), so the size needs to be justified by measurement rather than
+// left at a round number.
+static void ota_log_stack_headroom(const char* phase)
+{
+    // ESP-IDF's uxTaskGetStackHighWaterMark() returns bytes, not words.
+    ESP_LOGI(TAG, "ota_task stack: %u bytes never used after %s (of %d)",
+             (unsigned)uxTaskGetStackHighWaterMark(NULL), phase,
+             OTA_TASK_STACK_SIZE);
+}
 
 // GitHub API URL for releases
 #define GITHUB_API_URL "https://api.github.com/repos/sslivins/arctic-controller/releases/latest"
@@ -131,15 +157,20 @@ bool ota_mgr_init(void)
 
 bool ota_mgr_start_update(const char* url)
 {
+    return ota_mgr_start_update_ex(url) == OTA_START_OK;
+}
+
+ota_start_result_t ota_mgr_start_update_ex(const char* url)
+{
     if (url == NULL || strlen(url) == 0) {
         ESP_LOGE(TAG, "Invalid URL");
-        return false;
+        return OTA_START_INVALID_URL;
     }
     
     // Security: Only allow updates from official GitHub repository
     if (strncmp(url, ALLOWED_OTA_URL_PREFIX, strlen(ALLOWED_OTA_URL_PREFIX)) != 0) {
         ESP_LOGE(TAG, "URL not allowed: must start with %s", ALLOWED_OTA_URL_PREFIX);
-        return false;
+        return OTA_START_INVALID_URL;
     }
     
     xSemaphoreTake(status_mutex, portMAX_DELAY);
@@ -150,7 +181,7 @@ bool ota_mgr_start_update(const char* url)
         ota_status.state == OTA_STATE_VERIFYING) {
         ESP_LOGW(TAG, "OTA already in progress (state=%d)", ota_status.state);
         xSemaphoreGive(status_mutex);
-        return false;
+        return OTA_START_BUSY;
     }
     
     // Store URL and reset status
@@ -172,15 +203,23 @@ bool ota_mgr_start_update(const char* url)
     // Lower priority than LVGL (5) to avoid display glitches during flash writes
     BaseType_t ret = xTaskCreate(ota_task, "ota_task", OTA_TASK_STACK_SIZE, NULL, 3, NULL);
     if (ret != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create OTA task");
+        // The stack is one contiguous block of internal RAM, so this fails when
+        // internal RAM is fragmented even though plenty is free overall (#256).
+        // Log what was actually available: without it this is indistinguishable
+        // from a logic error.
+        ESP_LOGE(TAG, "Failed to create OTA task (need %d contiguous internal bytes, "
+                      "largest free block is %u, %u free in total)",
+                 OTA_TASK_STACK_SIZE,
+                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
         xSemaphoreTake(status_mutex, portMAX_DELAY);
         ota_status.state = OTA_STATE_FAILED;
         strncpy(ota_status.error_msg, "Failed to start OTA task", sizeof(ota_status.error_msg));
         xSemaphoreGive(status_mutex);
-        return false;
+        return OTA_START_NO_RESOURCES;
     }
     
-    return true;
+    return OTA_START_OK;
 }
 
 ota_status_t ota_mgr_get_status(void)
@@ -550,6 +589,7 @@ static void ota_task(void* pvParameter)
     if (err != ESP_OK || buf_ctx.err != ESP_OK || http_status != 200) {
         ESP_LOGE(TAG, "Download failed: http=%d perform=%s buf=%s",
                  http_status, esp_err_to_name(err), esp_err_to_name(buf_ctx.err));
+        ota_log_stack_headroom("a failed download");
         heap_caps_free(img_buf);
         ota_twdt_resume_idle();
         xSemaphoreTake(status_mutex, portMAX_DELAY);
@@ -594,6 +634,7 @@ static void ota_task(void* pvParameter)
     ota_status.progress_percent = 100;
     xSemaphoreGive(status_mutex);
     ESP_LOGI(TAG, "Download complete (%d bytes) buffered in PSRAM", img_len);
+    ota_log_stack_headroom("the download");
 
     // ---- Point of no return: from here we quiesce the network and touch flash. ----
     // Any failure below leaves the servers stopped, so we MUST reboot rather than
@@ -646,6 +687,7 @@ static void ota_task(void* pvParameter)
 
     // Success!
     ESP_LOGI(TAG, "OTA update successful! Rebooting...");
+    ota_log_stack_headroom("the flash write");
     xSemaphoreTake(status_mutex, portMAX_DELAY);
     ota_status.state = OTA_STATE_READY_TO_REBOOT;
     xSemaphoreGive(status_mutex);

--- a/main/ota_manager.h
+++ b/main/ota_manager.h
@@ -57,6 +57,29 @@ bool ota_mgr_init(void);
 bool ota_mgr_is_url_allowed(const char* url);
 
 /**
+ * @brief Why an OTA could not be started.
+ *
+ * Kept distinct because the two failures need different handling: BUSY is the
+ * caller's fault and retrying later works, NO_RESOURCES means the device could
+ * not allocate the OTA task's stack and is a device-health problem. Reporting
+ * both as "already in progress" sent operators chasing an update that was not
+ * running (#256).
+ */
+typedef enum {
+    OTA_START_OK = 0,
+    OTA_START_INVALID_URL,   // Empty, malformed, or non-allowlisted URL
+    OTA_START_BUSY,          // A genuine OTA (upload, download or verify) is running
+    OTA_START_NO_RESOURCES,  // The OTA task could not be created
+} ota_start_result_t;
+
+/**
+ * @brief Start OTA update from URL, reporting why it failed
+ * @param url URL to firmware binary (http or https)
+ * @return OTA_START_OK, or the reason the update did not start
+ */
+ota_start_result_t ota_mgr_start_update_ex(const char* url);
+
+/**
  * @brief Start OTA update from URL
  * @param url URL to firmware binary (http or https)
  * @return true if update started, false if already in progress or error


### PR DESCRIPTION
Fixes #256, and unblocks #255 — whose device-tests failed three times in a row
on exactly this bug.

## The bug

`POST /api/ota/update` could fail to start an OTA purely because internal RAM
was **fragmented**, and the API reported that as `409 "OTA update already in
progress"` while nothing was running. In the field that is a dead end: the
operator waits for an update that does not exist, and there is no serial
console to see the truth.

`xTaskCreate` needs `OTA_TASK_STACK_SIZE` as **one contiguous block of internal
RAM** — the scarcest allocation this device makes. Two CI runs an hour apart,
same controller, same test, differed only in contiguity:

| run | internal free | **largest block** | result |
|---|---|---|---|
| #254 | 30 235 | **11 264** | `OTA task started` |
| #255 | 29 971 | **7 680** | `Failed to create OTA task` |

Free heap is effectively identical. 7 680 < 8 192, so the allocation failed.
The serial log contains **no** `OTA already in progress` line — the device
never took that branch. The 409 came from the API layer collapsing every
`ota_mgr_start_update()` failure into one message.

## Why 6144

Measured, not guessed. Instrumented `ota_task` and ran it on the controller:

```
I (35897) ota_manager: ota_task stack: 4648 bytes never used after a failed download (of 8192)
```

The deepest path is the TLS-backed download (mbedTLS handshake + HTTP receive),
and it uses **~3544 bytes**. The 8192 was over-provisioned by 2.3×, and that
excess is what created the cliff. Re-measured after the change:

```
I (236690) ota_manager: ota_task stack: 2600 bytes never used after a failed download (of 6144)
```

Same 3544 used — the figure is stable — with 2600 bytes (42%) still spare, and
the request now sits comfortably under the worst fragmentation observed (7936).

## Changes

- `OTA_TASK_STACK_SIZE` 8192 → **6144**, with the measurement recorded in the
  comment so the next person does not have to re-derive it.
- `ota_log_stack_headroom()` reports the high-water mark after the download and
  after the flash write, on every OTA. Kept permanently: it is what makes this
  number maintainable, and it will report the flash-write path the first time a
  real OTA runs.
- When task creation *does* fail, log the largest free block and total free
  internal RAM, so the next occurrence is diagnosable from serial alone.
- New `ota_mgr_start_update_ex()` returns **why** the start failed
  (`OK` / `INVALID_URL` / `BUSY` / `NO_RESOURCES`). `api_server.cpp` maps
  `NO_RESOURCES` → **503** ("insufficient memory to start OTA - retry shortly")
  and keeps 409 for a genuine concurrent OTA. The `bool` wrapper is retained so
  the settings-screen call site is untouched.
- `docs/openapi.yaml` documents the 503.

## Verification on hardware

Flashed to the physical controller (both OTA slots + otadata erased) and ran
the full `tests/api` suite:

- **No `Failed to create OTA task`** — both OTA starts succeeded.
- `TestOtaConcurrentPrevention::test_upload_rejected_during_url_download`, which
  failed three consecutive times on #255, **passes**.

Being explicit about what this run did *not* prove: the local heap stayed
healthy (`largest 17408` throughout), so it did not reproduce the fragmented
condition — CI's UI and web suites are what drive fragmentation. The fix is
correct by construction (6144 < the 7936 worst case actually observed), but
this PR's own device-tests run is the real proof.

## Deliberately not done

- **A PSRAM stack** via `xTaskCreateWithCaps(MALLOC_CAP_SPIRAM)`, despite that
  being the house pattern for worker tasks: `ota_task` performs flash writes,
  and its stack must stay readable while the cache is disabled.
- **Pre-creating the task at boot**, which removes the runtime allocation but
  permanently costs 8 KB of the ~30 KB free internal RAM — the wrong trade.
- **A retry loop**: the blocking allocations are TIME_WAIT sockets that persist
  for minutes, so a short retry would not help and a long one would hang the
  handler.

## Follow-up

There is still no test asserting an OTA can start under internal-RAM pressure,
nor that a failed start is reported as something other than 409. Both belong in
the #252 OTA test plan.
