### PR TITLE
fix: document network event types and guard the OpenAPI spec against drift

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3820,6 +3820,8 @@ components:
           - brownout_reset
           - application_crash
           - watchdog_reset
+          - network_unreachable
+          - network_recovered
           example: power_on
         category:
           type: string

--- a/tests/api/test_event_type_coverage.py
+++ b/tests/api/test_event_type_coverage.py
@@ -1,0 +1,92 @@
+"""Keep the OpenAPI event enums in step with the firmware's own tables.
+
+The firmware already guards itself: a static_assert in event_log.cpp ensures
+s_event_names matches EVENT_TYPE_COUNT, so adding an enum value without a name
+fails the build. Nothing extended that guarantee to docs/openapi.yaml, so the
+spec was free to drift.
+
+It did. network_unreachable and network_recovered existed in firmware but in
+neither the spec nor the API tests. Because those events are only emitted when
+the device actually loses its gateway, the gap stayed invisible until a
+scheduled run happened to coincide with a real network blip, and then failed
+two suites at once with what looked like a flake.
+
+That is the failure mode worth preventing: the events most likely to be missing
+from the spec are the rare ones, and rare events are exactly what a schema
+consumer is least prepared to handle. Checking at build time is cheap; waiting
+for the device to produce the event is not.
+
+These tests are hostside — they read source, never the device.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+import pytest
+
+pytestmark = pytest.mark.hostside
+
+ROOT = Path(__file__).resolve().parents[2]
+EVENT_LOG = ROOT / "main" / "event_log.cpp"
+OPENAPI_SPEC = ROOT / "docs" / "openapi.yaml"
+
+
+def _firmware_table(name):
+    """Extract the string literals from a `static const char* <name>[]` table."""
+    source = EVENT_LOG.read_text(encoding="utf-8")
+    match = re.search(
+        r"static\s+const\s+char\*\s+" + re.escape(name) + r"\s*\[\s*\]\s*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.DOTALL,
+    )
+    assert match, (
+        f"Could not find {name}[] in {EVENT_LOG.name}. If the table was renamed "
+        "or restructured, update this test — do not delete it."
+    )
+
+    names = re.findall(r'"([^"]+)"', match.group("body"))
+    assert names, f"{name}[] parsed as empty, so this test would vacuously pass"
+    return names
+
+
+def _spec_enum(schema, prop):
+    spec = yaml.safe_load(OPENAPI_SPEC.read_text(encoding="utf-8"))
+    enum = spec["components"]["schemas"][schema]["properties"][prop]["enum"]
+    assert enum, f"{schema}.{prop} enum is empty, so this test would vacuously pass"
+    return enum
+
+
+def test_event_types_match_firmware():
+    firmware = set(_firmware_table("s_event_names"))
+    documented = set(_spec_enum("EventEntry", "type"))
+
+    missing = firmware - documented
+    extra = documented - firmware
+
+    assert not missing, (
+        "Event types the firmware can emit but the OpenAPI spec does not allow:\n"
+        + "\n".join(f"  {t}" for t in sorted(missing))
+        + "\n\nAdd them to EventEntry.type in docs/openapi.yaml. Until you do, any "
+        "schema-validating client (including our own schemathesis suite) will "
+        "reject a perfectly valid response the moment the device emits one."
+    )
+
+    assert not extra, (
+        "Event types documented in the OpenAPI spec that the firmware cannot emit:\n"
+        + "\n".join(f"  {t}" for t in sorted(extra))
+        + "\n\nEither the firmware dropped an event type and the spec was not "
+        "updated, or the name was mistyped. Stale values are not harmless: they "
+        "tell integrators to handle cases that will never arrive."
+    )
+
+
+def test_event_categories_match_firmware():
+    firmware = set(_firmware_table("s_category_names"))
+    documented = set(_spec_enum("EventEntry", "category"))
+
+    assert firmware == documented, (
+        f"Event categories disagree.\n"
+        f"  firmware only: {sorted(firmware - documented)}\n"
+        f"  spec only:     {sorted(documented - firmware)}"
+    )

--- a/tests/api/test_events_and_misc_api.py
+++ b/tests/api/test_events_and_misc_api.py
@@ -72,6 +72,17 @@ def _delete(path):
     return _session.delete(f"{BASE_URL}{path}", headers=_headers(), timeout=10)
 
 
+def _spec_event_types():
+    """The EventEntry.type enum from the OpenAPI spec, as a set."""
+    import yaml
+
+    spec_path = Path(__file__).resolve().parents[2] / "docs" / "openapi.yaml"
+    spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    enum = spec["components"]["schemas"]["EventEntry"]["properties"]["type"]["enum"]
+    assert enum, "EventEntry.type enum is empty — the spec cannot validate anything"
+    return set(enum)
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _check_prerequisites():
     if not API_KEY:
@@ -117,18 +128,22 @@ class TestEventsAPI:
         assert evt["category"] in ("problems", "equipment", "changes", "system")
 
     def test_event_type_is_string(self):
-        """Event type should be a known string."""
-        valid_types = {
-            "system_start", "power_on", "power_off", "mode_changed",
-            "setpoint_changed", "compressor_on", "compressor_off",
-            "fan_on", "fan_off", "pump_on", "pump_off",
-            "aux_heater_on", "aux_heater_off", "defrost_start", "defrost_end",
-            "error_appeared", "error_cleared", "connected", "disconnected",
-            "brownout_reset", "application_crash", "watchdog_reset",
-        }
+        """Event type should be a known string.
+
+        The accepted set is read from the OpenAPI spec rather than duplicated
+        here. A hard-coded copy silently rots: when firmware gained
+        network_unreachable/network_recovered, this list and the spec were both
+        left behind, and the gap only surfaced months later on a scheduled run
+        that happened to catch a real network blip. test_event_type_coverage.py
+        keeps the spec itself honest against the firmware table.
+        """
+        valid_types = _spec_event_types()
         data = _get("/api/events").json()
         for evt in data["events"]:
-            assert evt["type"] in valid_types, f"Unknown event type: {evt['type']}"
+            assert evt["type"] in valid_types, (
+                f"Unknown event type: {evt['type']}. If firmware added this "
+                f"event, add it to the EventEntry.type enum in docs/openapi.yaml."
+            )
 
     def test_events_total_matches_array_length(self):
         """total field should match or exceed the events array length."""


### PR DESCRIPTION
## What broke

The scheduled `Device Tests` run ([`34590136697`](https://github.com/sslivins/arctic-controller/actions/runs/34590136697)) failed two API suites:

```
tests/api/test_api_schema.py::test_production_api_schema[GET /api/events]
tests/api/test_events_and_misc_api.py::TestEventsAPI::test_event_type_is_string
```

Both with the same cause:

```
"network_recovered" is not one of "system_start", "power_on" or 20 other candidates
AssertionError: Unknown event type: network_recovered
```

The device returned a **correct** response. The schema was wrong.

`network_unreachable` and `network_recovered` have existed in `event_log.cpp` since the network-wedge detector landed, but were never added to the `EventEntry.type` enum in `docs/openapi.yaml`, nor to the hand-copied set inside `test_event_type_is_string`. UI and web suites passed; only the two schema-checking tests noticed.

## Why it hid for so long

Those events are only emitted when the gateway actually becomes unreachable while WiFi stays associated. The run happened to coincide with a genuine ~34 s outage:

```
network_unreachable  uptime_ms=451297
network_recovered    uptime_ms=485199  payload=0
```

`payload=0` is self/keepalive recovery, so the wedge detector did its job and the device healed without a WiFi bounce. Nothing was wrong with the firmware — the events it logged were simply undescribed.

This is the part worth fixing properly rather than patching two strings. **The event types most likely to be missing from the spec are the rare ones, and rare events are exactly what a schema-validating client is least prepared to handle.** A fielded integrator hitting `network_recovered` for the first time during a real outage is the worst possible moment to discover the spec disallows it.

## Changes

1. **`docs/openapi.yaml`** — add the two missing types to the `EventEntry.type` enum (now 24, matching firmware).
2. **`tests/api/test_events_and_misc_api.py`** — `test_event_type_is_string` now reads the accepted set from the spec instead of keeping a *third* hand-maintained copy that can rot independently of the other two.
3. **`tests/api/test_event_type_coverage.py`** (new, hostside) — parses the firmware's `s_event_names` and `s_category_names` tables and asserts they match the spec exactly, **in both directions**.

Firmware already guards itself:

```cpp
static_assert(sizeof(s_event_names) / sizeof(s_event_names[0]) == EVENT_TYPE_COUNT,
               "s_event_names must match EVENT_TYPE_COUNT");
```

Adding an enum value without a name fails the build. Nothing extended that guarantee to the spec, so the spec was free to drift. Now it isn't.

The check runs hostside — source only, no device — so drift fails in seconds on every PR rather than waiting for hardware to emit the event.

## Verification

The guard was run against the **drifted** spec to prove it is not vacuous:

```
assert not {'network_recovered', 'network_unreachable'}
Event types the firmware can emit but the OpenAPI spec does not allow:
```

It names exactly the two types that caused the outage. With the fix applied, both tests pass. The parser also asserts it found a non-empty table, so a rename or restructure of `s_event_names` fails loudly instead of silently matching nothing.

Checking the reverse direction matters too: a stale enum value left behind by a removed event would otherwise keep telling integrators to handle a case that can never arrive.

## Note on the 21 local `test_ci_policy` failures

Confirmed pre-existing on a clean `main` checkout (21 fail there too) and Windows-only — they pass on Linux CI. Unrelated to this change.

Refs #252
