### PR TITLE
feat(ota): require proven network reachability before committing firmware

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -938,6 +938,44 @@ paths:
                       USB-recovered device otherwise reports exactly the same
                       `build_sha` as a successfully updated one.
                     example: "ota_0"
+                  commit_status:
+                    type: string
+                    enum: [committed, not_pending, waiting_for_ui, waiting_for_network, waiting_for_network_grace]
+                    description: |
+                      Why an unverified image has not yet committed itself.
+
+                      With rollback enabled an OTA image boots in
+                      `PENDING_VERIFY` and must be explicitly committed, or the
+                      bootloader reverts to the previous slot on the next
+                      reboot. Committing is an assertion that the firmware
+                      works, so a *commissioned* device must have reached the
+                      network at least once this boot before it is allowed to
+                      commit. That closes the case where an image boots and
+                      renders its UI but has broken networking: it would
+                      otherwise commit itself and strand the device, which has
+                      no serial console in the field.
+
+                      `waiting_for_network` is the significant value: the device
+                      is up and serving this very response, but is refusing to
+                      commit and **will roll back if it reboots**. Reachability
+                      latches for the whole uptime and there is no deadline, so
+                      a device behind a router that is down for hours still
+                      commits the moment the network returns.
+
+                      `not_pending` means there is nothing to commit — the
+                      running image is already valid.
+                    example: "committed"
+                  commissioned:
+                    type: boolean
+                    description: |
+                      Whether this device has ever reached the network, latched
+                      persistently. Until it has, it is treated as being set up
+                      from the touchscreen and may commit on UI alone; there is
+                      no SoftAP provisioning path on this hardware. The latch is
+                      one-way so that a regression in credential loading cannot
+                      make a deployed device look factory-fresh and thereby
+                      re-earn the weaker criterion.
+                    example: true
                   new_version:
                     type: string
                     description: Version being installed (only during URL update)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -46,6 +46,7 @@ idf_component_register(
         "status_bar.cpp"
         "api_server.cpp"
         "ota_manager.cpp"
+        "ota_commit.cpp"
         "auth_manager.cpp"
         "ha_integration.cpp"
         "setup_pairing.cpp"

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -13,6 +13,7 @@
 #include "geocoding.h"
 #include "weather.h"
 #include "ota_manager.h"
+#include "ota_commit.h"
 #include "auth_manager.h"
 #include "ha_integration.h"
 #include "setup_pairing.h"
@@ -3310,6 +3311,13 @@ static esp_err_t ota_status_get_handler(httpd_req_t* req)
         part_label[16] = '\0';
         cJSON_AddStringToObject(root, "running_partition", part_label);
     }
