### PR TITLE
Add hardware JPEG screenshots (?format=jpeg) + fix OTA upload truncation

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -494,6 +494,9 @@ jobs:
             # ---- Nightly: asynchronous PULL path (/api/ota/update) ----
             ASSET_URL="https://github.com/sslivins/arctic-controller/releases/download/ci-nightly/arctic_controller.bin"
             echo "Nightly OTA pull path: instructing device to download $ASSET_URL"
+            # See the note on the push path: curl leaves a previous run's body
+            # in place when a transfer dies before the response.
+            rm -f /tmp/ota_response.txt
             HTTP_CODE=$(curl -sk -o /tmp/ota_response.txt -w "%{http_code}" \
               -X POST \
               -H "Content-Type: application/json" \
@@ -501,7 +504,7 @@ jobs:
               --connect-timeout 5 --max-time 20 \
               -d "{\"url\": \"$ASSET_URL\"}" \
               "$ARCTIC_URL_HTTPS/api/ota/update") || true
-            echo "Update trigger: HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt)"
+            echo "Update trigger: HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt 2>/dev/null || echo '<no response body>')"
             if [ "$HTTP_CODE" != "200" ]; then
               echo "::error::/api/ota/update was rejected (HTTP $HTTP_CODE). Nightly pull-path OTA failed to start."
               exit 1
@@ -549,15 +552,41 @@ jobs:
           else
             # ---- PR/push: synchronous PUSH path (/api/ota/upload) ----
             echo "Uploading firmware to device via /api/ota/upload ..."
+            FW_BYTES=$(stat -c %s build/arctic_controller.bin)
+            echo "Firmware is $FW_BYTES bytes"
+
+            # curl only creates/truncates the output file once it has body data
+            # to write, so a transfer that dies before the response leaves
+            # whatever a PREVIOUS run wrote still sitting there. The 000 branch
+            # below reads this file, so a stale success body would be accepted
+            # as though it described this upload. Run 34633291016 did exactly
+            # that: the device logged
+            #   E esp_ota_ops: New image failed verification
+            #   E api_server: esp_ota_end failed: ESP_ERR_OTA_VALIDATE_FAILED
+            # and answered 500, while the workflow read a leftover
+            # {"success":true,"bytes_received":2407824,...} — the byte count of
+            # the PREVIOUS build, not this one — and called the OTA good.
+            rm -f /tmp/ota_response.txt
+
+            # 300s, not 30s. --max-time is a hard stop on the whole transfer,
+            # so a limit sized for a response was silently cutting a ~2.4 MB
+            # TLS upload off mid-body. The device then received a truncated
+            # image, correctly failed esp_ota_end verification and returned
+            # 500. In run 34633291016 the device's receive window is visible
+            # ending at exactly 30,158 ms. This is also the whole of the
+            # "intermittent" behaviour in #273: the upload sat right at the
+            # limit, so it completed or was truncated depending on how the
+            # link happened to be performing, and a slightly larger firmware
+            # pushed it consistently over.
             HTTP_CODE=$(curl -skL -o /tmp/ota_response.txt -w "%{http_code}" \
               -X POST \
               -H "Content-Type: application/octet-stream" \
               -H "X-API-Key: ${ARCTIC_API_KEY}" \
               --connect-timeout 5 \
-              --max-time 30 \
+              --max-time 300 \
               --data-binary @build/arctic_controller.bin \
               "$ARCTIC_URL_HTTPS/api/ota/upload") || true
-            echo "Response: HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt)"
+            echo "Response: HTTP $HTTP_CODE — $(cat /tmp/ota_response.txt 2>/dev/null || echo '<no response body>')"
             if [ "$HTTP_CODE" = "200" ]; then
               echo "OTA upload successful, waiting for reboot..."
               wait_for_new_build_sha
@@ -565,27 +594,31 @@ jobs:
             fi
             # The device reboots the instant it has written the image, so it
             # never sends a clean TLS close_notify. curl can therefore receive
-            # the complete success body and still report 000, either because
-            # the connection was torn down mid-transfer or because --max-time
-            # expired waiting for a close that was never coming. Run
-            # 34625998136 failed exactly this way: the body read
-            # {"success":true,"bytes_received":2407824,"message":"Firmware
-            # uploaded. Rebooting..."} and the status code was 000, so a
-            # successful over-the-air install was recorded as a failure. The
-            # job then fell back to USB, which boots the factory slot, and
-            # the identity, OTA-strict, heap and floor gates all failed in
-            # cascade behind it.
+            # the complete success body and still report 000 because the
+            # connection was torn down before a clean close. Run 34625998136
+            # failed exactly this way: the body read {"success":true,
+            # "bytes_received":2407824,"message":"Firmware uploaded.
+            # Rebooting..."} and the status code was 000, so a successful
+            # over-the-air install was recorded as a failure. The job then fell
+            # back to USB, which boots the factory slot, and the identity,
+            # OTA-strict, heap and floor gates all failed in cascade behind it.
             #
