### PR TITLE
fix(ui): honour the 12/24-hour setting on the history screen

### DIFF
--- a/main/heatpump_history_screen.cpp
+++ b/main/heatpump_history_screen.cpp
@@ -257,7 +257,18 @@ static void chart_draw_cb(lv_event_t* event) {
         struct tm local = {};
         localtime_r(&tick_time, &local);
         char label[12];
-        strftime(label, sizeof(label), "%H:%M", &local);
+        if (time_mgr_get_24h_format()) {
+            strftime(label, sizeof(label), "%H:%M", &local);
+        } else {
+            // Ticks are snapped to whole hours above, so the minutes carry no
+            // information in 12-hour form -- "8 AM" rather than "08:00 AM".
+            // That also keeps the label narrower than the 24-hour "08:00", so
+            // adding the suffix cannot make axis labels collide.
+            int hour12 = local.tm_hour % 12;
+            if (hour12 == 0) hour12 = 12;
+            snprintf(label, sizeof(label), "%d %s", hour12,
+                     local.tm_hour < 12 ? "AM" : "PM");
+        }
         lv_area_t label_area = {x - 40, plot.y2 + 10, x + 40, coords.y2};
         draw_label(layer, label_area, label, UI_COLOR_TEXT_DIM,
                    LV_TEXT_ALIGN_CENTER);
@@ -323,8 +334,12 @@ static void update_range_label() {
     localtime_r(&end, &end_tm);
     char start_text[32];
     char end_text[32];
-    strftime(start_text, sizeof(start_text), "%b %d, %H:%M", &start_tm);
-    strftime(end_text, sizeof(end_text), "%b %d, %H:%M", &end_tm);
+    // The window edges are ragged (the range ends at "now"), so unlike the axis
+    // ticks the minutes are meaningful here and the full form is used.
+    const char* fmt =
+        time_mgr_get_24h_format() ? "%b %d, %H:%M" : "%b %d, %I:%M %p";
+    strftime(start_text, sizeof(start_text), fmt, &start_tm);
+    strftime(end_text, sizeof(end_text), fmt, &end_tm);
     char range[80];
     snprintf(range, sizeof(range), "%s - %s", start_text, end_text);
     lv_label_set_text(state.range_label, range);
@@ -543,6 +558,8 @@ void heatpump_history_show(lv_obj_t* parent,
     lv_obj_set_style_text_color(state.range_label, UI_COLOR_TEXT_DIM, LV_PART_MAIN);
     lv_obj_set_style_text_align(state.range_label, LV_TEXT_ALIGN_CENTER,
                                 LV_PART_MAIN);
+    lv_obj_set_user_data(state.range_label,
+                         (void*)"temperature_history_range");
 
     lv_obj_t* legend = lv_obj_create(state.overlay);
     lv_obj_remove_style_all(legend);

--- a/main/settings/settings_time_screen.cpp
+++ b/main/settings/settings_time_screen.cpp
@@ -14,6 +14,7 @@
 #include "geocoding.h"
 #include "i18n/i18n.h"
 #include "fonts/fonts.h"
+#include "status_bar.h"
 #include <esp_log.h>
 #include <string.h>
 #include <stdio.h>
@@ -184,6 +185,12 @@ static void save_settings(void)
 {
     // Use time_manager API to save format - it updates both NVS and in-memory state
     time_mgr_set_24h_format(s_state.use_24h);
+    // Repaint the status-bar clock now instead of leaving it in the old format
+    // until its 10-second refresh timer next fires. Without this the clock
+    // still reads e.g. "17:05" (or "05:05" with no AM/PM) for several seconds
+    // after the user toggles the format, which reads as the setting having
+    // been ignored.
+    status_bar_update_time();
     ESP_LOGI(TAG, "Saved 24h format: %d", s_state.use_24h);
 }
 

--- a/tests/device/README.md
+++ b/tests/device/README.md
@@ -157,7 +157,7 @@ The `conftest.py` session fixture handles this automatically.
 | [`test_status_bar.py`](test_status_bar.py) | 6 | WiFi icon, notification badge, dropdown, firmware notification |
 | [`test_firmware.py`](test_firmware.py) | 5 | Version display, GitHub check, mock update states |
 | [`test_timezone.py`](test_timezone.py) | 5 | Timezone roller, time preview, preferences |
-| [`test_time_format.py`](test_time_format.py) | 5 | 12h/24h toggle, status bar display |
+| [`test_time_format.py`](test_time_format.py) | 6 | 12h/24h toggle, status bar display, history range label |
 | [`test_wifi.py`](test_wifi.py) | 4 | Password dialog, show/hide toggle, open network bypass |
 | [`test_demo_mode.py`](test_demo_mode.py) | 3 | Demo mode toggle, reboot confirmation panel, cancel revert |
 | [`test_settings_menu.py`](test_settings_menu.py) | 4 | Open/close settings, close button |

--- a/tests/device/test_time_format.py
+++ b/tests/device/test_time_format.py
@@ -146,6 +146,63 @@ def test_toggle_to_12h_format(device: DeviceClient, time_format_restore):
         f"Expected format_24h=False, got {prefs['format_24h']}"
 
 
+def _open_temperature_history(device: DeviceClient):
+    """From the main screen, open the 8-hour temperature history graph."""
+    device.click(tag="nav_status")
+    device.wait_for_widget(tag="temperature_history_open", timeout=5.0)
+    device.click(tag="temperature_history_open")
+    device.wait_for_widget(tag="temperature_history_screen", timeout=5.0)
+
+
+def _history_range_text(device: DeviceClient) -> str:
+    w = device.find_widget(tag="temperature_history_range")
+    return (w.text or "").strip() if w is not None else ""
+
+
+def test_history_range_label_follows_time_format(
+    device: DeviceClient, time_format_restore
+):
+    """The history graph's range label must honour the 12/24h setting.
+
+    Regression guard: this screen formatted its range label and axis ticks with
+    a hardcoded "%H:%M", so it stayed on 24-hour time forever no matter what the
+    user selected. Every other screen already branched on the setting, which is
+    what made the omission easy to miss.
+    """
+    device.populate_temperature_history()
+
+    # 24-hour: the range reads like "Sep 10, 14:05" with no meridiem.
+    _navigate_to_time_screen(device)
+    _set_format_24h(device, True)
+    _return_to_main(device)
+    _open_temperature_history(device)
+    device.wait_until(
+        "history range label rendered",
+        lambda: bool(_history_range_text(device)),
+        timeout=5.0,
+    )
+    text_24h = _history_range_text(device)
+    assert not _12H_PATTERN.search(text_24h), \
+        f"Expected 24h range label (no AM/PM), got '{text_24h}'"
+    device.click(tag="temperature_history_back")
+
+    # 12-hour: the same label must now carry AM/PM.
+    _return_to_main(device)
+    _navigate_to_time_screen(device)
+    _set_format_24h(device, False)
+    _return_to_main(device)
+    _open_temperature_history(device)
+    device.wait_until(
+        "history range label shows 12h format",
+        lambda: bool(_12H_PATTERN.search(_history_range_text(device))),
+        timeout=5.0,
+    )
+    text_12h = _history_range_text(device)
+    assert _12H_PATTERN.search(text_12h), \
+        f"Expected 12h range label (with AM/PM), got '{text_12h}'"
+    device.click(tag="temperature_history_back")
+
+
 def test_main_screen_shows_24h(device: DeviceClient, time_format_restore):
     """After switching to 24h, the main screen status bar should show 24h format."""
     _navigate_to_time_screen(device)


### PR DESCRIPTION
Fixes the reported nit: the time on the device had no AM/PM in 12-hour format. Root-caused to two separate defects.

## 1. The history screen ignored the setting entirely (permanent)

`heatpump_history_screen.cpp` formatted its range label and x-axis ticks with a hardcoded `%H:%M` in three places, so that screen stayed on 24-hour time regardless of the setting. It is the only screen that did this -- the status bar, event log and errors screen all already branch on `time_mgr_get_24h_format()`, which is what made it easy to miss.

Axis ticks are snapped to whole hours, so in 12-hour form the minutes carry no information; they now read **"8 AM"** rather than "08:00 AM". That is also *narrower* than the existing "08:00", so the suffix cannot make labels collide in the 80 px tick area. The range label spans ragged window edges where minutes are meaningful, so it uses the full `%b %d, %I:%M %p`, matching `heatpump_errors_screen.cpp`.

## 2. The status-bar clock did not repaint on change (transient)

Changing the format left the clock stale for up to **10 seconds** (its `lv_timer` period). At a time like 05:53 the 12h and 24h renderings are identical apart from the missing suffix, so the stale value looks exactly like a formatting bug -- this is most likely what was actually observed. `save_settings()` now repaints immediately.

The API path (`POST /api/time/config`) deliberately does **not** do this: it runs on the HTTP task, where calling into LVGL is unsafe. Those changes stay on the 10-second timer, the same pattern already documented there for web-API temperature-unit changes.

## Evidence

Ruled out the obvious causes on real hardware before changing anything:

- `%p` is present in every format string, and works at the C-library level -- live `/api/time` returned `"time_12h":"05:51:37 AM"`.
- Not a buffer truncation (`strftime` writes nothing if the buffer is short): the status-bar buffer is 16 bytes, the button 220 px, and Montserrat 32 renders "05:55 AM" at ~130 px.
- `time_screen_get_24h_format()` has two definitions, but `main/time_screen.cpp` is not in `main/CMakeLists.txt`; the linked one delegates to `time_mgr` correctly.
- Reproduced the transient bug: after switching to 12-hour the status bar read `05:53`, then `05:55 AM` once the timer fired. Device restored to `format_24h:true` afterwards.

## Testing

Adds `test_history_range_label_follows_time_format` (asserts no AM/PM in 24h, AM/PM present in 12h) and tags the range label so tests can address it. Neither defect was catchable before: the existing status-bar tests allow a 15-second settle, which masks the refresh lag, and nothing exercised the history screen's time rendering.

Firmware builds clean. Hardware validation comes from this PR's own device-tests run.
