### PR TITLE
feat(ota): fail runs when OTA installation fails, and assert the install worked

### DIFF
--- a/.github/scripts/check_test_floor.py
+++ b/.github/scripts/check_test_floor.py
@@ -92,6 +92,14 @@ BENIGN_SKIP_PATTERNS = [
     # Self-invalidating by design: the call under test destroys the credential
     # the rest of the run depends on, so it can only be exercised in isolation.
     r"invalidates arctic_api_key",
+    # The OTA install assertions (#252 T-01) check properties of the install CI
+    # itself performed. Run outside CI there is no such install to assert on:
+    # no baked build_sha to compare against, and no statement of whether the
+    # firmware arrived over the air or over USB. Genuinely not applicable rather
+    # than untested — in CI these always execute.
+    r"not a ci build",
+    r"arctic_flash_method unset",
+    r"ota slot not applicable",
 ]
 
 # Deliberate, tracked gaps: the test is skipped because the feature or the

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -487,6 +487,13 @@ jobs:
         if: steps.partition_layout.outputs.changed != 'true' && steps.ota_flash.outcome == 'success'
         run: |
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          # Record how this firmware was installed so the OTA tests can assert on
+          # it. The device cannot report this itself: a USB-recovered device and a
+          # successfully OTA'd one present an identical build_sha, and differ only
+          # in which app slot they booted from — which is legitimate for a USB
+          # flash and a failure for an OTA. Only the workflow knows which was
+          # intended, so it states it here.
+          echo "ARCTIC_FLASH_METHOD=ota" >> "$GITHUB_ENV"
           sleep 10
           # 80s window: the async pull path (nightly) only starts flashing +
           # rebooting AFTER this step begins (it quiesced the network mid-download),
@@ -507,6 +514,9 @@ jobs:
         if: steps.partition_layout.outputs.changed == 'true' || steps.ota_flash.outcome == 'failure'
         run: |
           echo "OTA failed, falling back to USB serial flash..."
+          # See the note in "Wait for device reboot (OTA)". A USB flash boots the
+          # factory slot, so the OTA tests must not demand an ota_* slot here.
+          echo "ARCTIC_FLASH_METHOD=usb" >> "$GITHUB_ENV"
 
           # Generate NVS partition with WiFi credentials + API key so the device can auto-connect
           # and tests can authenticate.  The "auth" namespace pre-seeds the API key so
@@ -763,16 +773,37 @@ jobs:
           fi
           echo "OK: device is running the build under test ($EXPECTED)"
 
-      - name: Enforce nightly OTA pull-path success (strict)
-        # The nightly run exists to validate the /api/ota/update pull path that
-        # field devices use. If that path failed, the USB fallback above will have
-        # recovered the device to the build-under-test (so the rollback guard still
-        # passes), which would otherwise silently mask the failure. Fail the job
-        # explicitly so a broken pull-path OTA can never pass nightly. This runs
-        # AFTER recovery so the device is left healthy for the next scheduled run.
-        if: github.event_name == 'schedule' && steps.partition_layout.outputs.changed != 'true' && steps.ota_flash.outcome == 'failure'
+      - name: Enforce OTA installation success (strict)
+        # OTA is how firmware reaches devices in the field, so an OTA that fails
+        # must fail the run. It previously could not: "Flash device via OTA" is
+        # continue-on-error (deliberately — the USB fallback has to be allowed to
+        # rescue the rig), the fallback then recovers the device to the
+        # build-under-test, and the rollback guard above therefore passes. The
+        # net effect was a green run that had never successfully installed an
+        # image over the air. This gate closes that hole for every trigger.
+        #
+        # Which path was exercised depends on the trigger, and both matter:
+        #   - schedule → asynchronous PULL (/api/ota/update from the ci-nightly
+        #     release), which is what field devices actually do;
+        #   - PR/push/dispatch → synchronous PUSH (/api/ota/upload).
+        # Strictness used to be gated on `schedule`, leaving the push path — the
+        # one every PR relies on to install its own build — unenforced.
+        #
+        # Exempt: a partition-layout change, where OTA is genuinely impossible
+        # (the new table cannot be applied over the air) and USB is correct. That
+        # case skips the OTA step entirely, so its outcome is 'skipped', not
+        # 'failure', and does not trip this gate.
+        #
+        # This deliberately runs AFTER the USB fallback and the rollback guard so
+        # the device is left healthy for the next run even as we fail this one.
+        if: steps.partition_layout.outputs.changed != 'true' && steps.ota_flash.outcome == 'failure'
         run: |