+
+    // Why an unverified image has not committed itself yet. Lets the CMS (and
+    // the rollback-validation job) distinguish "healthy and committed" from
+    // "up, but refusing to commit because it cannot reach the network" — the
+    // latter will roll back on the next reboot.
+    cJSON_AddStringToObject(root, "commit_status", ota_commit_status());
+    cJSON_AddBoolToObject(root, "commissioned", ota_commit_is_commissioned());
     
     if (status.new_version[0] != '\0') {
         cJSON_AddStringToObject(root, "new_version", status.new_version);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -21,6 +21,7 @@
 #include "status_bar.h"
 #include "weather.h"
 #include "ota_manager.h"
+#include "ota_commit.h"
 #if CONFIG_ARCTIC_POISON_FIRMWARE
 #include "esp_ota_ops.h"
 #include "esp_rom_sys.h"
@@ -371,15 +372,18 @@ extern "C" void app_main(void)
 
     // Initialize OTA manager
     ota_mgr_init();
-    
+    ota_commit_init();
+
     // NOTE: ota_mgr_mark_valid() is NOT called here.  With rollback enabled,
-    // new firmware boots in PENDING_VERIFY state.  We defer mark_valid()
-    // until after the UI has been created and critical subsystems are up,
-    // proving the firmware is functional.  If the device crash-loops before
-    // reaching that point, the bootloader rolls back to the previous version.
+    // new firmware boots in PENDING_VERIFY state.  The commit decision is
+    // owned by ota_commit_eval(), driven from the main loop: the UI must come
+    // up AND (on a commissioned device) the network must have been reachable
+    // at least once this boot.  An image that crash-loops, or that boots but
+    // cannot reach the network, is never committed and the bootloader rolls
+    // back to the previous version.
     if (ota_mgr_is_pending_verify()) {
         ESP_LOGW(TAG, "*** First boot after OTA — firmware pending verification ***");
-        ESP_LOGW(TAG, "*** Will mark valid after UI creation succeeds ***");
+        ESP_LOGW(TAG, "*** Will mark valid once the UI is up and the network is reachable ***");
     }
 
 #if CONFIG_ARCTIC_POISON_FIRMWARE
@@ -477,6 +481,9 @@ extern "C" void app_main(void)
     bool health_marked = false;
     int64_t next_health_attempt_us = HEALTH_WINDOW_US;
 
+    const int64_t COMMIT_EVAL_INTERVAL_US = 1000000LL;  // 1 s
+    int64_t next_commit_eval_us = 0;
+
     // Main loop
     while (1) {
         esp_task_wdt_reset();
@@ -495,14 +502,29 @@ extern "C" void app_main(void)
             bsp_display_unlock();
             mclog::tagInfo(TAG, "UI Created");
             show_main_ui = false;  // Only create once
-            
-            // NOW mark firmware as valid — display init succeeded, LVGL is
-            // running, UI rendered, heat-pump integration started, event log is up.
-            // If we got here, the firmware is functional.
-            if (ota_mgr_is_pending_verify()) {
-                ESP_LOGI(TAG, "Post-OTA health check passed — marking firmware valid");
-                ota_mgr_mark_valid();
-            }
+
+            // Display init succeeded, LVGL is running, the UI rendered, the
+            // heat-pump integration started and the event log is up. That is
+            // one of the commit criteria — NOT the commit itself.
+            //
+            // The commit decision deliberately does not live in this block.
+            // This block runs exactly once, about a second into boot, whereas
+            // association and DHCP typically land several seconds later. A
+            // commit check here would observe "no network", never re-run, and
+            // leave every OTA'd unit uncommitted until it rolled itself back.
+            // ota_commit_eval() below re-evaluates until the criteria are met.
+            ota_commit_note_ui_ready();
+        }
+
+        // Decide whether this firmware has earned the right to commit itself.
+        // See ota_commit.h — a commissioned device must have been reachable at
+        // least once this boot, so an image that boots and renders but has
+        // broken networking is rolled back instead of stranding the device.
+        // Throttled: the loop runs at ~100 Hz and the evaluation reads the OTA
+        // partition state.
+        if (esp_timer_get_time() >= next_commit_eval_us) {
+            next_commit_eval_us = esp_timer_get_time() + COMMIT_EVAL_INTERVAL_US;
+            ota_commit_eval();
         }
 
         // Once the device has run for the stability window, declare it healthy

--- a/main/ota_commit.cpp
+++ b/main/ota_commit.cpp
@@ -1,0 +1,184 @@
+#include "ota_commit.h"
+
+#include "ota_manager.h"
+#include "wifi_manager.h"
+
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+#include <string.h>
+
+static const char* TAG = "ota_commit";
+
+#define NVS_NAMESPACE       "ota_commit"
+#define NVS_KEY_COMMISSIONED "commissioned"
+
+// How long an as-yet-uncommissioned device waits for a network before it
+// commits on UI alone. A device that has never had an IP is being set up from
+// the touchscreen (there is no SoftAP provisioning path on this hardware), so
+// it may legitimately never connect. The grace only exists so that a device
+// which *is* about to connect records itself commissioned first, rather than
+// taking the weaker UI-only path by racing DHCP.
+static const int64_t UNCOMMISSIONED_GRACE_US = 120LL * 1000000LL;
+
+// Nag cadence for an image that is stuck uncommitted, so the reason is visible
+// in the serial log without flooding it.
+static const int64_t NAG_INTERVAL_US = 60LL * 1000000LL;
+
+static bool s_ui_ready = false;
+static bool s_network_seen = false;
+static bool s_commissioned = false;
+static bool s_committed = false;
+static bool s_logged_pending = false;
+static int64_t s_first_eval_us = 0;
+static int64_t s_next_nag_us = 0;
+static const char* s_status = "not_pending";
+
+static void persist_commissioned(void)
+{
+    if (s_commissioned) {
+        return;
+    }
+    s_commissioned = true;
+
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs);
+    if (err != ESP_OK) {
+        // Non-fatal: the latch is an optimisation for the *next* boot. Losing
+        // it only means a future uncommissioned-looking boot takes the weaker
+        // UI-only path, which is what the old firmware did unconditionally.
+        ESP_LOGW(TAG, "Could not open NVS to record commissioning: %s", esp_err_to_name(err));
+        return;
+    }
+    err = nvs_set_u8(nvs, NVS_KEY_COMMISSIONED, 1);
+    if (err == ESP_OK) {
+        err = nvs_commit(nvs);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Could not persist commissioning latch: %s", esp_err_to_name(err));
+    } else {
+        ESP_LOGI(TAG, "Device commissioned — future OTAs must prove reachability to commit");
+    }
+    nvs_close(nvs);
+}
+
+void ota_commit_init(void)
+{
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs);
+    if (err == ESP_OK) {
+        uint8_t v = 0;
+        if (nvs_get_u8(nvs, NVS_KEY_COMMISSIONED, &v) == ESP_OK) {
+            s_commissioned = (v != 0);
+        }
+        nvs_close(nvs);
+    }
+    ESP_LOGI(TAG, "Commit criteria armed (commissioned=%s)", s_commissioned ? "yes" : "no");
+}
+
+void ota_commit_note_ui_ready(void)
+{
+    s_ui_ready = true;
+}
+
+bool ota_commit_is_commissioned(void)
+{
+    return s_commissioned;
+}
+
+const char* ota_commit_status(void)
+{
+    return s_status;
+}
+
+// Reachability means an association plus an address we could actually be
+// contacted on. Deliberately local: no server round-trip, so a device whose
+// AP is up but whose internet is down still commits.
+static bool network_is_up(void)
+{
+    if (wifi_mgr_get_state() != WIFI_MGR_STATE_CONNECTED) {
+        return false;
+    }
+    char ip[16] = {0};
+    if (!wifi_mgr_get_ip_addr(ip, sizeof(ip))) {
+        return false;
+    }
+    return ip[0] != '\0' && strcmp(ip, "0.0.0.0") != 0;
+}
+
+static void commit(const char* why)
+{
+    ESP_LOGI(TAG, "Commit criteria met (%s) — marking firmware valid", why);
+    ota_mgr_mark_valid();
+    s_committed = true;
+    s_status = "committed";
+}
+
+void ota_commit_eval(void)
+{
+    if (s_committed) {
+        return;
+    }
+
+    // Latch reachability regardless of pending state, so the commissioned flag
+    // is recorded on ordinary boots too and is already present the first time
+    // an OTA lands.
+    if (!s_network_seen && network_is_up()) {
+        s_network_seen = true;
+        persist_commissioned();
+    }
+
+    if (!ota_mgr_is_pending_verify()) {
+        s_status = "not_pending";
+        return;
+    }
+
+    const int64_t now = esp_timer_get_time();
+    if (s_first_eval_us == 0) {
+        s_first_eval_us = now;
+        s_next_nag_us = now + NAG_INTERVAL_US;
+    }
+    if (!s_logged_pending) {
+        s_logged_pending = true;
+        ESP_LOGW(TAG, "OTA_PENDING_VERIFY firmware is unverified; commit requires %s",
+                 s_commissioned ? "UI + network reachability" : "UI (device not yet commissioned)");
+    }
+
+    if (!s_ui_ready) {
+        s_status = "waiting_for_ui";
+        return;
+    }
+
+    if (s_network_seen) {
+        commit("ui+network");
+        return;
+    }
+
+    if (!s_commissioned) {
+        // Never been on a network in its life. Give a short grace for DHCP so
+        // a device that can connect gets the strong criterion, then accept UI
+        // alone rather than stranding a genuinely standalone unit.
+        if (now - s_first_eval_us < UNCOMMISSIONED_GRACE_US) {
+            s_status = "waiting_for_network_grace";
+            return;
+        }
+        commit("ui-only:never-commissioned");
+        return;
+    }
+
+    // Commissioned but not reachable on this boot. Stay pending — deliberately
+    // forever. No forced reboot: if the network returns in an hour we commit
+    // then, and if the device reboots first the bootloader rolls this image
+    // back, which is exactly the desired outcome for an image that broke
+    // networking.
+    s_status = "waiting_for_network";
+    if (now >= s_next_nag_us) {
+        s_next_nag_us = now + NAG_INTERVAL_US;
+        ESP_LOGW(TAG,
+                 "OTA_COMMIT_BLOCKED no network since boot (%lld s); firmware stays unverified "
+                 "and will roll back if the device reboots",
+                 (long long)((now - s_first_eval_us) / 1000000LL));
+    }
+}

