### PR TITLE
fix(ci): generate the blank OTA image without tripping SIGPIPE

### DIFF
--- a/.github/workflows/ota-resilience.yml
+++ b/.github/workflows/ota-resilience.yml
@@ -220,7 +220,12 @@ jobs:
           set -euo pipefail
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           SIZE=$(stat -c%s recovery/arctic_controller.bin)
-          tr '\0' '\377' < /dev/zero | head -c "$SIZE" > /tmp/blank.bin
+          # head must read from /dev/zero directly rather than from a tr
+          # pipeline: when head closes the pipe after $SIZE bytes, tr dies of
+          # SIGPIPE (exit 141) and `set -o pipefail` fails the step before the
+          # device is ever contacted.
+          head -c "$SIZE" /dev/zero | tr '\0' '\377' > /tmp/blank.bin
+          test "$(stat -c%s /tmp/blank.bin)" = "$SIZE"
           echo "Uploading a $SIZE byte blank (0xFF) image..."
 
           CODE=$(curl -sk -o /tmp/blank_resp.txt -w '%{http_code}' --max-time 120 \
@@ -244,6 +249,7 @@ jobs:
           ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
           SIZE=$(stat -c%s recovery/arctic_controller.bin)
           head -c "$SIZE" /dev/urandom > /tmp/garbage.bin
+          test "$(stat -c%s /tmp/garbage.bin)" = "$SIZE"
 
           CODE=$(curl -sk -o /tmp/garbage_resp.txt -w '%{http_code}' --max-time 120 \
             -X POST -H "X-API-Key: $ARCTIC_API_KEY" \


### PR DESCRIPTION
The first hardware dispatch of the resilience workflow ([34555192473](https://github.com/sslivins/arctic-controller/actions/runs/34555192473)) failed **before it ever contacted the device**:

```
tr: write error: Broken pipe
##[error]Process completed with exit code 1
```

## Root cause

```bash
tr '\0' '\377' < /dev/zero | head -c "$SIZE" > /tmp/blank.bin
```

`head` closes the pipe as soon as it has taken its bytes, which kills `tr` with SIGPIPE (exit 141). Under `set -o pipefail` that fails the whole step. `/dev/zero` is infinite, so this was guaranteed to happen every run — it is not a race.

Reversing the pipeline lets `head` read `/dev/zero` directly, so `tr` sees a finite stream and exits 0.

Verified on the runner itself:

```
old form: rc=141
new form: rc=0 size=1000000 firstbytes=ffffffff
```

Note this is exactly the class of bug `bash -n` cannot catch — the syntax was always valid.

## Also

Both payloads now assert their generated size. A future generation bug would otherwise silently upload a zero-byte body, which the device would reject *for the wrong reason* — indistinguishable from the pass this test is trying to demonstrate.

## What the failed run did establish

- The credential sync and preflight both worked **on the first attempt**, recording `sha=02be5929 partition=ota_0`. That pattern transferred correctly from the rollback workflow.
- The controller was healthy throughout and needed no recovery.

The interesting assertions — whether the device actually rejects blank and corrupt images, and whether an interrupted transfer releases the OTA lock — remain unproven. I'll re-dispatch once this lands.

Refs #252.