-            # The body is the device's own statement that it accepted and
-            # wrote the image, and "Enforce OTA installation success (strict)"
-            # later proves the running image by build_sha — strictly stronger
-            # evidence than any status code. So accept the body, and only
-            # when the code is 000; a real HTTP error code still fails.
-            if [ "$HTTP_CODE" = "000" ] && grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ota_response.txt; then
-              echo "OTA upload reported success in-body but the connection closed uncleanly (HTTP $HTTP_CODE)."
-              echo "Accepting the upload; the running image is verified by build_sha below."
-              wait_for_new_build_sha
-              exit $?
+            # So accept the body when the code is 000 — but only if it is
+            # actually this upload's body. Requiring bytes_received to equal
+            # the firmware size is what makes that check honest: it rejects
+            # both a stale file from an earlier run and a genuine short write,
+            # either of which would otherwise pass on "success":true alone.
+            if [ "$HTTP_CODE" = "000" ] && [ -f /tmp/ota_response.txt ] \
+               && grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ota_response.txt; then
+              GOT=$(python3 -c "import sys,json; print(int(json.load(sys.stdin).get('bytes_received',-1)))" \
+                    < /tmp/ota_response.txt 2>/dev/null) || GOT=-1
+              if [ "$GOT" = "$FW_BYTES" ]; then
+                echo "OTA upload reported success in-body for all $FW_BYTES bytes, but the connection closed uncleanly (HTTP $HTTP_CODE)."
+                echo "Accepting the upload; the running image is verified by build_sha below."
+                wait_for_new_build_sha
+                exit $?
+              fi
+              echo "::error::Ignoring a success body that does not describe this upload: it reports bytes_received=${GOT} but the firmware is ${FW_BYTES} bytes. Either the upload was truncated or this is a stale response from an earlier run."
             fi
             echo "OTA upload failed"
             exit 1

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3209,25 +3209,58 @@ paths:
     get:
       tags:
       - Display
-      summary: Capture live screen as PNG
+      summary: Capture live screen as PNG or JPEG
       description: |
-        Returns a PNG screenshot of the current LVGL display.
-        The image is encoded as an **uncompressed PNG** (DEFLATE stored blocks)
-        for minimal CPU overhead on the ESP32. The response is streamed via
-        HTTP chunked transfer — no extra memory allocation beyond the
-        framebuffer capture (~2.7 MB in PSRAM).
+        Returns a screenshot of the current LVGL display.
 
         Image dimensions: 720×1280 (portrait), RGB888 color.
-        Typical response size: ~2.77 MB.
+
+        **`format=png`** (default, unchanged): an **uncompressed PNG**
+        (DEFLATE stored blocks) for minimal CPU overhead. Streamed via HTTP
+        chunked transfer — no allocation beyond the framebuffer capture
+        (~2.7 MB in PSRAM). Typical response size ~2.77 MB.
+
+        **`format=jpeg`**: encoded by the ESP32-P4's **hardware JPEG
+        encoder**, so compression costs a few milliseconds rather than CPU
+        time. Chroma subsampling is 4:4:4, chosen because a UI screenshot is
+        thin text and single-pixel borders — exactly the content 4:2:0
+        smears. Typically a few hundred KB, roughly an order of magnitude
+        smaller than the PNG, which also cuts TLS work on the device by the
+        same factor. Sent as a single response rather than chunked.
+
+        Prefer JPEG unless you need pixel-exact output.
       operationId: getScreenshot
       security:
       - apiKey: []
       - sessionCookie: []
+      parameters:
+      - name: format
+        in: query
+        required: false
+        description: Output image format. Defaults to `png` for backward compatibility.
+        schema:
+          type: string
+          enum: [png, jpeg, jpg]
+          default: png
+      - name: quality
+        in: query
+        required: false
+        description: |
+          JPEG quality factor. Ignored when `format=png`.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 80
       responses:
         '200':