-          echo "::error::Nightly /api/ota/update (pull-path OTA) FAILED. The device was recovered via USB fallback, but nightly must strictly validate the pull path. Failing the job."
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            PATH_NAME="/api/ota/update (asynchronous pull path)"
+          else
+            PATH_NAME="/api/ota/upload (synchronous push path)"
+          fi
+          echo "::error::OTA installation FAILED via $PATH_NAME. The device was recovered over USB, so it is healthy and running the build under test — but the over-the-air install did not work, which is the failure mode that strands a field device. Failing the job."
           exit 1
 
       - name: Run device UI tests

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -919,6 +919,25 @@ paths:
                       been validated yet. If the device reboots before validation,
                       the bootloader reverts to the previous partition.
                     example: false
+                  build_sha:
+                    type: string
+                    description: |
+                      Per-build fingerprint baked in at compile time. CI asserts
+                      this equals the build it just installed, so a silent
+                      rollback to the previous image is caught rather than being
+                      masked by tests passing against the reverted firmware.
+                    example: "a1b2c3d"
+                  running_partition:
+                    type: string
+                    description: |
+                      Label of the app partition currently executing, e.g.
+                      `factory`, `ota_0` or `ota_1`. Where `build_sha` identifies
+                      *which* build is running, this identifies *how it got
+                      there*: a device running from `factory` was flashed over
+                      USB, so an OTA either never ran or was rolled back. A
+                      USB-recovered device otherwise reports exactly the same
+                      `build_sha` as a successfully updated one.
+                    example: "ota_0"
                   new_version:
                     type: string
                     description: Version being installed (only during URL update)

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3262,6 +3262,7 @@ static const char* ota_state_to_string(ota_state_t state)
 {
     switch (state) {
         case OTA_STATE_IDLE: return "idle";
+        case OTA_STATE_UPLOADING: return "uploading";
         case OTA_STATE_DOWNLOADING: return "downloading";
         case OTA_STATE_VERIFYING: return "verifying";
         case OTA_STATE_READY_TO_REBOOT: return "ready_to_reboot";

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -3296,6 +3296,19 @@ static esp_err_t ota_status_get_handler(httpd_req_t* req)
     // build it just OTA'd, so a silent rollback to the previous image is caught
     // instead of being masked by tests passing against the rolled-back firmware.
     cJSON_AddStringToObject(root, "build_sha", ARCTIC_BUILD_SHA);
+
+    // Which app slot is executing. `build_sha` proves *which build* is running;
+    // this proves *how it got there*. A device that booted from `factory` was
+    // flashed over USB, so an OTA either never ran or was rolled back — a
+    // distinction the OTA tests need and could not previously make, because a
+    // USB-recovered device presents exactly the same build_sha as a
+    // successfully OTA'd one (see the OTA strictness gate in device-tests.yml).
+    {
+        char part_label[17] = {0};
+        ota_mgr_get_partition_info(part_label, NULL, NULL);
+        part_label[16] = '\0';
+        cJSON_AddStringToObject(root, "running_partition", part_label);
+    }
     
     if (status.new_version[0] != '\0') {
         cJSON_AddStringToObject(root, "new_version", status.new_version);

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -702,60 +702,110 @@ def _get_firmware_binary():
     return bin_path.read_bytes()
 
 
-@pytest.mark.skip(reason="Requires serial connection and device reboot — not yet available on CI runner")
-class TestOtaRoundTrip:
-    """Tier 2: Upload current firmware via OTA, wait for reboot, verify recovery.
+def _expected_build_sha():
+    """The build_sha CI baked into the firmware under test, or None locally.
 
-    This proves the full OTA pipeline works end-to-end without needing a
-    different firmware version. The device should reboot onto the alternate
-    partition with the same version.
+    Same source of truth the workflow's rollback guard reads.
+    """
+    p = Path(__file__).resolve().parent.parent.parent / "build" / "build_sha.txt"
+    if not p.exists():
+        return None
+    return p.read_text().strip() or None
+
+
+class TestOtaRoundTrip:
+    """Tier 2 — assert that the OTA install CI just performed actually worked.
+
+    Un-skips the coverage tracked as T-01 in #252. The old skip reason
+    ("requires serial connection and device reboot — not yet available on CI
+    runner") has been stale for some time: device-tests.yml installs every
+    build under test *by OTA* as its primary path, over
+    /api/ota/upload on PR/push runs and /api/ota/update on nightly, falling
+    back to USB only when that fails.
+
+    These tests deliberately assert on that install rather than performing a
+    second one. Re-uploading the identical binary mid-suite would reboot the
+    device for ~90s, reset state that later tests depend on, and double the
+    flash wear — while producing no evidence the CI install had not already
+    produced. It is the same binary over the same code path. What was actually
+    missing was never the OTA; it was the assertions on its outcome, which
+    lived only in shell inside the workflow.
+
+    Three properties matter, and each fails differently:
+      - the running image is the build under test (else we silently tested a
+        rolled-back image — the failure #234 hit);
+      - it was committed, i.e. mark_valid() ran (else the device is still in
+        PENDING_VERIFY and the next reboot reverts it);
+      - it is executing from an OTA slot (else it arrived over USB, and the
+        over-the-air path — the only one field devices have — is unproven).
     """
 
-    def test_upload_same_version_round_trip(self):
-        """Upload current firmware binary → reboot → device comes back healthy."""
-        firmware = _get_firmware_binary()
+    def test_running_image_is_the_build_under_test(self):
+        """The device reports the build_sha CI baked into this build.
 
-        # Record pre-OTA state
-        pre = _get("/api/ota/status").json()
-        pre_version = pre["current_version"]
-
-        # Upload firmware
-        r = _post_raw("/api/ota/upload", data=firmware)
-        assert r.status_code == 200, f"Upload failed: {r.text}"
-        data = r.json()
-        assert data.get("success") is True
-        assert data.get("bytes_received") == len(firmware)
-
-        # Device will auto-reboot — wait for it to go offline then come back
-        post = _wait_for_device(timeout=90)
-
-        # Same version, idle state
-        assert post["current_version"] == pre_version
-        assert post["state"] == "idle"
-
-    def test_pending_verify_after_ota(self):
-        """After OTA reboot, firmware should briefly be in pending_verify
-        state before mark_valid() runs. By the time we can query the API,
-        mark_valid() has already fired (it runs during create_ui), so
-        pending_verify should be false.
+        Guards against a silent rollback: a reverted device stays reachable and
+        happily serves the whole suite from the *previous* image.
         """
-        # This runs after test_upload_same_version_round_trip
+        expected = _expected_build_sha()
+        if expected is None:
+            pytest.skip("build/build_sha.txt absent — not a CI build, nothing to compare against")
+
         data = _get("/api/ota/status").json()
-        assert data["pending_verify"] is False, (
-            "Firmware should have been validated by mark_valid() after create_ui()"
+        actual = data.get("build_sha")
+        assert actual, "Device reported no build_sha — firmware predates the rollback guard"
+        assert actual == expected, (
+            f"Device is running build_sha {actual!r}, expected {expected!r}. "
+            "The device most likely rolled back to the previous image, which means "
+            "this run has been testing firmware that is not the build under test."
+        )
+
+    def test_installed_image_was_committed(self):
+        """pending_verify is false — mark_valid() ran, so rollback is cancelled.
+
+        A device left in PENDING_VERIFY looks perfectly healthy over the API and
+        passes the whole suite, then reverts on its next reboot. That is exactly
+        the state a field device must never be released in.
+        """
+        data = _get("/api/ota/status").json()
+        assert data.get("pending_verify") is False, (
+            "Running image is still PENDING_VERIFY: mark_valid() never ran, so the "
+            "bootloader will revert to the previous image on the next reboot."
+        )
+
+    def test_running_from_ota_slot(self):
+        """The image is executing from an ota_* slot, not factory.
+
+        build_sha alone cannot distinguish a successful OTA from a USB recovery —
+        both report the same value. The slot label can.
+        """
+        method = os.environ.get("ARCTIC_FLASH_METHOD")
+        if method is None:
+            pytest.skip("ARCTIC_FLASH_METHOD unset — install method unknown outside CI")
+
+        data = _get("/api/ota/status").json()
+        part = data.get("running_partition")
+        assert part, "Device reported no running_partition"
+
+        if method == "usb":
+            # Legitimate: a partition-layout change cannot be applied over the
+            # air. The workflow's strict gate fails the run separately if USB was
+            # used because the OTA failed, so nothing is being excused here.
+            pytest.skip(f"Firmware was installed over USB (running from {part!r}); OTA slot not applicable")
+
+        assert part.startswith("ota_"), (
+            f"Firmware was installed by OTA but the device is running from {part!r}. "
+            "It should be executing an ota_* slot; 'factory' means the OTA did not "
+            "take and the device is running a USB-flashed image."
         )
 
     def test_device_functional_after_ota(self):
-        """After OTA, basic API endpoints should still work."""
-        # Health check
+        """Basic API endpoints still work on the OTA-installed image."""
         r = _get("/api/ota/status")
         assert r.status_code == 200
-
-        # Verify another endpoint works too
-        r = _get("/api/ota/status")
         data = r.json()
         assert "current_version" in data
         assert "pending_verify" in data
+        assert data["state"] == "idle", f"OTA state should be idle after install, got {data['state']!r}"
 
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -805,7 +805,28 @@ class TestOtaRoundTrip:
         data = r.json()
         assert "current_version" in data
         assert "pending_verify" in data
-        assert data["state"] == "idle", f"OTA state should be idle after install, got {data['state']!r}"
+
+        # Deliberately NOT asserting state == "idle". `failed` is a sticky,
+        # terminal state: it has to persist so a client polling status can see
+        # why its OTA failed, and it is only cleared when the next OTA op
+        # starts (ota_mgr_try_lock_upload). Earlier classes in this file
+        # (TestOtaErrorState, TestOtaUploadBadData) drive the state machine to
+        # `failed` on purpose, so requiring `idle` here just asserts test
+        # ordering. What actually matters after an install is that the device
+        # is quiescent — an in-flight or staged operation would block the next
+        # update, whereas `failed` does not. Allowlist rather than blocklist so
+        # an unexpected/unmapped state fails loudly instead of slipping through.
+        assert data["state"] in ("idle", "failed"), (
+            f"Device should be quiescent after install, got {data['state']!r}. "
+            "Only 'idle' or the sticky terminal 'failed' are expected; anything "
+            "else means an OTA is still in flight or staged awaiting reboot."
+        )
+
+        # "Functional" should mean more than the OTA endpoint answering.
+        health = _get("/api/health")
+        assert health.status_code == 200, (
+            f"Device is not serving /api/health after OTA install: {health.status_code}"
+        )
 
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Addresses the two highest-priority non-firmware items in #252: the CI enforcement gap (section 7.1) and **T-01**.

## 1. A failed OTA could pass the run

`Flash device via OTA` is `continue-on-error: true` — deliberately, so the USB fallback can rescue the rig. But the fallback then reinstalls the same build, so the `build_sha` rollback guard is satisfied and the job goes green. The net effect: **a passing run that had never once installed an image over the air**, which is the only path a field device has.

Strict enforcement already existed, but was gated on `github.event_name == 'schedule'`. It covered the nightly *pull* path (`/api/ota/update`) and left the *push* path (`/api/ota/upload`) — the one every PR relies on to install its own build — completely unenforced.

The gate now applies to **all triggers**. Deliberately unchanged:

- the USB fallback stays, so the rig remains usable;
- the gate still runs **after** the fallback and the rollback guard, so the device is left healthy for the next run even as this run fails;
- a **partition-layout change is exempt** — OTA genuinely cannot apply a new partition table, and USB is correct there. That case skips the OTA step entirely, so its outcome is `skipped`, not `failure`, and does not trip the gate.

## 2. T-01 — un-skip `TestOtaRoundTrip`

The skip reason ("requires serial connection and device reboot — not yet available on CI runner") has been stale for some time: `device-tests.yml` already installs every build under test **by OTA** as its primary path.

**These tests assert on that install rather than performing a second one.** Re-uploading the identical binary mid-suite would reboot the device for ~90 s, reset state that later tests depend on, and double flash wear — while producing no evidence the CI install had not already produced. It is the same binary over the same code path. What was actually missing was never the OTA; it was the assertions on its outcome, which lived only in shell inside the workflow.

Three properties, each failing differently:

| Property | What its failure means |
|---|---|
| Running image is the build under test | Silent rollback — the suite has been testing the *previous* image. This is the failure #234 hit. |
| Image was committed (`pending_verify == false`) | Device is still `PENDING_VERIFY`: looks perfectly healthy over the API, passes the suite, then **reverts on its next reboot**. |
| Running from an `ota_*` slot | It arrived over USB — the over-the-air path is unproven. |

## 3. Two additions the third assertion needed

**`running_partition` in `/api/ota/status`**, from the existing `ota_mgr_get_partition_info()`. `build_sha` says *which* build is running, but a USB-recovered device reports **exactly the same `build_sha`** as a successfully updated one. Only the slot label separates them.

**`ARCTIC_FLASH_METHOD` recorded by the workflow.** Because a USB flash is legitimate for a partition-layout change, the test cannot infer from the device alone whether `factory` is a failure or expected. Only the workflow knows which install was intended, so it states it rather than leaving the test to guess.

## Also

- Documents `build_sha` and `running_partition` in `openapi.yaml`. `build_sha` was already returned but undocumented — the spec was behind.
- Classifies the three new skip reasons in `check_test_floor.py`, so `test_every_skip_message_in_the_tree_is_classified` stays green. They are `benign`: outside CI there is no install to assert on, and in CI they always execute.

## Validation

Firmware builds clean. `tests/api/test_executed_floor.py` — 31 passed, including the tree-scan classification gate. `openapi_spec_validator` passes. Workflow YAML parses. Hardware validation comes from this PR's own device-tests run, which now exercises the strict gate on itself.

Refs #252
