### PR TITLE
ci: enforce LF endings and record the normalization for git blame (2/2)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Revisions that only reformat, and should be skipped by `git blame`.
+#
+# Enable locally (once per clone):
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub's blame view reads this file automatically, so the web UI needs no
+# configuration.
+
+# chore: normalize all tracked text files to LF (#258)
+5112633a675baf92c6b1ac20e329049b3313c846

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -43,6 +43,26 @@ jobs:
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 
+      - name: Enforce LF line endings
+        # The repo was normalized to LF (see .gitattributes "* text=auto" and
+        # the churn commit recorded in .git-blame-ignore-revs). Without a gate,
+        # a Windows contributor whose editor writes CRLF can reintroduce it and
+        # the next unrelated edit rewrites the whole file, burying the real
+        # change in a whole-file diff.
+        #
+        # This checks the INDEX (i/...), not the working tree, so it is
+        # unaffected by however the runner happens to check files out.
+        run: |
+          set -euo pipefail
+          if git ls-files --eol | grep -E '^i/(crlf|mixed)' > /tmp/crlf.txt; then
+            echo "::error::Tracked files have CRLF or mixed line endings in the index:"
+            sed 's/^/  /' /tmp/crlf.txt
+            echo ""
+            echo "Fix with: git add --renormalize . && git commit"
+            exit 1
+          fi
+          echo "All tracked text files are LF in the index."
+
       - name: Run host-side tests (no hardware)
         # tests/web has its own playwright dependency set and is browser-only;
         # exclude it from collection so a missing browser dep can't abort the


### PR DESCRIPTION
Part 2 of 2 for the line-ending cleanup, following #258 (which normalized the repo and is now merged as `5112633`). `main` currently has **0** tracked files with CRLF or mixed endings; this PR keeps it that way.

## `.git-blame-ignore-revs`

Records #258's squashed commit so `git blame` skips the 235-file churn. GitHub's blame view reads this file automatically; locally it needs `git config blame.ignoreRevsFile .git-blame-ignore-revs` once per clone, which the file documents inline.

(This is precisely why the work was split into two PRs: the repo squash-merges, so a combined PR would have collapsed both commits and the SHA recorded here would have referenced a commit that never existed on `main`.)

## The enforcement gate

A new step in the `host-tests` job fails the build when any tracked file has CRLF or mixed endings.

It inspects the **index** (`git ls-files --eol`, matching `^i/(crlf|mixed)`) rather than the working tree, so the result does not depend on how the runner happens to check files out — a working-tree check would be meaningless, since `text=auto` legitimately leaves CRLF in a Windows contributor's working tree while the index stays LF.

On failure it prints the offending paths and the one-line fix (`git add --renormalize .`) instead of just a non-zero exit.

### Verified, not assumed

I confirmed the gate actually catches a regression rather than trivially passing. Adding a file that bypasses normalization (`tmpcrlf.txt -text` in `.gitattributes`, content written with CRLF) makes the check report:

```
i/crlf  w/crlf  attr/-text            tmpcrlf.txt
```

and the step exits non-zero. With that file removed it reports 0 and passes. The recorded blame SHA was also verified to resolve (`git cat-file -t 5112633a...` -> `commit`).

## Note on `text=auto` and mixed endings

`* text=auto` alone does not prevent CRLF from entering history — a contributor can still commit CRLF via an explicit `-text` attribute, and more realistically a future `.gitattributes` edit could unnormalize a path without anyone noticing. The gate is what makes the normalization durable.