-          description: PNG screenshot of the current display
+          description: Screenshot of the current display
           content:
             image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
               schema:
                 type: string
                 format: binary

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -103,6 +103,7 @@ idf_component_register(
         "tls_manager.cpp"
         "png_encoder.c"
         "png_uncompressed.c"
+        "jpeg_screenshot.c"
     INCLUDE_DIRS
         "."
         "settings"
@@ -125,6 +126,7 @@ idf_component_register(
         mdns
         esp_http_server
         esp_https_server
+        esp_driver_jpeg
         cjson
         esp_https_ota
         app_update

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -52,6 +52,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>   // strcasecmp — case-insensitive ?format= matching
 #include <esp_ota_ops.h>
 #include <esp_app_format.h>
 #include <lvgl.h>

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -43,6 +43,7 @@
 #include "test_endpoints.h"
 #include "tls_manager.h"
 #include "png_uncompressed.h"
+#include "jpeg_screenshot.h"
 #include <esp_http_server.h>
 #include <esp_https_server.h>
 #include <esp_log.h>
@@ -5673,6 +5674,83 @@ static esp_err_t png_http_write(void *ctx, const void *buf, size_t len)
     return httpd_resp_send_chunk((httpd_req_t *)ctx, (const char *)buf, len);
 }
 
+/**
+ * Capture the live screen and send it as a hardware-encoded JPEG.
+ *
+ * Unlike the PNG path this does not swap channels. LVGL's RGB888 stores B,G,R
+ * in memory and the P4 encoder's JPEG_ENCODE_IN_FORMAT_RGB888 is defined as
+ * ESP_COLOR_FOURCC_BGR24, so LVGL's output is already in the byte order the
+ * peripheral wants. Skipping the swap avoids a per-pixel pass over ~2.7 MB.
+ */
+static esp_err_t screenshot_send_jpeg(httpd_req_t* req, int32_t w, int32_t h,
+                                      uint32_t stride, uint8_t quality)
+{
+    /*
+     * The encoder consumes tightly packed rows. With CONFIG_LV_DRAW_BUF_STRIDE_ALIGN=1
+     * LVGL already produces those, so rather than carry a repacking path that
+     * never executes and is therefore never tested, refuse loudly if that
+     * assumption is ever broken by a config change. A wrong stride would
+     * otherwise produce a silently skewed image.
+     */
+    if (stride != (uint32_t)w * 3) {
+        ESP_LOGE(TAG, "stride %lu != packed %lu; JPEG path needs packed rows",
+                 (unsigned long)stride, (unsigned long)((uint32_t)w * 3));
+        send_json_error(req, "500 Internal Server Error",
+                        "Display stride is not packed; JPEG encoding unavailable");
+        return ESP_OK;
+    }
+
+    jpeg_screenshot_ctx_t ctx;
+    esp_err_t err = jpeg_screenshot_begin(&ctx, (uint32_t)w, (uint32_t)h);
+    if (err == ESP_ERR_INVALID_SIZE) {
+        send_json_error(req, "500 Internal Server Error",
+                        "Display dimensions are not a multiple of 8");
+        return ESP_OK;
+    }
+    if (err != ESP_OK) {
+        send_json_error(req, "500 Internal Server Error", "Out of memory");
+        return ESP_OK;
+    }
+
+    lv_draw_buf_t snapshot;
+    lv_draw_buf_init(&snapshot, w, h, LV_COLOR_FORMAT_RGB888, stride,
+                     ctx.in_buf, ctx.in_capacity);
+
+    bsp_display_lock(0);
+    lv_obj_t* screen = lv_screen_active();
+    lv_result_t snap_res = lv_snapshot_take_to_draw_buf(screen, LV_COLOR_FORMAT_RGB888, &snapshot);
+    bsp_display_unlock();
+
+    if (snap_res != LV_RESULT_OK) {
+        ESP_LOGE(TAG, "Snapshot capture failed");
+        jpeg_screenshot_end(&ctx);
+        send_json_error(req, "500 Internal Server Error", "Snapshot capture failed");
+        return ESP_OK;
+    }
+
+    uint32_t jpeg_len = 0;
+    int64_t t0 = esp_timer_get_time();
+    err = jpeg_screenshot_encode(&ctx, (uint32_t)w, (uint32_t)h, quality, &jpeg_len);
+    int64_t encode_ms = (esp_timer_get_time() - t0) / 1000;
+
+    if (err != ESP_OK || jpeg_len == 0) {
+        jpeg_screenshot_end(&ctx);
+        send_json_error(req, "500 Internal Server Error", "JPEG encoding failed");
+        return ESP_OK;
+    }
+
+    httpd_resp_set_type(req, "image/jpeg");
+    httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=\"screenshot.jpg\"");
+    esp_err_t send_err = httpd_resp_send(req, (const char*)ctx.out_buf, jpeg_len);
+
+    jpeg_screenshot_end(&ctx);
+
+    ESP_LOGI(TAG, "Screenshot sent: %ldx%ld, q%u, %lu bytes, encoded in %ld ms (JPEG)",
+             (long)w, (long)h, (unsigned)quality,
+             (unsigned long)jpeg_len, (long)encode_ms);
+    return send_err;
+}
+
 static esp_err_t screenshot_get_handler(httpd_req_t* req)
 {
     if (!check_api_auth(req)) {
@@ -5680,7 +5758,33 @@ static esp_err_t screenshot_get_handler(httpd_req_t* req)
         return ESP_OK;
     }
 
-    ESP_LOGI(TAG, "Screenshot requested");
+    // ?format=png|jpeg (default png for backward compatibility), ?quality=1-100
+    bool want_jpeg = false;
+    uint8_t quality = JPEG_SCREENSHOT_DEFAULT_QUALITY;
+    char query[64];
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+        char param[16];
+        if (httpd_query_key_value(query, "format", param, sizeof(param)) == ESP_OK) {
+            if (strcasecmp(param, "jpeg") == 0 || strcasecmp(param, "jpg") == 0) {
+                want_jpeg = true;
+            } else if (strcasecmp(param, "png") != 0) {
+                send_json_error(req, "400 Bad Request",
+                                "format must be 'png' or 'jpeg'");
+                return ESP_OK;
+            }
+        }
+        if (httpd_query_key_value(query, "quality", param, sizeof(param)) == ESP_OK) {
+            long q = atol(param);
+            if (q < 1 || q > 100) {
+                send_json_error(req, "400 Bad Request",
+                                "quality must be between 1 and 100");
+                return ESP_OK;
+            }
+            quality = (uint8_t)q;
+        }
+    }
+
+    ESP_LOGI(TAG, "Screenshot requested (%s)", want_jpeg ? "jpeg" : "png");
 
     // Get screen dimensions under LVGL lock
     bsp_display_lock(0);
