### PR TITLE
Make CI report reality: stale rollback skip (#242) + OTA upload race

### DIFF
--- a/.github/scripts/check_test_floor.py
+++ b/.github/scripts/check_test_floor.py
@@ -87,7 +87,6 @@ BENIGN_SKIP_PATTERNS = [
     r"device cannot reach github",
     r"another ota operation in progress",
     r"download failed too quickly",
-    r"poison firmware binary not yet available",
     r"live weather reading",
     # Self-invalidating by design: the call under test destroys the credential
     # the rest of the run depends on, so it can only be exercised in isolation.
@@ -109,11 +108,13 @@ BENIGN_SKIP_PATTERNS = [
 #
 # Evidence for the entries below (device run 34306377818, the first run to
 # publish the skip itemisation): 48 API skips, of which 0 were infra.
+#
+# A `requires serial connection` entry was removed here (#242). It covered a
+# skipped stub for OTA rollback and asserted the harness had not been built --
+# by then untrue. Rollback is exercised nightly on hardware by
+# .github/workflows/ota-rollback.yml, so classifying it as an outstanding debt
+# understated coverage. Do not re-add it without a stub to match.
 DEFERRED_SKIP_PATTERNS = [
-    # OTA rollback Tiers 2/3 -- #217 T05/T06. The runner does in fact have USB
-    # serial access to the controller, so "not available on CI" understates it:
-    # the harness has not been built. Tracked rather than silently tolerated.
-    r"requires serial connection",
     # Aux/backup heater has no Tuya register mapping yet, so the reading is
     # hardcoded false; the test is real and will matter once it is mapped.
     r"not mapped from any tuya register yet",

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -517,21 +517,58 @@ jobs:
           # flash and a failure for an OTA. Only the workflow knows which was
           # intended, so it states it here.
           echo "ARCTIC_FLASH_METHOD=ota" >> "$GITHUB_ENV"
-          sleep 10
-          # 80s window: the async pull path (nightly) only starts flashing +
-          # rebooting AFTER this step begins (it quiesced the network mid-download),
-          # so allow for flash-from-PSRAM + reboot + C6 bringup. Harmless for the
-          # synchronous upload path, which is already rebooting by now.
-          for i in $(seq 1 80); do
-            if curl -skL --connect-timeout 2 "$ARCTIC_URL/api/heatpump/status" > /dev/null 2>&1 || \
-               curl -skL --connect-timeout 2 "$ARCTIC_URL_HTTPS/api/heatpump/status" > /dev/null 2>&1; then
-              echo "Device is back online after $((i + 10))s"
-              exit 0
+
+          # Waiting for "something answers" is not enough. The device keeps
+          # serving the OLD image for several seconds after it acknowledges the
+          # upload — it only reboots once it has finished writing the slot. A
+          # reachability poll therefore returns as soon as the pre-OTA firmware
+          # replies, and the identity gate downstream then reads the old
+          # build_sha and fails. Run 34627065548 did exactly that: "Device is
+          # back online after 11s", immediately followed by a mismatch naming
+          # the previous run's build. It was masked until now because the OTA
+          # step used to be misreported as failing (see the note in "Flash
+          # device via OTA"), which sent every run down the USB fallback and
+          # skipped this step entirely.
+          #
+          # So wait for the condition we actually care about: the device
+          # reporting the build_sha we just installed. Where build_sha.txt is
+          # absent (local or dispatch builds with no baked identity) fall back
+          # to plain reachability, which is all that is knowable there.
+          #
+          # HTTPS-only: this request carries the API key, and the security
+          # contract (tests/api/test_ha_security_contract.py) forbids
+          # secret-bearing automation from falling back to plain HTTP.
+          EXPECTED=$(cat build/build_sha.txt 2>/dev/null || true)
+          echo "Waiting for device to report build_sha '${EXPECTED:-<unknown>}'"
+
+          # 150s: covers reboot, WiFi association and C6 bringup, and the
+          # nightly pull path which only begins flashing from PSRAM once this
+          # step is already running.
+          sleep 5
+          deadline=$((SECONDS + 150))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            RESP=$(curl -sk --connect-timeout 2 --max-time 5 \
+              -H "X-API-Key: ${ARCTIC_API_KEY}" \
+              "$ARCTIC_URL_HTTPS/api/ota/status" 2>/dev/null) || true
+            if [ -n "$RESP" ]; then
+              if [ -z "$EXPECTED" ]; then
+                echo "No expected build_sha to match; device is reachable after ${SECONDS}s"
+                exit 0
+              fi
+              ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || true
+              if [ "$ACTUAL" = "$EXPECTED" ]; then
+                echo "Device is running the new build ($EXPECTED) after ${SECONDS}s"
+                exit 0
+              fi
             fi
-            sleep 1
+            sleep 2
           done
-          echo "Device did not come back online within 90s"
-          exit 1
+
+          echo "Device did not report build_sha '$EXPECTED' within 150s"
+          # Deliberately not a failure. The dedicated identity gate below
+          # distinguishes a rollback from an OTA that never took and says so
+          # precisely; failing here would pre-empt it with a vaguer message.
+          exit 0
 
       - name: Fallback — flash via USB serial
         if: steps.partition_layout.outputs.changed == 'true' || steps.ota_flash.outcome == 'failure'

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -374,6 +374,29 @@ jobs:
             echo "does NOT exercise the OTA rollback path."
           fi
 
+      - name: Start serial capture for the OTA window
+        # The OTA window was the one part of the run with no console coverage:
+        # the main capture below cannot start until the USB port is free of
+        # flashing and hard-resets, which is long after the OTA has happened.
+        # That blind spot cost a full diagnostic cycle in run 34628089378, where
+        # the device accepted the whole image, answered "Rebooting..." and then
+        # did not reboot — and the only serial we had began 3 minutes later, so
+        # the uptime counter was the sole evidence of what occurred.
+        #
+        # This capture is deliberately scoped to the OTA step and stopped again
+        # before anything needs the port, so it cannot interfere with the USB
+        # fallback or the readiness hard-reset.
+        id: ota_serial
+        if: steps.partition_layout.outputs.changed != 'true'
+        run: |
+          python .github/scripts/capture_serial.py \
+            --usb-serial "$CONTROLLER_USB_SERIAL" \
+            --output controller-serial-ota.log &
+          echo "OTA_SERIAL_PID=$!" >> "$GITHUB_ENV"
+          sleep 2
+        env:
+          CONTROLLER_USB_SERIAL: ${{ secrets.CONTROLLER_USB_SERIAL }}
+
       - name: Flash device via OTA
         id: ota_flash
         if: steps.partition_layout.outputs.changed != 'true'
@@ -410,6 +433,63 @@ jobs:
           fi
           echo "Device responding at $ARCTIC_URL_HTTPS"
 
+          # An OTA "succeeded" only if the device is actually running the image
+          # we just sent. Everything before this point — an HTTP 200, a success
+          # body, a ready_to_reboot status — is the device telling us what it
+          # intends to do, not evidence that it did it. Run 34628089378 is the
+          # cautionary case: /api/ota/upload accepted all 2,407,824 bytes and
+          # answered "Firmware uploaded. Rebooting...", and the device then
+          # simply never rebooted (serial showed an unbroken 25-minute uptime
+          # straight through the OTA window).
+          #
+          # So verify, inside this step, that the reported build_sha is the one
+          # we installed. Doing it here rather than in a step of its own is what
+          # makes the outcome mean something: this step is continue-on-error, so
+          # a failure here lets "Fallback — flash via USB serial" rescue the rig,
+          # the suite still runs against the right build, and "Enforce OTA
+          # installation success (strict)" fails the job with the precise reason.
+          # Verifying in a separate step could do none of that — it could only
+          # dead-end the run with the device left on the old firmware.
+          wait_for_new_build_sha() {
+            local EXPECTED
+            EXPECTED=$(cat build/build_sha.txt 2>/dev/null || true)
+            if [ -z "$EXPECTED" ]; then
+              echo "::error::build/build_sha.txt is empty/missing — cannot confirm the OTA took."
+              return 1
+            fi
+            echo "Waiting for the device to report build_sha '$EXPECTED'..."
+
+            # 150s covers reboot, WiFi association and C6 bringup, plus the
+            # nightly pull path's flash-from-PSRAM, which only begins once the
+            # device has gone offline above.
+            local deadline=$((SECONDS + 150))
+            local RESP ACTUAL LAST=""
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              RESP=$(curl -sk --connect-timeout 2 --max-time 5 \
+                -H "X-API-Key: ${ARCTIC_API_KEY}" \
+                "$ARCTIC_URL_HTTPS/api/ota/status" 2>/dev/null) || RESP=""
+              if [ -n "$RESP" ]; then
+                ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || ACTUAL=""
+                if [ "$ACTUAL" = "$EXPECTED" ]; then
+                  echo "Device is running the new build ($EXPECTED) after ${SECONDS}s"
+                  # Record how this firmware was installed so the OTA tests can
+                  # assert on it. The device cannot report this itself: a
+                  # USB-recovered device and a successfully OTA'd one present an
+                  # identical build_sha and differ only in which app slot they
+                  # booted from — legitimate for a USB flash, a failure for an
+                  # OTA. Only the workflow knows which was intended.
+                  echo "ARCTIC_FLASH_METHOD=ota" >> "$GITHUB_ENV"
+                  return 0
+                fi
+                LAST="$ACTUAL"
+              fi
+              sleep 2
+            done
+
+            echo "::error::The device never came up running the OTA'd image. Expected build_sha '$EXPECTED'; the device is still reporting '${LAST:-<unreachable>}' 150s after it accepted the upload. The bytes were delivered and acknowledged, so this is not a transfer failure — either the device did not reboot, or it rebooted and the bootloader reverted to the previous image. Check controller-serial.log for the OTA window."
+            return 1
+          }
+
           if [ "${{ github.event_name }}" = "schedule" ]; then
             # ---- Nightly: asynchronous PULL path (/api/ota/update) ----
             ASSET_URL="https://github.com/sslivins/arctic-controller/releases/download/ci-nightly/arctic_controller.bin"
@@ -431,7 +511,8 @@ jobs:
             # The status server goes offline *before* it reports ready_to_reboot, so
             # poll /api/ota/status until either it reports 'failed', or the device
             # goes offline AFTER we have observed download progress (= quiesce/flash/
-            # reboot underway). The subsequent "Wait for device reboot" step reconnects.
+            # reboot underway). wait_for_new_build_sha then reconnects and confirms
+          # the device came up on the new image.
             SAW_PROGRESS=false
             for i in $(seq 1 90); do
               ST=$(curl -sk --connect-timeout 2 --max-time 5 \
@@ -440,7 +521,8 @@ jobs:
               if [ -z "$ST" ]; then
                 if [ "$SAW_PROGRESS" = "true" ]; then
                   echo "Device went offline after download progress — quiesce/flash/reboot underway"
-                  exit 0
+                  wait_for_new_build_sha
+                  exit $?
                 fi
                 echo "  device not yet reachable for status (no progress seen yet)..."
               else
@@ -456,7 +538,8 @@ jobs:
                 fi
                 if [ "$STATE" = "ready_to_reboot" ]; then
                   echo "Device reported ready_to_reboot — rebooting into new firmware"
-                  exit 0
+                  wait_for_new_build_sha
+                  exit $?
                 fi
               fi
               sleep 2
@@ -477,7 +560,8 @@ jobs:
             echo "Response: HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt)"
             if [ "$HTTP_CODE" = "200" ]; then
               echo "OTA upload successful, waiting for reboot..."
-              exit 0
+              wait_for_new_build_sha
+              exit $?
             fi
             # The device reboots the instant it has written the image, so it
             # never sends a clean TLS close_notify. curl can therefore receive
@@ -499,82 +583,49 @@ jobs:
             # when the code is 000; a real HTTP error code still fails.
             if [ "$HTTP_CODE" = "000" ] && grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ota_response.txt; then
               echo "OTA upload reported success in-body but the connection closed uncleanly (HTTP $HTTP_CODE)."
-              echo "Accepting the upload; the running image is verified by build_sha downstream."
-              exit 0
+              echo "Accepting the upload; the running image is verified by build_sha below."
+              wait_for_new_build_sha
+              exit $?
             fi
             echo "OTA upload failed"
             exit 1
           fi
 
-      - name: Wait for device reboot (OTA)
-        if: steps.partition_layout.outputs.changed != 'true' && steps.ota_flash.outcome == 'success'
+
+      - name: Stop OTA-window serial capture
+        # Must run even when the OTA failed — that is precisely when the log is
+        # worth having — and must complete before anything touches the USB port.
+        if: always() && steps.ota_serial.outcome == 'success'
         run: |
-          ARCTIC_URL_HTTPS="${ARCTIC_URL/http:/https:}"
-          # Record how this firmware was installed so the OTA tests can assert on
-          # it. The device cannot report this itself: a USB-recovered device and a
-          # successfully OTA'd one present an identical build_sha, and differ only
-          # in which app slot they booted from — which is legitimate for a USB
-          # flash and a failure for an OTA. Only the workflow knows which was
-          # intended, so it states it here.
-          echo "ARCTIC_FLASH_METHOD=ota" >> "$GITHUB_ENV"
+          if [ -n "${OTA_SERIAL_PID:-}" ]; then
+            kill "$OTA_SERIAL_PID" 2>/dev/null || true
+            # Give the child a moment to flush and close the port, or the USB
+            # fallback's esptool will find it still held.
+            for i in $(seq 1 10); do
+              kill -0 "$OTA_SERIAL_PID" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "$OTA_SERIAL_PID" 2>/dev/null || true
+          fi
 
-          # Waiting for "something answers" is not enough. The device keeps
-          # serving the OLD image for several seconds after it acknowledges the
-          # upload — it only reboots once it has finished writing the slot. A
-          # reachability poll therefore returns as soon as the pre-OTA firmware
-          # replies, and the identity gate downstream then reads the old
-          # build_sha and fails. Run 34627065548 did exactly that: "Device is
-          # back online after 11s", immediately followed by a mismatch naming
-          # the previous run's build. It was masked until now because the OTA
-          # step used to be misreported as failing (see the note in "Flash
-          # device via OTA"), which sent every run down the USB fallback and
-          # skipped this step entirely.
-          #
-          # So wait for the condition we actually care about: the device
-          # reporting the build_sha we just installed. Where build_sha.txt is
-          # absent (local or dispatch builds with no baked identity) fall back
-          # to plain reachability, which is all that is knowable there.
-          #
-          # HTTPS-only: this request carries the API key, and the security
-          # contract (tests/api/test_ha_security_contract.py) forbids
-          # secret-bearing automation from falling back to plain HTTP.
-          EXPECTED=$(cat build/build_sha.txt 2>/dev/null || true)
-          echo "Waiting for device to report build_sha '${EXPECTED:-<unknown>}'"
-
-          # 150s: covers reboot, WiFi association and C6 bringup, and the
-          # nightly pull path which only begins flashing from PSRAM once this
-          # step is already running.
-          sleep 5
-          deadline=$((SECONDS + 150))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            RESP=$(curl -sk --connect-timeout 2 --max-time 5 \
-              -H "X-API-Key: ${ARCTIC_API_KEY}" \
-              "$ARCTIC_URL_HTTPS/api/ota/status" 2>/dev/null) || true
-            if [ -n "$RESP" ]; then
-              if [ -z "$EXPECTED" ]; then
-                echo "No expected build_sha to match; device is reachable after ${SECONDS}s"
-                exit 0
-              fi
-              ACTUAL=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('build_sha',''))" 2>/dev/null) || true
-              if [ "$ACTUAL" = "$EXPECTED" ]; then
-                echo "Device is running the new build ($EXPECTED) after ${SECONDS}s"
-                exit 0
-              fi
-            fi
-            sleep 2
-          done
-
-          echo "Device did not report build_sha '$EXPECTED' within 150s"
-          # Deliberately not a failure. The dedicated identity gate below
-          # distinguishes a rollback from an OTA that never took and says so
-          # precisely; failing here would pre-empt it with a vaguer message.
-          exit 0
+          if [ -s controller-serial-ota.log ]; then
+            echo "Device console during the OTA window:"
+            echo "----------------------------------------"
+            tail -80 controller-serial-ota.log
+            echo "----------------------------------------"
+            # The device's own account of the install, surfaced in the job log
+            # so a failed OTA is diagnosable without downloading artifacts.
+            grep -nE 'ota|OTA|Rebooting|Safe restart|restart|boot|Guru Meditation|abort\(\)|assert failed' \
+              controller-serial-ota.log | tail -40 || true
+          else
+            echo "::warning::No serial captured for the OTA window."
+          fi
 
       - name: Fallback — flash via USB serial
         if: steps.partition_layout.outputs.changed == 'true' || steps.ota_flash.outcome == 'failure'
         run: |
           echo "OTA failed, falling back to USB serial flash..."
-          # See the note in "Wait for device reboot (OTA)". A USB flash boots the
+          # See the note in "Flash device via OTA". A USB flash boots the
           # factory slot, so the OTA tests must not demand an ota_* slot here.
           echo "ARCTIC_FLASH_METHOD=usb" >> "$GITHUB_ENV"
 
@@ -1022,7 +1073,9 @@ jobs:
         if: always()
         with:
           name: controller-serial-log
-          path: controller-serial.log
+          path: |
+            controller-serial.log
+            controller-serial-ota.log
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -479,6 +479,29 @@ jobs:
               echo "OTA upload successful, waiting for reboot..."
               exit 0
             fi
+            # The device reboots the instant it has written the image, so it
+            # never sends a clean TLS close_notify. curl can therefore receive
+            # the complete success body and still report 000, either because
+            # the connection was torn down mid-transfer or because --max-time
+            # expired waiting for a close that was never coming. Run
+            # 34625998136 failed exactly this way: the body read
+            # {"success":true,"bytes_received":2407824,"message":"Firmware
+            # uploaded. Rebooting..."} and the status code was 000, so a
+            # successful over-the-air install was recorded as a failure. The
+            # job then fell back to USB, which boots the factory slot, and
+            # the identity, OTA-strict, heap and floor gates all failed in
+            # cascade behind it.
+            #
+            # The body is the device's own statement that it accepted and
+            # wrote the image, and "Enforce OTA installation success (strict)"
+            # later proves the running image by build_sha — strictly stronger
+            # evidence than any status code. So accept the body, and only
+            # when the code is 000; a real HTTP error code still fails.
+            if [ "$HTTP_CODE" = "000" ] && grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ota_response.txt; then
+              echo "OTA upload reported success in-body but the connection closed uncleanly (HTTP $HTTP_CODE)."
+              echo "Accepting the upload; the running image is verified by build_sha downstream."
+              exit 0
+            fi
             echo "OTA upload failed"
             exit 1
           fi

--- a/tests/api/test_executed_floor.py
+++ b/tests/api/test_executed_floor.py
@@ -142,7 +142,7 @@ def test_deferred_skip_never_fails_even_when_enforcing(tmp_path):
         xml,
         tests=454,
         skipped=1,
-        skip_messages=["Requires serial connection and device reboot"],
+        skip_messages=["Backup/aux heater is not mapped from any Tuya register yet"],
     )
     floors = tmp_path / "floors.json"
     floors.write_text(json.dumps({"api": 380}), encoding="utf-8")
@@ -158,7 +158,7 @@ def test_report_separates_deferred_from_benign(tmp_path):
         tests=454,
         skipped=2,
         skip_messages=[
-            "Requires serial connection and device reboot",
+            "Backup/aux heater is not mapped from any Tuya register yet",
             "dangerous endpoint: /login",
         ],
     )
@@ -176,7 +176,12 @@ def test_report_separates_deferred_from_benign(tmp_path):
 def test_deferred_takes_precedence_over_a_broader_benign_pattern():
     # Ordering inside classify_skip is load-bearing: if benign were checked
     # first, a debt could be absorbed by a more general pattern and disappear.
-    assert mod.classify_skip("Requires serial connection and device reboot") == "deferred"
+    # Construct a message that genuinely matches BOTH classes, otherwise this
+    # test passes without ever exercising the ordering it claims to guard.
+    both = "No events on device: backup/aux heater is not mapped from any Tuya register yet"
+    assert any(rx.search(both) for rx in mod._BENIGN_RE), "fixture no longer matches a benign pattern"
+    assert any(rx.search(both) for rx in mod._DEFERRED_RE), "fixture no longer matches a deferred pattern"
+    assert mod.classify_skip(both) == "deferred"
     assert mod.DEFERRED_SKIP_PATTERNS, "the deferred class has been emptied"
 
 
@@ -195,8 +200,12 @@ def test_deferred_takes_precedence_over_a_broader_benign_pattern():
         ("Another OTA operation in progress - cannot test error state", "benign"),
         ("Need at least 2 entries to test ordering", "benign"),
         ("Regenerating the API key invalidates ARCTIC_API_KEY for the rest of the run", "benign"),
-        ("Requires serial connection and device reboot", "deferred"),
-        ("Requires serial connection, poison firmware, and manual recovery", "deferred"),
+        # Deliberately unknown since #242: the OTA rollback stub these described
+        # was removed once .github/workflows/ota-rollback.yml began exercising
+        # rollback nightly on hardware. Pinned here so re-adding the patterns
+        # without a matching stub is caught. Unknown only warns, never fails.
+        ("Requires serial connection and device reboot", "unknown"),
+        ("Poison firmware binary not yet available", "unknown"),
         ("Backup/aux heater is not mapped from any Tuya register yet", "deferred"),
         ("some brand new reason nobody classified", "unknown"),
         ("", "unknown"),

--- a/tests/api/test_ota_api.py
+++ b/tests/api/test_ota_api.py
@@ -882,60 +882,37 @@ class TestOtaRoundTrip:
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# Tier 3 — Rollback validation
+# Tier 3 — Rollback validation: covered by .github/workflows/ota-rollback.yml
 # ══════════════════════════════════════════════════════════════════════════
-
-# These tests verify that the bootloader reverts to the previous firmware
-# if the new one fails to call mark_valid(). They require:
-#   - Serial connection (to flash recovery firmware after rollback)
-#   - CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
-#   - A "poison" firmware binary that crashes before mark_valid()
 #
-# Building the poison firmware:
-#   1. Add an assert(false) or abort() call in create_ui() (before mark_valid)
-#   2. Build with: idf.py build
-#   3. Save build/arctic_controller.bin as the poison binary
-#   4. Rebuild normal firmware for recovery
+# The most dangerous OTA property — an image that boots but dies BEFORE
+# committing itself is rolled back by the bootloader, leaving the device
+# reachable on its previous firmware — is validated on real hardware by the
+# "OTA Rollback Validation" workflow, nightly at 03:00 UTC and on demand:
 #
-# This is complex enough that it should probably be a manual test script
-# rather than part of the automated suite, at least initially.
-
-@pytest.mark.skip(reason="Requires serial connection, poison firmware, and manual recovery — future work")
-class TestOtaRollback:
-    """Tier 3: Verify bootloader rolls back bad firmware.
-
-    Upload a firmware that crashes before mark_valid(). After the device
-    reboots, the bootloader should revert to the previous working partition.
-    """
-
-    def test_rollback_on_crash_before_mark_valid(self):
-        """Upload poison firmware → device crashes → bootloader reverts.
-
-        Test plan:
-        1. Record current version and partition
-        2. Upload poison firmware (crashes in create_ui before mark_valid)
-        3. Device reboots into poison → crashes → bootloader reverts
-        4. Device boots back into original firmware
-        5. Verify version matches, state is idle, pending_verify is false
-        """
-        import time
-
-        # Record pre-OTA state
-        pre = _get("/api/ota/status").json()
-        pre_version = pre["current_version"]
-
-        # TODO: Load poison firmware binary
-        # poison_path = Path(__file__).resolve().parent / "fixtures" / "poison_firmware.bin"
-        # poison = poison_path.read_bytes()
-
-        # TODO: Upload poison firmware
-        # r = _post_raw("/api/ota/upload", data=poison)
-        # assert r.status_code == 200
-
-        # Wait for crash + rollback + reboot (may take 2 cycles)
-        # post = _wait_for_device(timeout=120)
-        # assert post["current_version"] == pre_version
-        # assert post["state"] == "idle"
-        # assert post["pending_verify"] is False
-
-        pytest.skip("Poison firmware binary not yet available")
+#     gh workflow run ota-rollback.yml --repo sslivins/arctic-controller
+#
+# It builds a known-good recovery image, builds a poison image that aborts
+# before esp_ota_mark_app_valid_cancel_rollback(), OTAs the poison image to
+# the controller, waits for the bootloader to revert, and recovers the device
+# over USB serial with esptool.
+#
+# It deliberately does NOT live in this suite (see the header of
+# ota-rollback.yml for the full rationale):
+#
+#   1. device-tests.yml fails the job on "abort() was called". This test's
+#      whole purpose is to produce exactly that signature, and teaching the
+#      shared crash gate to tolerate an abort would weaken the guard that
+#      caught the #234 regression.
+#   2. Recovery needs esptool, but device-tests.yml holds the controller's
+#      serial port open for the duration of the run and the port has a single
+#      owner.
+#   3. It is destructive and slow; running it per-PR would double physical
+#      device time on the repository's only controller for a property that
+#      changes rarely.
+#
+# A skipped stub class used to sit here claiming this was "future work"
+# requiring "serial connection, poison firmware, and manual recovery". All of
+# that has since been built, so the stub made the executed-floor report
+# advertise rollback as an uncovered gap when it is in fact exercised nightly.
+# Removed rather than left lying - see #242.


### PR DESCRIPTION
Closes #242.

## The claim that was false

`tests/api/test_ota_api.py` carried a skipped `TestOtaRollback` stub reading:

> Requires serial connection, poison firmware, and manual recovery — future work

- **Serial:** `ghr-mi` has USB serial to the controller. It is how `controller-serial.log` is captured on every device run, and how the crash and heap gates get their input.
- **Poison firmware and recovery:** `.github/workflows/ota-rollback.yml` builds a known-good recovery image, builds a poison image that aborts before `esp_ota_mark_app_valid_cancel_rollback()`, OTAs it to the physical controller, waits for the bootloader to revert, and recovers the device with esptool. It has run nightly at 03:00 UTC since #252 and was proven on hardware in run `34536019154`.

The stub's three test bodies were TODO comments, so there was nothing to un-skip.

## Why it mattered

`check_test_floor.py` classified the reason as `deferred` — the class reserved for real, owned debts so they stay countable rather than blending into permanent-by-design skips. So the executed-floor report advertised OTA rollback as an outstanding gap while it was being validated nightly on real hardware.

That is the inverse of #270. There the spec was wrong and the device right; here the test metadata is wrong and the workflow right. Both are hand-maintained claims drifting from reality, and both mislead in the direction that matters: one hid a real gap, this one invented a fake one.

## Changes

- Removed the stub; left a comment pointing at `ota-rollback.yml` and recording **why** the test deliberately lives outside this suite — `device-tests.yml` fails the job on `abort() was called`, which is exactly the signature this test exists to produce, and teaching the shared crash gate to tolerate an abort would weaken the guard that caught #234.
- Dropped the two now-dead classification patterns: `requires serial connection` from `DEFERRED_SKIP_PATTERNS`, `poison firmware binary not yet available` from `BENIGN_SKIP_PATTERNS`. Left a comment at the removal site explaining why, so nobody re-adds them reflexively.
- Pinned both strings as `unknown` in the classification table, so re-adding a pattern without a matching stub is caught. `unknown` only warns and can never fail a run.

## Drive-by: a guard that never guarded

`test_deferred_takes_precedence_over_a_broader_benign_pattern` asserts that `classify_skip` checks deferred before benign, so a debt can't be absorbed by a broader benign pattern and disappear. But its fixture matched **no benign pattern at all**, so it passed without ever exercising the ordering. It now uses a message matching both classes and asserts that precondition explicitly:

```python
both = "No events on device: backup/aux heater is not mapped from any Tuya register yet"
assert any(rx.search(both) for rx in mod._BENIGN_RE), "fixture no longer matches a benign pattern"
assert any(rx.search(both) for rx in mod._DEFERRED_RE), "fixture no longer matches a deferred pattern"
assert mod.classify_skip(both) == "deferred"
```

## Verification

- `tests/api/test_executed_floor.py` — **31 passed** locally.
- `tests/api/test_ota_api.py` collects cleanly: 44 tests, down from 47, the 3 being the removed stubs.
- **Executed-test floors are unaffected**: the removed tests were skipped, never executed, so both `tests` and `skipped` drop by 3 and `executed` is unchanged.

Zero device time — entirely hostside.

Refs #217, #252.

---

## Second commit: stop recording a successful OTA upload as a failure

The first CI run on this PR (`34625998136`) failed with four red gates. None of them were caused by the change above — the diff is three hostside Python files that do not run until long after the failure point. The cause was a **pre-existing race in `device-tests.yml`**, and it is worth reading the evidence because the log is initially misleading:

```
Uploading firmware to device via /api/ota/upload ...
Response: HTTP 000 — {"success":true,"bytes_received":2407824,"message":"Firmware uploaded. Rebooting..."}
OTA upload failed
```

**The upload worked.** The device received all 2,407,824 bytes and said so. But it reboots the instant it has written the image, so it never sends a clean TLS `close_notify`. curl therefore sat until `--max-time 30` expired waiting for a close that was never coming, and reported `%{http_code}` as `000`. The check was `[ "$HTTP_CODE" = "200" ]`, so a successful over-the-air install was recorded as a failure.

Everything after that was cascade: the job fell back to USB flash, which boots the factory slot, so the identity gate found a `build_sha` mismatch, the OTA-strict gate failed, the serial log had no netdiag lines and the heap gate refused to pass on absent data, and the executed floor fell short.

**All four gates behaved correctly.** Each refused to pass on missing or contradictory evidence — including the heap gate, which failed closed rather than reporting a pass it could not substantiate. The single wrong judgement was upstream of all of them.

### Fix

Accept the upload when the code is `000` **and** the body reports `"success": true`. Both conditions, so a real HTTP error code still fails and a genuinely rejected upload is unaffected. The body is the device's own statement that it accepted and wrote the image, and `Enforce OTA installation success (strict)` independently proves the running image by `build_sha` afterwards — strictly stronger evidence than any status code.

This is a race, not a permanent break, which is why it has passed on other runs. It will keep resurfacing until the check stops depending on a clean connection teardown the device is never going to perform.

### Why both changes are in one PR

The repository has exactly one physical controller and a device run costs 20–40 minutes, so each PR spends the scarcest resource the project has. These two changes also share a theme: both are cases of **CI reporting something other than reality** — one advertised a covered property as an outstanding gap, the other recorded a successful install as a failure.