--- a/main/ota_commit.h
+++ b/main/ota_commit.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file ota_commit.h
+ * @brief Commit criteria for a newly OTA'd image (#252 T-05 / F-06).
+ *
+ * With rollback enabled an OTA image boots in PENDING_VERIFY and must be
+ * explicitly committed, or the bootloader reverts to the other slot on the
+ * next reboot. Committing is therefore an assertion that the new firmware
+ * actually works — and the bar for that assertion is the whole safety
+ * property, because a fielded controller has no serial console.
+ *
+ * Historically the bar was "the LVGL UI was created". That catches an image
+ * which crashes early (proven on hardware by the rollback-validation job) but
+ * not one which boots, renders, commits itself and is then permanently
+ * unreachable — a WiFi/SDIO regression, say. That image is a truck roll.
+ *
+ * So a commissioned device must also have been reachable at least once on
+ * this boot before it is allowed to commit.
+ *
+ * There is deliberately NO deadline and no forced reboot. Reachability latches
+ * for the whole uptime, so a device whose router is down for hours still
+ * commits the moment the network returns. An image that never connects simply
+ * stays pending, and the next reboot — power cut, watchdog, user — rolls it
+ * back. That keeps the mechanism free of a timer racing a slow-recovering
+ * network, which is the main way this kind of policy rolls back good firmware.
+ */
+
+/** Read the commissioned latch. Call once, after nvs_flash_init(). */
+void ota_commit_init(void);
+
+/** Latch that the UI came up. Safe to call repeatedly. */
+void ota_commit_note_ui_ready(void);
+
+/**
+ * Evaluate the criteria and commit if they are met.
+ *
+ * Cheap and idempotent; call from the main loop. Must NOT be called only once
+ * at UI creation: reachability normally arrives seconds later, so a one-shot
+ * check would find the device unreachable, never re-evaluate, and leave every
+ * unit uncommitted.
+ */
+void ota_commit_eval(void);
+
+/**
+ * Why the image has not been committed yet, for telemetry and tests.
+ *
+ * One of: "committed", "not_pending" (nothing to commit), "waiting_for_ui",
+ * "waiting_for_network", or "waiting_for_network_grace".
+ */
+const char* ota_commit_status(void);
+
+/** True once this device has ever reached the network, persisted across boots. */
+bool ota_commit_is_commissioned(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -386,6 +386,58 @@ class TestOtaStatusSchema:
             f"Unexpected state: {data['state']}"
         )
 