@@ -5690,8 +5794,13 @@ static esp_err_t screenshot_get_handler(httpd_req_t* req)
     int32_t h = lv_obj_get_height(screen);
     bsp_display_unlock();
 
-    // Allocate pixel buffer in PSRAM (720x1280x3 ≈ 2.7 MB)
     uint32_t stride = lv_draw_buf_width_to_stride(w, LV_COLOR_FORMAT_RGB888);
+
+    if (want_jpeg) {
+        return screenshot_send_jpeg(req, w, h, stride, quality);
+    }
+
+    // Allocate pixel buffer in PSRAM (720x1280x3 ≈ 2.7 MB)
     uint32_t buf_size = stride * h;
     void* pixel_buf = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
     if (!pixel_buf) {

--- a/main/api_server.cpp
+++ b/main/api_server.cpp
@@ -52,7 +52,6 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>   // strcasecmp — case-insensitive ?format= matching
 #include <esp_ota_ops.h>
 #include <esp_app_format.h>
 #include <lvgl.h>
@@ -5752,6 +5751,24 @@ static esp_err_t screenshot_send_jpeg(httpd_req_t* req, int32_t w, int32_t h,
     return send_err;
 }
 
+/*
+ * Case-insensitive compare for short query-parameter values. strcasecmp lives
+ * in <strings.h>, which this toolchain does not expose to C++ in this
+ * translation unit, so compare directly rather than depend on feature-test
+ * macros.
+ */
+static bool query_value_ieq(const char* a, const char* b)
+{
+    while (*a != '\0' && *b != '\0') {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+            return false;
+        }
+        ++a;
+        ++b;
+    }
+    return *a == '\0' && *b == '\0';
+}
+
 static esp_err_t screenshot_get_handler(httpd_req_t* req)
 {
     if (!check_api_auth(req)) {
@@ -5766,9 +5783,9 @@ static esp_err_t screenshot_get_handler(httpd_req_t* req)
     if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
         char param[16];
         if (httpd_query_key_value(query, "format", param, sizeof(param)) == ESP_OK) {
-            if (strcasecmp(param, "jpeg") == 0 || strcasecmp(param, "jpg") == 0) {
+            if (query_value_ieq(param, "jpeg") || query_value_ieq(param, "jpg")) {
                 want_jpeg = true;
-            } else if (strcasecmp(param, "png") != 0) {
+            } else if (!query_value_ieq(param, "png")) {
                 send_json_error(req, "400 Bad Request",
                                 "format must be 'png' or 'jpeg'");
                 return ESP_OK;

--- a/main/jpeg_screenshot.c
+++ b/main/jpeg_screenshot.c
@@ -1,0 +1,144 @@
+/*
+ * Hardware JPEG encoding for screenshots. See jpeg_screenshot.h.
+ */
+#include "jpeg_screenshot.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "driver/jpeg_encode.h"
+#include "esp_log.h"
+
+static const char *TAG = "jpeg_shot";
+
+/*
+ * YUV444 keeps full chroma resolution. A screenshot is mostly thin text and
+ * single-pixel borders on saturated backgrounds, which is precisely the content
+ * that 4:2:0 chroma subsampling smears. The file is larger than 4:2:0 would be
+ * and still an order of magnitude smaller than the uncompressed PNG, so the
+ * trade is worth taking for an image whose whole purpose is to be read.
+ */
+#define JPEG_SHOT_SUBSAMPLING JPEG_DOWN_SAMPLING_YUV444
+
+/*
+ * Encoding 720x1280 takes single-digit milliseconds on the P4. A second is far
+ * beyond any plausible encode time, so this trips only on a wedged peripheral
+ * rather than masking slowness.
+ */
+#define JPEG_SHOT_TIMEOUT_MS 1000
+
+/*
+ * Output capacity, as bytes per pixel. A UI screenshot at quality 80 lands
+ * nearer 0.1 bpp, so one byte per pixel is a wide margin; the peripheral fails
+ * the encode rather than overrunning if it is ever not enough.
+ */
+#define JPEG_SHOT_OUT_BPP 1
+
+esp_err_t jpeg_screenshot_begin(jpeg_screenshot_ctx_t *ctx, uint32_t w, uint32_t h)
+{
+    if (ctx == NULL || w == 0 || h == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    memset(ctx, 0, sizeof(*ctx));
+
+    if ((w % JPEG_SCREENSHOT_MCU) != 0 || (h % JPEG_SCREENSHOT_MCU) != 0) {
+        ESP_LOGE(TAG, "%" PRIu32 "x%" PRIu32 " is not a multiple of %d",
+                 w, h, JPEG_SCREENSHOT_MCU);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    jpeg_encode_memory_alloc_cfg_t in_cfg = {
+        .buffer_direction = JPEG_ENC_ALLOC_INPUT_BUFFER,
+    };
+    ctx->in_buf = (uint8_t *)jpeg_alloc_encoder_mem((size_t)w * h * 3, &in_cfg,
+                                                    &ctx->in_capacity);
+    if (ctx->in_buf == NULL) {
+        ESP_LOGE(TAG, "input buffer alloc failed (%" PRIu32 " bytes)", w * h * 3);
+        return ESP_ERR_NO_MEM;
+    }
+
+    jpeg_encode_memory_alloc_cfg_t out_cfg = {
+        .buffer_direction = JPEG_ENC_ALLOC_OUTPUT_BUFFER,
+    };
+    ctx->out_buf = (uint8_t *)jpeg_alloc_encoder_mem((size_t)w * h * JPEG_SHOT_OUT_BPP,
+                                                     &out_cfg, &ctx->out_capacity);
+    if (ctx->out_buf == NULL) {
+        ESP_LOGE(TAG, "output buffer alloc failed");
+        jpeg_screenshot_end(ctx);
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t jpeg_screenshot_encode(jpeg_screenshot_ctx_t *ctx,
+                                 uint32_t w, uint32_t h,
+                                 uint8_t quality,
+                                 uint32_t *out_len)
+{
+    if (ctx == NULL || ctx->in_buf == NULL || ctx->out_buf == NULL || out_len == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *out_len = 0;
+
+    if (quality == 0) {
+        quality = JPEG_SCREENSHOT_DEFAULT_QUALITY;
+    } else if (quality > 100) {
+        quality = 100;
+    }
+
+    jpeg_encode_engine_cfg_t eng_cfg = {
+        .timeout_ms = JPEG_SHOT_TIMEOUT_MS,
+    };
+    jpeg_encoder_handle_t engine = NULL;
+    esp_err_t err = jpeg_new_encoder_engine(&eng_cfg, &engine);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "jpeg_new_encoder_engine failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    jpeg_encode_cfg_t enc_cfg = {
+        .width = w,
+        .height = h,
+        .src_type = JPEG_ENCODE_IN_FORMAT_RGB888,  /* BGR24 byte order, see header */
+        .sub_sample = JPEG_SHOT_SUBSAMPLING,
+        .image_quality = quality,
+    };
+
+    err = jpeg_encoder_process(engine, &enc_cfg,
+                               ctx->in_buf, (uint32_t)((size_t)w * h * 3),
+                               ctx->out_buf, (uint32_t)ctx->out_capacity,
+                               out_len);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "jpeg_encoder_process failed: %s", esp_err_to_name(err));
+    }
+
+    /*
+     * Destroy the engine even on failure. Leaking it would strand the
+     * peripheral and make every subsequent screenshot fail, turning a single
+     * bad encode into a permanent one.
+     */
+    esp_err_t del_err = jpeg_del_encoder_engine(engine);
+    if (del_err != ESP_OK) {
+        ESP_LOGE(TAG, "jpeg_del_encoder_engine failed: %s", esp_err_to_name(del_err));
+        if (err == ESP_OK) {
+            err = del_err;
+        }
+    }
+
+    return err;
+}
+
+void jpeg_screenshot_end(jpeg_screenshot_ctx_t *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+    free(ctx->in_buf);
+    free(ctx->out_buf);
+    ctx->in_buf = NULL;
+    ctx->out_buf = NULL;
+    ctx->in_capacity = 0;
+    ctx->out_capacity = 0;
+}

--- a/main/jpeg_screenshot.h
+++ b/main/jpeg_screenshot.h
@@ -1,0 +1,81 @@
+/*
+ * Hardware JPEG encoding for screenshots.
+ *
+ * The ESP32-P4 carries a hardware JPEG codec (CONFIG_SOC_JPEG_ENCODE_SUPPORTED),
+ * so a screenshot can be compressed by the peripheral instead of being shipped
+ * as a ~2.7 MB uncompressed PNG. That matters for more than wall-clock time:
+ * every byte of the response is also a byte pushed through mbedTLS, and the
+ * chunk storm from the uncompressed path is what made #234 visible.
+ *
+ * Usage is three calls, and jpeg_screenshot_end() is safe to call on a context
+ * that begin() failed to populate, so the caller can use a single cleanup path:
+ *
+ *     jpeg_screenshot_ctx_t ctx;
+ *     jpeg_screenshot_begin(&ctx, w, h);     // allocates DMA-capable buffers
+ *     ... render BGR888 pixels into ctx.in_buf ...
+ *     jpeg_screenshot_encode(&ctx, w, h, quality, &len);
+ *     ... send ctx.out_buf[0..len) ...
+ *     jpeg_screenshot_end(&ctx);
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Default encode quality, if the caller does not specify one. */
+#define JPEG_SCREENSHOT_DEFAULT_QUALITY 80
+
+/** Encoder MCU size. Frame dimensions must be a multiple of this. */
+#define JPEG_SCREENSHOT_MCU 8
+
+typedef struct {
+    uint8_t *in_buf;       /*!< BGR888 input, DMA-capable and cache-aligned. */
+    size_t   in_capacity;  /*!< Actual allocated size, >= the requested size. */
+    uint8_t *out_buf;      /*!< JPEG output, DMA-capable and cache-aligned. */
+    size_t   out_capacity; /*!< Actual allocated size, >= the requested size. */
+} jpeg_screenshot_ctx_t;
+
+/**
+ * Allocate the DMA-capable input and output buffers for one frame.
+ *
+ * The buffers come from jpeg_alloc_encoder_mem(), not plain heap_caps_malloc(),
+ * because the peripheral requires specific address and size alignment. Both
+ * land in PSRAM.
+ *
+ * @return ESP_ERR_INVALID_SIZE if w or h is not a multiple of
+ *         JPEG_SCREENSHOT_MCU, ESP_ERR_NO_MEM if either allocation fails.
+ */
+esp_err_t jpeg_screenshot_begin(jpeg_screenshot_ctx_t *ctx, uint32_t w, uint32_t h);
+
+/**
+ * Encode ctx->in_buf into ctx->out_buf.
+ *
+ * The input must be BGR888 — byte order B, G, R — which is exactly what LVGL's
+ * LV_COLOR_FORMAT_RGB888 already produces, so no channel swap is needed on the
+ * way in. ESP-IDF names the format JPEG_ENCODE_IN_FORMAT_RGB888 but defines it
+ * as ESP_COLOR_FOURCC_BGR24; the name refers to the channel set, not the byte
+ * order.
+ *
+ * The encoder engine is created and destroyed per call. Screenshots are rare,
+ * and holding the engine open would pin DMA descriptors for a peripheral that
+ * is otherwise idle.
+ *
+ * @param quality 1-100. Clamped into range; 0 selects the default.
+ * @param out_len Receives the encoded length in bytes.
+ */
+esp_err_t jpeg_screenshot_encode(jpeg_screenshot_ctx_t *ctx,
+                                 uint32_t w, uint32_t h,
+                                 uint8_t quality,
+                                 uint32_t *out_len);
+
+/** Release both buffers. Idempotent and null-safe. */
+void jpeg_screenshot_end(jpeg_screenshot_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/web/index.html
+++ b/main/web/index.html
@@ -1000,7 +1000,7 @@
         <select id="log-level" style="width:120px"><option>V</option><option>D</option><option>I</option><option>W</option><option>E</option></select></div>
         <div id="log-container" class="logs">${state.logs.map(l => `<div class="log ${esc(l.level)}">[${esc(l.level)}] ${esc(l.tag)}: ${esc(l.message)}</div>`).join("") || "No logs loaded."}</div>
         <div class="btn-row" style="margin-top:14px"><button class="btn" data-action="refresh-logs">Refresh</button><button class="btn danger" data-action="clear-logs">Clear logs</button>
-          <a class="btn" href="/api/heatpump/diagnostic" download>Download report</a><a class="btn" href="/api/screenshot" target="_blank">Device screenshot</a></div></section>`;
+          <a class="btn" href="/api/heatpump/diagnostic" download>Download report</a><a class="btn" href="/api/screenshot?format=jpeg" target="_blank">Device screenshot</a></div></section>`;
     }
     function systemSettings() {
       return `<div class="grid"><section class="card"><h2>Controller</h2>

--- a/tests/device/test_screenshot_api.py
+++ b/tests/device/test_screenshot_api.py
@@ -47,6 +47,11 @@ _session.mount("https://", HTTPAdapter(max_retries=_retry))
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
+# JPEG framing. SOI opens every JPEG, EOI closes it; checking both is what
+# distinguishes a complete image from one truncated by a failed send.
+JPEG_SOI = b"\xff\xd8"
+JPEG_EOI = b"\xff\xd9"
+
 
 def _api_headers(api_key: str = API_KEY) -> dict:
     """Build request headers with optional API key."""
@@ -56,11 +61,12 @@ def _api_headers(api_key: str = API_KEY) -> dict:
     return headers
 
 
-def _get_screenshot(api_key: str = API_KEY) -> requests.Response:
+def _get_screenshot(api_key: str = API_KEY, params: dict = None) -> requests.Response:
     """Fetch a screenshot from the production endpoint."""
     return _session.get(
         f"{ARCTIC_URL}/api/screenshot",
         headers=_api_headers(api_key),
+        params=params,
         timeout=30.0,
     )
 
@@ -135,6 +141,36 @@ def _parse_png_ihdr(data: bytes) -> dict:
         "bit_depth": bit_depth,
         "color_type": color_type,
     }
+
+
+def _parse_jpeg_dimensions(data: bytes) -> tuple:
+    """Return (width, height) from a JPEG's SOFn marker.
+
+    Walks the marker segments rather than assuming a fixed offset, because the
+    hardware encoder is free to emit whatever tables and APPn segments it likes
+    ahead of the frame header.
+    """
+    assert data[:2] == JPEG_SOI, "Not a JPEG (missing SOI)"
+    i = 2
+    while i + 3 < len(data):
+        if data[i] != 0xFF:
+            raise AssertionError(f"Expected a marker at offset {i}, got {data[i]:#04x}")
+        marker = data[i + 1]
+        # Standalone markers carry no length field.
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+            i += 2
+            continue
+        seg_len = struct.unpack(">H", data[i + 2:i + 4])[0]
+        # SOF0/1/2/3, 5-7, 9-11, 13-15 — every frame header except DHT (0xC4),
+        # JPG (0xC8) and DAC (0xCC), which share the 0xCn range.
+        if marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+                      0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+            height, width = struct.unpack(">HH", data[i + 5:i + 9])
+            return width, height
+        if marker == 0xDA:  # start of scan — no frame header found
+            break
+        i += 2 + seg_len
+    raise AssertionError("No SOF marker found in JPEG")
 
 
 # ── Tests ────────────────────────────────────────────────────────────────
@@ -225,3 +261,115 @@ class TestScreenshotAPI:
         ihdr2 = _parse_png_ihdr(r2.content)
         assert ihdr1["width"] == ihdr2["width"]
         assert ihdr1["height"] == ihdr2["height"]
+
+
+@pytest.mark.skipif(not API_KEY, reason="ARCTIC_API_KEY not set")
+class TestScreenshotJPEG:
+    """Tests for GET /api/screenshot?format=jpeg (hardware JPEG encoder)."""
+
+    def test_jpeg_content_type(self):
+        """format=jpeg returns image/jpeg, not image/png."""
+        r = _get_screenshot(params={"format": "jpeg"})
+        assert r.status_code == 200
+        assert "image/jpeg" in r.headers.get("Content-Type", "")
+
+    def test_jpeg_is_complete(self):
+        """Body is framed by SOI and EOI.
+
+        EOI matters as much as SOI: a truncated response still starts with
+        SOI, so only the terminator proves the whole image arrived.
+        """
+        r = _get_screenshot(params={"format": "jpeg"})
+        assert r.status_code == 200
+        assert r.content[:2] == JPEG_SOI, "Response is not a JPEG"
+        assert r.content[-2:] == JPEG_EOI, "JPEG is truncated (no EOI)"
+
+    def test_jpeg_dimensions(self):
+        """SOF reports the full 720×1280 display."""
+        r = _get_screenshot(params={"format": "jpeg"})
+        assert r.status_code == 200
+        width, height = _parse_jpeg_dimensions(r.content)
+        assert width == EXPECTED_WIDTH, f"Expected width {EXPECTED_WIDTH}, got {width}"
+        assert height == EXPECTED_HEIGHT, f"Expected height {EXPECTED_HEIGHT}, got {height}"
+
+    def test_jpeg_is_far_smaller_than_png(self):
+        """The point of the JPEG path is the payload reduction.
+
+        The PNG is ~2.77 MB uncompressed. If the JPEG is not dramatically
+        smaller the feature has no reason to exist, so assert the benefit
+        rather than merely asserting validity.
+        """
+        r = _get_screenshot(params={"format": "jpeg"})
+        assert r.status_code == 200
+        size = len(r.content)
+        assert size > 10_000, f"JPEG suspiciously small ({size} bytes) — likely blank or corrupt"
+        assert size < 1_000_000, f"JPEG not meaningfully smaller than the PNG ({size} bytes)"
+
+    def test_jpg_alias(self):
+        """format=jpg is accepted as a synonym for jpeg."""
+        r = _get_screenshot(params={"format": "jpg"})
+        assert r.status_code == 200
+        assert "image/jpeg" in r.headers.get("Content-Type", "")
+
+    def test_jpeg_content_disposition(self):
+        """Filename reflects the actual format, not screenshot.png."""
+        r = _get_screenshot(params={"format": "jpeg"})
+        assert r.status_code == 200
+        assert "screenshot.jpg" in r.headers.get("Content-Disposition", "")
+
+    def test_default_format_is_still_png(self):
+        """Omitting format must not change existing clients' behaviour."""
+        r = _get_screenshot()
+        assert r.status_code == 200
+        assert "image/png" in r.headers.get("Content-Type", "")
+        assert r.content[:8] == PNG_SIGNATURE
+
+    def test_explicit_png_format(self):
+        """format=png selects the PNG path explicitly."""
+        r = _get_screenshot(params={"format": "png"})
+        assert r.status_code == 200
+        assert r.content[:8] == PNG_SIGNATURE
+
+    def test_quality_changes_payload_size(self):
+        """quality is wired through to the encoder, not silently ignored.
+
+        Asserting only that a low-quality request succeeds would pass even if
+        the parameter were dropped, so compare the sizes at the two extremes.
+        """
+        low = _get_screenshot(params={"format": "jpeg", "quality": 10})
+        high = _get_screenshot(params={"format": "jpeg", "quality": 95})
+        assert low.status_code == 200
+        assert high.status_code == 200
+        assert len(low.content) < len(high.content), (
+            f"quality had no effect: q10={len(low.content)} bytes, "
+            f"q95={len(high.content)} bytes"
+        )
+
+    @pytest.mark.parametrize("bad_format", ["gif", "bmp", "", "jpeg2000"])
+    def test_invalid_format_rejected(self, bad_format):
+        """An unsupported format is a client error, not a silent PNG."""
+        r = _get_screenshot(params={"format": bad_format})
+        assert r.status_code == 400, (
+            f"format={bad_format!r} should be rejected, got {r.status_code}"
+        )
+
+    @pytest.mark.parametrize("bad_quality", ["0", "101", "-1", "abc"])
+    def test_invalid_quality_rejected(self, bad_quality):
+        """Out-of-range or non-numeric quality is a client error."""
+        r = _get_screenshot(params={"format": "jpeg", "quality": bad_quality})
+        assert r.status_code == 400, (
+            f"quality={bad_quality!r} should be rejected, got {r.status_code}"
+        )
+
+    def test_consecutive_jpeg_screenshots(self):
+        """Back-to-back encodes must both succeed.
+
+        The encoder engine is created and destroyed per request; if it were
+        ever leaked the peripheral would be stranded and the second request
+        would fail. That makes this the regression test for engine teardown.
+        """
+        for attempt in range(3):
+            r = _get_screenshot(params={"format": "jpeg"})
+            assert r.status_code == 200, f"attempt {attempt + 1} failed: {r.status_code}"
+            assert r.content[:2] == JPEG_SOI
+            assert r.content[-2:] == JPEG_EOI

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -61,7 +61,7 @@ class TestSettingsWorkspace:
         open_settings(dashboard_page, "Diagnostics")
         expect(dashboard_page.locator("#log-container")).to_be_visible()
         expect(dashboard_page.locator('a[href="/api/heatpump/diagnostic"]')).to_be_visible()
-        expect(dashboard_page.locator('a[href="/api/screenshot"]')).to_be_visible()
+        expect(dashboard_page.locator('a[href="/api/screenshot?format=jpeg"]')).to_be_visible()
 
     def test_system_and_factory_reset(self, dashboard_page: Page):
         open_settings(dashboard_page, "System")


### PR DESCRIPTION
`/api/screenshot` only ever produced an uncompressed PNG — 2.77 MB for a 720×1280 screen. That is roughly 13x more bytes than the image needs, and on this device every one of them is pushed through mbedTLS. The chunk storm behind #234 originated at this endpoint.

The ESP32-P4 has a hardware JPEG encoder that was simply unused (`CONFIG_SOC_JPEG_ENCODE_SUPPORTED=y`), so compression here costs peripheral time rather than CPU time.

## What changed

- **`main/jpeg_screenshot.{c,h}`** wraps the encoder: allocate DMA-capable buffers via `jpeg_alloc_encoder_mem()`, create an engine, encode, destroy. The engine is destroyed **even when the encode fails**, so one bad encode cannot strand the peripheral and break every screenshot thereafter.
- **`/api/screenshot`** gains `?format=png|jpeg|jpg` and `?quality=1-100`. The default is still PNG, so existing clients are untouched; invalid values are a `400` rather than a silent fallback.
- **The web UI's "Device screenshot" link** now asks for JPEG, which is where the TLS saving actually lands for users.
- **`docs/openapi.yaml`** documents both parameters and the `image/jpeg` response.

## Two findings that shaped the implementation

`JPEG_ENCODE_IN_FORMAT_RGB888` is `#define`d as `ESP_COLOR_FOURCC_BGR24` — B,G,R byte order in memory, which is exactly what LVGL's `LV_COLOR_FORMAT_RGB888` already produces. The JPEG path therefore **skips the PNG path's 921,600-iteration byte-swap loop entirely** rather than needing one of its own.

With `CONFIG_LV_DRAW_BUF_STRIDE_ALIGN=1` the captured rows are already tightly packed, which is what the encoder wants. Rather than carry a repacking path that never executes and is therefore never tested, the code asserts the assumption and fails loudly if a config change breaks it — a wrong stride would otherwise yield a silently skewed image.

Subsampling is **4:4:4** by deliberate choice. A UI screenshot is thin text and single-pixel borders on saturated backgrounds, precisely the content 4:2:0 smears; 4:4:4 is still an order of magnitude smaller than the PNG.

## Tests

The tests assert the *benefit* and the *wiring*, not just validity:

- the payload is far smaller than the PNG (the reason the feature exists);
- `quality` actually changes the size — a test that only checked for a `200` would pass if the parameter were silently dropped;
- `EOI` is present, so a truncated response cannot pass on `SOI` alone;
- three consecutive encodes succeed — the regression test for engine teardown;
- the default and explicit `format=png` still return PNG.

## Verification

Firmware compiles clean on all three variants (`build`, `build-demo-disabled`, `build-tuya-master`) — run 34630851366. The device suite in this PR is what validates encode time, payload size and that the image is neither skewed nor colour-swapped.


---

## Also carries the CI fix that unblocks this PR

This branch initially failed device-tests, and the OTA-window serial capture added in #271 showed why on its first real failure:

```
I  api_server: Receiving firmware upload, content length: 2422528
E  esp_ota_ops: New image failed verification
E  api_server: esp_ota_end failed: ESP_ERR_OTA_VALIDATE_FAILED
```

The device received a truncated image, correctly refused it, and answered 500. Two CI bugs hid that:

1. **`--max-time 30` was truncating the upload.** `--max-time` is a hard stop on the whole transfer, so a limit sized for a response was cutting a ~2.4 MB TLS upload off mid-body — the device's receive window ends at exactly 30,158 ms in the serial log. This is also the entirety of the "intermittent" behaviour in #273: the upload sat right at the limit, and this PR's slightly larger firmware pushed it over consistently. There is no firmware bug — the device never failed to reboot, it was never given a valid image to reboot into.

2. **The 000-acceptance branch was reading a *previous run's* response.** curl only truncates `-o`'s target once it has body data to write, so a transfer that dies before the response leaves the old file in place. A run whose device returned 500 was recorded as success because the workflow read a leftover `{"success":true,"bytes_received":2407824,...}` — the byte count of the *previous* build.

Fixed by removing the file before each request and requiring `bytes_received` to equal the firmware size before believing a success body. That second condition is what makes the check honest rather than merely fresh: it rejects a stale response and a genuine short write alike, where `"success":true` alone accepts both.

Folded in here rather than split out because this PR cannot pass without it, and the device suite is the scarce resource — one run validates both.
