### PR TITLE
fix(ci): reset device credentials before syncing the key in the rollback workflow

### DIFF
--- a/.github/workflows/ota-rollback.yml
+++ b/.github/workflows/ota-rollback.yml
@@ -246,21 +246,35 @@ jobs:
       - name: Sync API key from device
         # MUST run before the preflight: /api/ota/status is auth-gated, so an
         # unauthenticated probe returns {"error":"API key required"} and the
-        # baseline guard cannot read build_sha. Uses the same login flow as
-        # device-tests.yml (POST /login for a session cookie, then
-        # GET /api/auth/apikey) — the device's own key may differ from the
-        # secret if it was provisioned separately.
+        # baseline guard cannot read build_sha.
+        #
+        # The device's credentials are NOT the ARCTIC_USERNAME/ARCTIC_PASSWORD
+        # secrets: device-tests.yml provisions isolated per-run credentials, so
+        # whichever job ran last left its own behind and a login with the
+        # secrets 401s. Mirror the proven "Sync API key from device (pre-OTA)"
+        # step in device-tests.yml and first reset them to known values through
+        # the unauthenticated, test-only /api/test/credentials endpoint
+        # (CONFIG_TEST_ENDPOINTS), then log in.
         run: |
           set -uo pipefail
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
+          TEST_USERNAME="arctic"
+          TEST_PASSWORD="ArcticTest!2026"
+          BODY="{\"username\": \"$TEST_USERNAME\", \"password\": \"$TEST_PASSWORD\"}"
           DEVICE_KEY=""
+
           for i in $(seq 1 12); do
+            curl -sk --connect-timeout 3 --max-time 8 \
+              -X POST "$ARCTIC_URL_HTTPS/api/test/credentials" \
+              -H "Content-Type: application/json" \
+              -d "$BODY" > /dev/null 2>&1 || true
+
             JAR=$(mktemp)
-            curl -skf -c "$JAR" --connect-timeout 5 --max-time 10 \
+            curl -sk -c "$JAR" --connect-timeout 3 --max-time 8 \
               -X POST "$ARCTIC_URL_HTTPS/login" \
               -H "Content-Type: application/json" \
-              -d "{\"username\": \"$ARCTIC_USERNAME\", \"password\": \"$ARCTIC_PASSWORD\"}" > /dev/null 2>&1 || true
-            RESP=$(curl -skf -b "$JAR" --connect-timeout 5 --max-time 10 \
+              -d "$BODY" > /dev/null 2>&1 || true
+            RESP=$(curl -sk -b "$JAR" --connect-timeout 3 --max-time 8 \
               "$ARCTIC_URL_HTTPS/api/auth/apikey" 2>/dev/null) || true
             rm -f "$JAR"
             DEVICE_KEY=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null) || true
@@ -275,9 +289,6 @@ jobs:
           echo "::add-mask::$DEVICE_KEY"
           echo "ARCTIC_API_KEY=$DEVICE_KEY" >> "$GITHUB_ENV"
           echo "Device API key acquired."
-        env:
-          ARCTIC_USERNAME: ${{ secrets.ARCTIC_USERNAME }}
-          ARCTIC_PASSWORD: ${{ secrets.ARCTIC_PASSWORD }}
 
       - name: Preflight — record the known-good baseline
         # Everything downstream is asserted against this. If the device is not


### PR DESCRIPTION
Follow-up to #264. Replaces #265, which was branched off the pre-squash commits of #262/#263/#264 and therefore conflicted once those were squash-merged (`mergeStateStatus: DIRTY`, CI never ran). This branch is cut cleanly from `main`; the change is identical.

The second hardware run ([34512394926](https://github.com/sslivins/arctic-controller/actions/runs/34512394926)) confirmed the #264 fixes worked — the recovery step correctly reported the controller healthy and did **not** perform a needless reflash or raise a false "rig is DOWN" — but the key sync itself then failed:

```
Could not read the device API key
```

## Root cause

The step logged in with the `ARCTIC_USERNAME` / `ARCTIC_PASSWORD` secrets, but **those are not the device's live credentials**. `device-tests.yml` provisions *isolated per-run* credentials ("Provision isolated test credentials"), so whichever job ran last left its own behind. The login 401s.

`device-tests.yml` already solves exactly this in its **pre-OTA** sync: reset the running firmware's credentials to known values via the unauthenticated, test-only `/api/test/credentials` endpoint (`CONFIG_TEST_ENDPOINTS`), *then* log in and read the key. This mirrors that, rather than depending on whatever auth state a previous job happened to leave.

## Verified live against the controller on `ghr-mi`

```
creds  HTTP:200 {"success":true}
login  HTTP:200 {"success":true}
apikey {"api_key":"..."}

/api/ota/status ->
{"state":"failed", ..., "pending_verify":false,
 "build_sha":"6327e22...", "running_partition":"ota_1"}
```

That is precisely what the preflight baseline needs: `build_sha`, `running_partition`, and `pending_verify:false`. (`state:"failed"` is the sticky terminal residue from the OTA error-state test — expected, and explicitly allowed by the preflight.)

The poison upload has **still never executed** — both prior runs aborted in preflight. This should be the run that finally exercises it.

Refs #252 (T-02).