+    def test_commit_status_is_valid_enum(self):
+        """
+        commit_status must be one of the documented values.
+
+        This field reports why an unverified image has not committed itself.
+        It is the observable half of the commit criteria (#252 T-05): a
+        commissioned device must have reached the network at least once this
+        boot before it marks its firmware valid, so that an image which boots
+        and renders but cannot reach the network rolls back instead of
+        stranding a device that has no serial console in the field.
+        """
+        data = _get("/api/ota/status").json()
+        valid = {
+            "committed", "not_pending", "waiting_for_ui",
+            "waiting_for_network", "waiting_for_network_grace",
+        }
+        assert data["commit_status"] in valid, (
+            f"Unexpected commit_status: {data['commit_status']}"
+        )
+        assert isinstance(data["commissioned"], bool)
+
+    def test_reachable_device_is_not_stuck_uncommitted(self):
+        """
+        A device answering over the network must not be refusing to commit.
+
+        We are talking to it over TCP, so networking demonstrably works on this
+        boot and the reachability criterion is satisfied by construction. If it
+        still reports waiting_for_network, the latch is broken and this image
+        would roll itself back on the next reboot despite being healthy --
+        which on a fielded unit means an unexplained version regression.
+        """
+        data = _get("/api/ota/status").json()
+        assert data["commit_status"] != "waiting_for_network", (
+            "Device is reachable over HTTP but reports waiting_for_network; "
+            "the reachability latch is not being set, so this firmware would "
+            "roll back on the next reboot."
+        )
+
+    def test_reachable_device_is_commissioned(self):
+        """
+        Reaching the device over the network must have latched 'commissioned'.
+
+        The latch is what stops a credential-loading regression from making a
+        deployed device look factory-fresh and thereby qualify for the weaker
+        UI-only commit criterion.
+        """
+        data = _get("/api/ota/status").json()
+        assert data["commissioned"] is True, (
+            "Device served an HTTP request but is not marked commissioned; "
+            "the persistent latch is not being written."
+        )
+
 
 # ── OTA Status — idle baseline values ─────────────────────────────────────
 


### PR DESCRIPTION
Closes the last brick scenario in the OTA matrix — **F-06** in #252 (T-05).

## The gap

[Run 34536019154](https://github.com/sslivins/arctic-controller/actions/runs/34536019154) proved on hardware that an image which **crashes** before the commit point is rolled back. But the commit criterion was *"the LVGL UI was created"*, which does not cover an image that **boots, renders, commits itself, and is then permanently unreachable** — a WiFi/SDIO regression, say. It marks itself valid, so rollback never triggers. A fielded controller has no serial console, so that is a truck roll.

A **commissioned** device must now also have been **reachable at least once on this boot** before it may commit.

## Deliberately not a deadline

The obvious design — "commit within N minutes or `esp_restart()` into a rollback" — was rejected. Reachability instead **latches for the whole uptime**:

- A device whose router is down for hours still commits **the moment the network returns**.
- An image that never connects simply **stays pending**, and the next reboot (power cut, watchdog, user) rolls it back.

This removes a timer racing a slow-recovering network, which is the main way this class of policy rolls back *good* firmware. The concrete case: whole-home power recovery, where the controller boots in ~30 s but the router/ONT/mesh takes 10+ minutes. It also avoids an `esp_restart()` that the **shared** crash-streak/safe-mode NVS state could misread as a crash — note `boot_stats_note_healthy()` fires at 3 min, so a timer-based design would have had the device vote itself healthy and *then* force a rollback, the two subsystems flatly disagreeing.

## The trap this avoids

The commit decision is evaluated **from the main loop, not at UI creation**. That placement is load-bearing:

```cpp
if (show_main_ui) {        // runs exactly once, ~1 s into boot
    create_ui();
    show_main_ui = false;
    if (ota_mgr_is_pending_verify()) ota_mgr_mark_valid();   // old commit point
}
```

Association and DHCP land several seconds *later*. Simply AND-ing reachability into that block would observe "no network", never re-run, and leave **every** OTA'd unit uncommitted until it rolled itself back — a fleet-wide regression strictly worse than today. `ota_commit_eval()` re-evaluates once a second until the criteria are met.

## Other deliberate choices

- **Reachability is local** — associated + a real IP, never a server round-trip — so a WAN outage with a working AP still commits.
- **Uncommissioned devices may still commit on UI alone**, after a short grace. There is no SoftAP provisioning path on this hardware; setup happens at the touchscreen, so a standalone unit must not be stranded.
- **The commissioned latch is persistent and one-way.** This matters: keying the exemption off `wifi_mgr_has_saved_credentials()` would read the *same subsystem F-06 is meant to police* — a regression in credential loading would make a deployed device look factory-fresh and re-earn the weaker criterion, i.e. the buggier the storage layer, the more likely we exempt it.
- **Heat-pump liveness is deliberately *not* a commit gate.** A build that reaches the network but cannot drive the heat pump is bad, but it is remotely recoverable — so it is not a brick, and gating on it would add false rollbacks on transient bus faults at cold boot.

Hang-without-crash is already covered: TWDT is 60 s with `CONFIG_ESP_TASK_WDT_PANIC=y`, so a hang panics and reboots while still pending.

## Observability

`/api/ota/status` gains `commit_status` and `commissioned`, documented in `openapi.yaml`. The significant value is **`waiting_for_network`**: the device is up and serving that very response, but is refusing to commit and *will roll back if it reboots*.

Tests assert the invariant that falls out of that — a device we are talking to **over HTTP** must never report `waiting_for_network` or `commissioned: false`, since networking demonstrably works by construction. If it did, the latch would be broken and healthy firmware would roll back on the next reboot, showing up in the field as an unexplained version regression.

## Verification

- [x] `Project build complete` (ESP-IDF v6.1, ESP32-P4)
- [x] `openapi.yaml` parses; test file compiles
- [x] Index CRLF 0
- [ ] Device tests on the physical controller (CI)

Design was reviewed against its false-rollback failure modes before implementation; the one-shot trap above was caught in that review.

Refs #252.
